### PR TITLE
Fix #11: resolve custom rule commands relative to config file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,9 @@ pub struct Config {
     pub rules: HashMap<String, RuleSeverity>,
     pub ignore_rules: HashMap<String, Vec<String>>,
     pub custom_rules: HashMap<String, CustomRuleConfig>,
+    /// Directory containing the drft.toml this config was loaded from.
+    /// Used to resolve relative paths in custom rule commands.
+    pub config_dir: Option<std::path::PathBuf>,
     ignore_rules_compiled: HashMap<String, Option<GlobSet>>,
 }
 
@@ -66,6 +69,7 @@ impl Config {
             rules,
             ignore_rules: HashMap::new(),
             custom_rules: HashMap::new(),
+            config_dir: None,
             ignore_rules_compiled: HashMap::new(),
         }
     }
@@ -85,6 +89,7 @@ impl Config {
             .with_context(|| format!("failed to parse {}", config_path.display()))?;
 
         let mut config = Self::defaults();
+        config.config_dir = config_path.parent().map(|p| p.to_path_buf());
 
         if let Some(ignore) = raw.ignore {
             config.ignore = ignore;

--- a/src/rules/custom.rs
+++ b/src/rules/custom.rs
@@ -16,12 +16,23 @@ use crate::graph::Graph;
 /// are set by drft from the config — the script doesn't need to provide them.
 pub fn run_custom_rules(graph: &Graph, root: &Path, config: &Config) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
+    let config_dir = config.config_dir.as_deref().unwrap_or(root);
 
     for (rule_name, rule_config) in &config.custom_rules {
-        match run_one(rule_name, rule_config, graph, root) {
+        match run_one(rule_name, rule_config, graph, root, config_dir) {
             Ok(mut results) => diagnostics.append(&mut results),
             Err(e) => {
                 eprintln!("warn: custom rule \"{rule_name}\" failed: {e}");
+                // Surface failures as diagnostics so JSON consumers see them
+                diagnostics.push(Diagnostic {
+                    rule: rule_name.clone(),
+                    severity: rule_config.severity,
+                    message: format!("custom rule failed: {e}"),
+                    fix: Some(format!(
+                        "custom rule \"{rule_name}\" failed to execute — check the command path and script"
+                    )),
+                    ..Default::default()
+                });
             }
         }
     }
@@ -34,6 +45,7 @@ fn run_one(
     rule_config: &CustomRuleConfig,
     graph: &Graph,
     root: &Path,
+    config_dir: &Path,
 ) -> anyhow::Result<Vec<Diagnostic>> {
     // Build the graph JSON to pass on stdin
     let graph_json = build_graph_json(graph);
@@ -44,7 +56,14 @@ fn run_one(
         anyhow::bail!("empty command");
     }
 
-    let output = Command::new(parts[0])
+    // Resolve command path relative to config directory (where drft.toml lives)
+    let cmd = if parts[0].starts_with("./") || parts[0].starts_with("../") {
+        config_dir.join(parts[0]).to_string_lossy().to_string()
+    } else {
+        parts[0].to_string()
+    };
+
+    let output = Command::new(&cmd)
         .args(&parts[1..])
         .current_dir(root)
         .stdin(std::process::Stdio::piped())
@@ -194,7 +213,7 @@ mod tests {
         };
 
         let graph = make_graph();
-        let diagnostics = run_one("my-rule", &config, &graph, dir.path()).unwrap();
+        let diagnostics = run_one("my-rule", &config, &graph, dir.path(), dir.path()).unwrap();
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, "my-rule");
@@ -221,7 +240,7 @@ mod tests {
         };
 
         let graph = make_graph();
-        let result = run_one("bad-rule", &config, &graph, dir.path());
+        let result = run_one("bad-rule", &config, &graph, dir.path(), dir.path());
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary
- Custom rule `command` paths starting with `./` or `../` now resolve relative to the directory containing `drft.toml`, not the scope's CWD
- Config tracks `config_dir` — the directory where `drft.toml` was found (supports inheritance)
- Failed custom rules now appear as diagnostics in JSON output instead of only stderr warnings

Closes #11

## Test plan
- [x] 109 tests passing
- [x] clippy clean
- [ ] CI passes