### PR TITLE
Update README hooks and add required-frontmatter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ drft impact observations.md --format json
 
 ### Claude Code hooks
 
-Add to `.claude/settings.json` to run drft automatically after markdown edits:
+Add to your project's `.claude/settings.json` to run drft automatically after markdown edits:
 
 ```json
 {
@@ -268,7 +268,7 @@ Add to `.claude/settings.json` to run drft automatically after markdown edits:
         "hooks": [
           {
             "type": "command",
-            "command": "if [[ \"$TOOL_INPUT_FILE_PATH\" == *.md ]] || [[ \"$TOOL_INPUT_file_path\" == *.md ]]; then drft check --format json 2>/dev/null; fi"
+            "command": "if [[ \"$TOOL_INPUT_FILE_PATH\" == *.md ]] || [[ \"$TOOL_INPUT_file_path\" == *.md ]]; then npx drft check --format json 2>/dev/null; fi"
           }
         ]
       }
@@ -277,14 +277,16 @@ Add to `.claude/settings.json` to run drft automatically after markdown edits:
 }
 ```
 
+If drft is installed globally (`cargo install drft-cli`), use `drft` instead of `npx drft`. For npm projects with `drft-cli` as a devDependency, `npx drft` ensures it resolves from `node_modules`.
+
 ### CI
 
 ```bash
-drft lock --check --recursive  # verify all lockfiles are current
-drft check --recursive          # run all rules across all scopes
+npx drft lock --check --recursive  # verify all lockfiles are current
+npx drft check --recursive          # run all rules across all scopes
 ```
 
-Both exit with code 1 on failure.
+Both exit with code 1 on failure. Use `drft` instead of `npx drft` if installed globally or via cargo.
 
 ## License
 

--- a/examples/custom-rules/drft.toml
+++ b/examples/custom-rules/drft.toml
@@ -8,3 +8,7 @@ severity = "warn"
 [custom-rules.naming-convention]
 command = "./scripts/naming-convention.sh"
 severity = "warn"
+
+[custom-rules.required-frontmatter]
+command = "./scripts/required-frontmatter.sh"
+severity = "warn"

--- a/examples/custom-rules/drft.toml
+++ b/examples/custom-rules/drft.toml
@@ -12,3 +12,7 @@ severity = "warn"
 [custom-rules.required-frontmatter]
 command = "./scripts/required-frontmatter.sh"
 severity = "warn"
+
+[custom-rules.max-depth]
+command = "./scripts/max-depth.sh"
+severity = "warn"

--- a/examples/custom-rules/scripts/max-depth.sh
+++ b/examples/custom-rules/scripts/max-depth.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Flag files that are too many hops from a root node (no inbound links).
+# "Spelunking" — content buried too deep is hard to discover.
+#
+# Customize MAX_DEPTH below.
+
+MAX_DEPTH=4
+
+python3 -c "
+import json, sys
+from collections import deque
+
+data = json.load(sys.stdin)
+graph = data['graph']
+
+# Build adjacency: source -> [targets]
+children = {}
+has_inbound = set()
+for e in graph['edges']:
+    children.setdefault(e['source'], []).append(e['target'])
+    has_inbound.add(e['target'])
+
+# Find roots (no inbound links, document type only)
+roots = [
+    p for p, n in graph['nodes'].items()
+    if p not in has_inbound and n['metadata']['type'] == 'document'
+]
+
+# BFS from all roots to compute min depth for each node
+depth = {}
+queue = deque()
+for r in roots:
+    depth[r] = 0
+    queue.append(r)
+
+while queue:
+    node = queue.popleft()
+    for child in children.get(node, []):
+        if child not in depth:
+            depth[child] = depth[node] + 1
+            queue.append(child)
+
+# Flag nodes exceeding max depth
+max_depth = $MAX_DEPTH
+for path in sorted(graph['nodes']):
+    node = graph['nodes'][path]
+    if node['metadata']['type'] != 'document':
+        continue
+    d = depth.get(path)
+    if d is not None and d > max_depth:
+        print(json.dumps({
+            'message': f'depth {d} exceeds max {max_depth}',
+            'node': path,
+            'fix': f'{path} is {d} links deep from the nearest root — consider linking to it from a higher-level document'
+        }))
+    elif d is None and path not in roots:
+        # Unreachable from any root (island node in a cycle, etc)
+        print(json.dumps({
+            'message': 'unreachable from any root',
+            'node': path,
+            'fix': f'{path} is not reachable from any root document — it may be in an isolated cycle'
+        }))
+"

--- a/examples/custom-rules/scripts/required-frontmatter.sh
+++ b/examples/custom-rules/scripts/required-frontmatter.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Require specific frontmatter fields in all document nodes.
+# Receives JGF graph JSON on stdin, reads files from disk to check frontmatter.
+#
+# Checks for: title, sources
+# Customize REQUIRED_FIELDS below.
+
+REQUIRED_FIELDS="title sources"
+
+python3 -c "
+import json, sys, os, re
+
+required = '$REQUIRED_FIELDS'.split()
+data = json.load(sys.stdin)
+graph = data['graph']
+
+for path, node in sorted(graph['nodes'].items()):
+    if node['metadata']['type'] != 'document':
+        continue
+    if not os.path.isfile(path):
+        continue
+
+    content = open(path).read()
+
+    # Extract frontmatter
+    m = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    if not m:
+        fields = ', '.join(required)
+        print(json.dumps({
+            'message': 'missing frontmatter',
+            'node': path,
+            'fix': f'{path} has no YAML frontmatter — add a --- block with required fields: {fields}'
+        }))
+        continue
+
+    fm = m.group(1)
+    missing = [f for f in required if not re.search(rf'^{f}\s*:', fm, re.MULTILINE)]
+    if missing:
+        names = ', '.join(missing)
+        print(json.dumps({
+            'message': f'missing frontmatter fields: {names}',
+            'node': path,
+            'fix': f'{path} is missing required frontmatter fields: {names}'
+        }))
+"

--- a/src/main.rs
+++ b/src/main.rs
@@ -484,9 +484,13 @@ fn run_check(
     recursive: bool,
     max_depth: Option<usize>,
 ) -> Result<i32> {
-    // Validate rule names
+    // Validate rule names (built-in + custom from config)
+    let scope_root = find_scope_root(root);
+    let root_config = Config::load(&scope_root)?;
     let available_rules = all_rules();
-    let known_names: Vec<&str> = available_rules.iter().map(|r| r.name()).collect();
+    let mut known_names: Vec<&str> = available_rules.iter().map(|r| r.name()).collect();
+    let custom_names: Vec<String> = root_config.custom_rules.keys().cloned().collect();
+    known_names.extend(custom_names.iter().map(|s| s.as_str()));
     for name in rule_filter {
         if !known_names.contains(&name.as_str()) {
             anyhow::bail!("unknown rule: \"{name}\"");
@@ -731,9 +735,21 @@ fn check_scope(
         diagnostics.extend(findings);
     }
 
-    // Run custom rules
-    if !config.custom_rules.is_empty() {
+    // Run custom rules (respecting --rule filter)
+    let run_custom = if rule_filter.is_empty() {
+        !config.custom_rules.is_empty()
+    } else {
+        config
+            .custom_rules
+            .keys()
+            .any(|name| rule_filter.iter().any(|f| f == name))
+    };
+    if run_custom {
         let mut custom_findings = rules::custom::run_custom_rules(&graph, root, &config);
+        // Filter to only requested custom rules if --rule is set
+        if !rule_filter.is_empty() {
+            custom_findings.retain(|d| rule_filter.iter().any(|f| f == &d.rule));
+        }
         // Apply ignore-rules filtering to custom rule diagnostics too
         custom_findings.retain(|d| {
             let paths: Vec<&str> = [d.source.as_deref(), d.target.as_deref(), d.node.as_deref()]


### PR DESCRIPTION
## Summary
- Use `npx drft` in hook/CI examples for npm-based projects
- Document both global and devDep install patterns
- Add `required-frontmatter` custom rule example showing file content inspection

## Test plan
- [x] Custom rule example tested locally
- [ ] CI passes