### PR TITLE
Release v0.1.3: fix npm binary version sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to drft are documented here.
 
+## 0.1.3 (2026-03-29)
+
+- Fix npm package downloading binaries from wrong release version
+
 ## 0.1.2 (2026-03-29)
 
 - Add `lockfile-outdated` rule: `drft check` detects when lockfile doesn't match current graph

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "drft-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drft-cli"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "A structural integrity checker for markdown directories"
 license = "MIT"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "drft-cli",
-  "version": "0.1.2",
-  "binaryVersion": "0.1.0",
+  "version": "0.1.3",
+  "binaryVersion": "0.1.3",
   "description": "A structural integrity checker for markdown directories",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- npm `binaryVersion` was stuck at `0.1.0` from manual publish
- Bump all versions to `0.1.3` so CI publish syncs everything correctly

## Test plan
- [ ] CI passes
- [ ] After merge + tag, verify `npm view drft-cli` shows `binaryVersion: 0.1.3`