### PR TITLE
Fix #9: containment catches ../ escape; Fix #8: frontmatter exemptions

### DIFF
--- a/examples/custom-rules/scripts/required-frontmatter.sh
+++ b/examples/custom-rules/scripts/required-frontmatter.sh
@@ -2,15 +2,16 @@
 # Require specific frontmatter fields in all document nodes.
 # Receives JGF graph JSON on stdin, reads files from disk to check frontmatter.
 #
-# Checks for: title, sources
-# Customize REQUIRED_FIELDS below.
+# Customize REQUIRED_FIELDS and SKIP_NAMES below.
 
 REQUIRED_FIELDS="title sources"
+SKIP_NAMES="README.md CHANGELOG.md CONTRIBUTING.md CLAUDE.md"
 
 python3 -c "
 import json, sys, os, re
 
 required = '$REQUIRED_FIELDS'.split()
+skip_names = set('$SKIP_NAMES'.split())
 data = json.load(sys.stdin)
 graph = data['graph']
 
@@ -18,6 +19,11 @@ for path, node in sorted(graph['nodes'].items()):
     if node['metadata']['type'] != 'document':
         continue
     if not os.path.isfile(path):
+        continue
+
+    # Skip exempt filenames
+    filename = os.path.basename(path)
+    if filename in skip_names:
         continue
 
     content = open(path).read()

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -220,23 +220,25 @@ pub fn build_graph(root: &Path, config: &Config) -> Result<Graph> {
 
 /// Normalize a relative path by resolving `.` and `..` components using Path APIs.
 /// Does not touch the filesystem. Always returns forward-slash separated paths.
+/// Preserves leading `..` that escape above the root — these indicate scope escape.
 pub fn normalize_relative_path(path: &str) -> String {
-    let mut components: Vec<&std::ffi::OsStr> = Vec::new();
+    let mut parts: Vec<String> = Vec::new();
     for component in Path::new(path).components() {
         match component {
             std::path::Component::CurDir => {}
             std::path::Component::ParentDir => {
-                components.pop();
+                // Only pop if there's a normal component to pop (not a leading ..)
+                if parts.last().is_some_and(|p| p != "..") {
+                    parts.pop();
+                } else {
+                    parts.push("..".to_string());
+                }
             }
-            std::path::Component::Normal(c) => components.push(c),
+            std::path::Component::Normal(c) => parts.push(c.to_string_lossy().to_string()),
             _ => {}
         }
     }
-    components
-        .iter()
-        .map(|c| c.to_string_lossy())
-        .collect::<Vec<_>>()
-        .join("/")
+    parts.join("/")
 }
 
 /// Resolve a link target relative to a source file, producing a path relative to the scope root.
@@ -268,8 +270,22 @@ mod tests {
     }
 
     #[test]
-    fn normalize_leading_dotdot() {
-        assert_eq!(normalize_relative_path("../a"), "a");
+    fn normalize_preserves_leading_dotdot() {
+        assert_eq!(normalize_relative_path("../a"), "../a");
+    }
+
+    #[test]
+    fn normalize_deep_escape() {
+        assert_eq!(normalize_relative_path("../../a"), "../../a");
+    }
+
+    #[test]
+    fn normalize_escape_after_descent() {
+        // guides/../../README.md -> ../README.md (one level above root)
+        assert_eq!(
+            normalize_relative_path("guides/../../README.md"),
+            "../README.md"
+        );
     }
 
     #[test]

--- a/src/rules/containment.rs
+++ b/src/rules/containment.rs
@@ -24,30 +24,8 @@ impl Rule for ContainmentRule {
                 continue;
             }
 
-            // Check if the raw target (before normalization) escapes the scope.
-            // After normalization, paths that escape resolve to something like "" or
-            // the normalized form won't match a file inside the scope.
-            // But we need to check the un-normalized edge: if the link text
-            // included ../ that would go above root, it's a containment violation.
-            //
-            // We re-derive this by checking if the target path, when joined with root,
-            // would land outside root.
-            let joined = root.join(&edge.target);
-            let canonical_root = match root.canonicalize() {
-                Ok(p) => p,
-                Err(_) => return diagnostics,
-            };
-            // For broken links the target may not exist, so we canonicalize the parent
-            let target_parent = match joined.parent() {
-                Some(p) if p.exists() => match p.canonicalize() {
-                    Ok(cp) => cp,
-                    Err(_) => continue,
-                },
-                _ => continue,
-            };
-            let target_canonical = target_parent.join(joined.file_name().unwrap_or_default());
-
-            if !target_canonical.starts_with(&canonical_root) {
+            // A target starting with ../ escapes the scope root
+            if edge.target.starts_with("../") || edge.target == ".." {
                 diagnostics.push(Diagnostic {
                     rule: "containment".into(),
                     message: "links outside scope boundary".into(),
@@ -75,12 +53,8 @@ mod tests {
 
     #[test]
     fn detects_escape() {
-        let parent = TempDir::new().unwrap();
-        let scope = parent.path().join("docs");
-        fs::create_dir(&scope).unwrap();
-        fs::write(scope.join("drft.lock"), "lockfile_version = 1\n").unwrap();
-        fs::write(scope.join("index.md"), "").unwrap();
-        fs::write(parent.path().join("README.md"), "").unwrap();
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("drft.lock"), "lockfile_version = 1\n").unwrap();
 
         let mut graph = Graph::new();
         graph.add_node(Node {
@@ -95,18 +69,38 @@ mod tests {
         });
 
         let rule = ContainmentRule;
-        let diagnostics = rule.evaluate(&graph, &scope);
+        let diagnostics = rule.evaluate(&graph, dir.path());
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, "containment");
         assert_eq!(diagnostics[0].target.as_deref(), Some("../README.md"));
     }
 
     #[test]
+    fn detects_deep_escape() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("drft.lock"), "lockfile_version = 1\n").unwrap();
+
+        let mut graph = Graph::new();
+        graph.add_node(Node {
+            path: "index.md".into(),
+            node_type: NodeType::Document,
+            hash: None,
+        });
+        graph.add_edge(Edge {
+            source: "index.md".into(),
+            target: "../../other.md".into(),
+            edge_type: EdgeType::Inline,
+        });
+
+        let rule = ContainmentRule;
+        let diagnostics = rule.evaluate(&graph, dir.path());
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
     fn no_violation_for_internal_link() {
         let dir = TempDir::new().unwrap();
         fs::write(dir.path().join("drft.lock"), "lockfile_version = 1\n").unwrap();
-        fs::write(dir.path().join("index.md"), "").unwrap();
-        fs::write(dir.path().join("setup.md"), "").unwrap();
 
         let mut graph = Graph::new();
         graph.add_node(Node {
@@ -128,14 +122,8 @@ mod tests {
     #[test]
     fn vacuous_without_lockfile() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("index.md"), "").unwrap();
 
         let mut graph = Graph::new();
-        graph.add_node(Node {
-            path: "index.md".into(),
-            node_type: NodeType::Document,
-            hash: None,
-        });
         graph.add_edge(Edge {
             source: "index.md".into(),
             target: "../escape.md".into(),

--- a/src/rules/lockfile_outdated.rs
+++ b/src/rules/lockfile_outdated.rs
@@ -53,7 +53,7 @@ impl Rule for LockfileOutdatedRule {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::graph::{build_graph, hash_bytes, Edge, EdgeType, Node, NodeType};
+    use crate::graph::build_graph;
     use crate::lockfile::write_lockfile;
     use std::fs;
     use tempfile::TempDir;

--- a/tests/scenarios.rs
+++ b/tests/scenarios.rs
@@ -992,3 +992,27 @@ fn lockfile_contains_version() {
     let lockfile = fs::read_to_string(dir.path().join("drft.lock")).unwrap();
     assert!(lockfile.starts_with("lockfile_version = 1"));
 }
+
+// ── Containment escape ─────────────────────────────────────────
+
+/// Issue #9: ../  links should trigger containment rule.
+#[test]
+fn containment_catches_escape() {
+    let dir = TempDir::new().unwrap();
+    let child = dir.path().join("docs");
+    fs::create_dir(&child).unwrap();
+    fs::write(child.join("drft.lock"), "lockfile_version = 1\n").unwrap();
+    fs::write(child.join("index.md"), "[escape](../README.md)").unwrap();
+    fs::write(dir.path().join("README.md"), "# Root").unwrap();
+
+    let output = drft_bin()
+        .args(["-C", child.to_str().unwrap(), "check"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("containment"),
+        "expected containment violation for ../README.md, got: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary
- **#9**: `normalize_relative_path` now preserves leading `../` instead of silently dropping it. Containment rule detects scope escape. Added integration test.
- **#8**: `required-frontmatter` example adds `SKIP_NAMES` variable (defaults to README.md, CHANGELOG.md, CONTRIBUTING.md, CLAUDE.md).

## Test plan
- [x] 109 tests passing (74 unit + 35 integration)
- [x] New integration test: `containment_catches_escape`
- [x] clippy clean
- [ ] CI passes

Closes #8, closes #9