### PR TITLE
Add analysis module, redundant-edge rule, and report command

### DIFF
--- a/docs/analyses/README.md
+++ b/docs/analyses/README.md
@@ -1,0 +1,24 @@
+# Analyses
+
+drft treats a directory of markdown files as a dependency graph — files are nodes, links are edges. **Analyses** compute structural properties of this graph. They describe shape, not correctness.
+
+Rules consume analyses to produce diagnostics (pass/fail judgments). The `drft report` command exposes analyses directly, without judgment, so you can understand your graph's structure before deciding what to enforce.
+
+## Available analyses
+
+| Analysis | Command | Description |
+|----------|---------|-------------|
+| [Transitive reduction](transitive-reduction.md) | `drft report --analysis transitive-reduction` | Finds edges that are structurally redundant |
+
+## Graph theory and knowledge systems
+
+When you organize files and link them together, you are building a graph — whether or not you think of it that way. Graph theory provides a vocabulary for reasoning about the structural properties that emerge. drft uses this vocabulary directly (e.g., "transitive reduction" rather than "redundant link detection") because the concepts are precise, well-studied, and transferable. Each analysis doc explains the underlying graph theory and how it applies to file-based knowledge systems.
+
+## Analyses vs. rules
+
+An **analysis** computes a property: "this edge is transitively redundant." A **rule** applies a threshold: "transitively redundant edges are a warning." This separation means:
+
+- You can explore your graph's structure without being told what's wrong
+- Rules stay thin — a judgment layer over shared data
+- Multiple rules can consume the same analysis
+- New rules can compose existing analyses (e.g., "warn on stale files that are also dominators")

--- a/docs/analyses/transitive-reduction.md
+++ b/docs/analyses/transitive-reduction.md
@@ -1,0 +1,99 @@
+# Transitive reduction
+
+## The concept
+
+The **transitive reduction** of a directed graph is the smallest set of edges that preserves all reachability. If you can get from A to C through B, then a direct edge A → C is redundant — it adds no reachability that the path A → B → C doesn't already provide.
+
+The difference between your actual graph and its transitive reduction is the set of **transitively redundant edges**: shortcuts that can be removed without changing which nodes can reach which other nodes.
+
+```
+Before                          Transitive reduction
+
+A ──→ B ──→ C                   A ──→ B ──→ C
+│           ▲
+└───────────┘  ← redundant
+```
+
+The direct edge A → C is redundant because A already reaches C through B. Removing it doesn't change what A can reach — it only removes a shortcut.
+
+## Why it matters for knowledge systems
+
+In a file-based knowledge system with intentional layers — say, research → observations → design → acceptance criteria — each layer is meant to cite only the layer below it. A direct link that skips a layer is usually a structural mistake:
+
+```
+synthesis.md → observations.md → evidence/EVD-01.md
+synthesis.md → evidence/EVD-01.md   ← redundant
+```
+
+Synthesis already reaches EVD-01 through observations. The direct link:
+
+- **Obscures the actual dependency structure.** The layered chain tells you _how_ synthesis depends on EVD-01 (through observations). The shortcut hides that.
+- **Creates unnecessary staleness propagation.** When EVD-01 changes, both observations _and_ synthesis get flagged as stale. But only observations should be the direct dependent — synthesis should hear about it through observations.
+- **Makes impact analysis noisier.** `drft impact evidence/EVD-01.md` reports more dependents than necessary because the shortcut creates an extra propagation path.
+
+Not every redundant edge is a mistake. In some structures, direct links are intentional convenience — a table of contents linking to every page, for example. That's why the `redundant-edge` rule defaults to `off`. But in systems with intentional layering, redundant edges almost always indicate structural drift.
+
+## What drft surfaces
+
+### As an analysis (`drft report`)
+
+```bash
+drft report --analysis transitive-reduction
+```
+
+```
+=== transitive-reduction ===
+synthesis.md → evidence/EVD-01.md (via observations.md)
+```
+
+JSON output:
+
+```json
+{
+  "analyses": {
+    "transitive-reduction": {
+      "redundant_edges": [
+        {
+          "source": "synthesis.md",
+          "target": "evidence/EVD-01.md",
+          "via": "observations.md"
+        }
+      ]
+    }
+  }
+}
+```
+
+The `via` field shows one intermediate node proving the alternate path exists. When multiple alternate paths exist, only one is reported — the goal is to show _that_ the edge is redundant, not to enumerate every alternate route.
+
+### As a rule (`drft check`)
+
+The `redundant-edge` rule wraps this analysis in a diagnostic:
+
+```
+warn[redundant-edge]: synthesis.md → evidence/EVD-01.md (transitively redundant via observations.md)
+```
+
+Enable it in `drft.toml`:
+
+```toml
+[rules]
+redundant-edge = "warn"   # or "error"
+```
+
+Or check on demand without changing config:
+
+```bash
+drft check --rule redundant-edge
+```
+
+## Algorithm
+
+For each edge (A, C) in the graph, drft runs a breadth-first search from A, following forward edges but skipping the direct edge to C. If C is still reachable, the edge is redundant and the first intermediate node encountered on the alternate path is recorded as the `via`.
+
+Edges to nodes outside the graph (broken links, external URLs) and self-loops are excluded from the analysis.
+
+## Further reading
+
+- [Transitive reduction](https://en.wikipedia.org/wiki/Transitive_reduction) on Wikipedia
+- Aho, Garey, and Ullman (1972), "The transitive reduction of a directed graph" — the original paper establishing that every finite directed graph has a unique transitive reduction

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1,0 +1,15 @@
+pub mod transitive_reduction;
+
+use crate::graph::Graph;
+use std::path::Path;
+
+/// An analysis computes structured data about the graph.
+/// Rules consume analysis results and map them to diagnostics.
+/// See `docs/analyses/` for conceptual documentation on each analysis.
+pub trait Analysis {
+    type Output: serde::Serialize;
+
+    fn name(&self) -> &str;
+
+    fn run(&self, graph: &Graph, root: &Path) -> Self::Output;
+}

--- a/src/analysis/transitive_reduction.rs
+++ b/src/analysis/transitive_reduction.rs
@@ -1,0 +1,269 @@
+use super::Analysis;
+use crate::graph::Graph;
+use std::collections::{HashSet, VecDeque};
+use std::path::Path;
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RedundantEdge {
+    pub source: String,
+    pub target: String,
+    pub via: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TransitiveReductionResult {
+    pub redundant_edges: Vec<RedundantEdge>,
+}
+
+/// See `docs/analyses/transitive-reduction.md` for the full conceptual explanation.
+pub struct TransitiveReduction;
+
+impl Analysis for TransitiveReduction {
+    type Output = TransitiveReductionResult;
+
+    fn name(&self) -> &str {
+        "transitive-reduction"
+    }
+
+    fn run(&self, graph: &Graph, _root: &Path) -> TransitiveReductionResult {
+        let node_set: HashSet<&str> = graph.nodes.keys().map(|s| s.as_str()).collect();
+        let mut redundant_edges = Vec::new();
+
+        for edge in &graph.edges {
+            // Skip edges to/from nodes not in the graph
+            if !node_set.contains(edge.source.as_str()) || !node_set.contains(edge.target.as_str())
+            {
+                continue;
+            }
+
+            // Skip self-loops
+            if edge.source == edge.target {
+                continue;
+            }
+
+            // BFS from source, skipping the direct edge to target.
+            // If target is still reachable, the edge is redundant.
+            if let Some(via) =
+                reachable_without_direct(graph, &edge.source, &edge.target, &node_set)
+            {
+                redundant_edges.push(RedundantEdge {
+                    source: edge.source.clone(),
+                    target: edge.target.clone(),
+                    via,
+                });
+            }
+        }
+
+        redundant_edges.sort_by(|a, b| {
+            a.source
+                .cmp(&b.source)
+                .then_with(|| a.target.cmp(&b.target))
+        });
+
+        TransitiveReductionResult { redundant_edges }
+    }
+}
+
+/// BFS from `source` following forward edges, but skip any direct edge to `target`.
+/// If `target` is reached, return the first intermediate node on the path (the `via`).
+fn reachable_without_direct(
+    graph: &Graph,
+    source: &str,
+    target: &str,
+    node_set: &HashSet<&str>,
+) -> Option<String> {
+    let mut visited = HashSet::new();
+    // Queue entries: (current_node, first_intermediate_on_this_path)
+    let mut queue: VecDeque<(&str, Option<&str>)> = VecDeque::new();
+
+    visited.insert(source);
+    queue.push_back((source, None));
+
+    while let Some((current, first_hop)) = queue.pop_front() {
+        let Some(edge_indices) = graph.forward.get(current) else {
+            continue;
+        };
+
+        for &idx in edge_indices {
+            let neighbor = graph.edges[idx].target.as_str();
+
+            // Skip the direct source→target edge
+            if current == source && neighbor == target {
+                continue;
+            }
+
+            // Only traverse within known nodes
+            if !node_set.contains(neighbor) {
+                continue;
+            }
+
+            if !visited.insert(neighbor) {
+                continue;
+            }
+
+            // Track the first intermediate node on this path
+            let via = first_hop.unwrap_or(neighbor);
+
+            if neighbor == target {
+                return Some(via.to_string());
+            }
+
+            queue.push_back((neighbor, Some(via)));
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::{Edge, EdgeType, Graph, Node, NodeType};
+
+    fn make_node(path: &str) -> Node {
+        Node {
+            path: path.into(),
+            node_type: NodeType::Document,
+            hash: None,
+        }
+    }
+
+    fn make_edge(source: &str, target: &str) -> Edge {
+        Edge {
+            source: source.into(),
+            target: target.into(),
+            edge_type: EdgeType::Inline,
+        }
+    }
+
+    #[test]
+    fn diamond_redundancy() {
+        // A → B → C, A → C (redundant)
+        let mut graph = Graph::new();
+        graph.add_node(make_node("a.md"));
+        graph.add_node(make_node("b.md"));
+        graph.add_node(make_node("c.md"));
+        graph.add_edge(make_edge("a.md", "b.md"));
+        graph.add_edge(make_edge("b.md", "c.md"));
+        graph.add_edge(make_edge("a.md", "c.md"));
+
+        let analysis = TransitiveReduction;
+        let result = analysis.run(&graph, Path::new("."));
+
+        assert_eq!(result.redundant_edges.len(), 1);
+        assert_eq!(result.redundant_edges[0].source, "a.md");
+        assert_eq!(result.redundant_edges[0].target, "c.md");
+        assert_eq!(result.redundant_edges[0].via, "b.md");
+    }
+
+    #[test]
+    fn no_redundancy() {
+        // A → B → C (no shortcuts)
+        let mut graph = Graph::new();
+        graph.add_node(make_node("a.md"));
+        graph.add_node(make_node("b.md"));
+        graph.add_node(make_node("c.md"));
+        graph.add_edge(make_edge("a.md", "b.md"));
+        graph.add_edge(make_edge("b.md", "c.md"));
+
+        let analysis = TransitiveReduction;
+        let result = analysis.run(&graph, Path::new("."));
+
+        assert!(result.redundant_edges.is_empty());
+    }
+
+    #[test]
+    fn multiple_redundancies() {
+        // A → B → C, A → C (redundant)
+        // A → B → D, A → D (redundant)
+        let mut graph = Graph::new();
+        graph.add_node(make_node("a.md"));
+        graph.add_node(make_node("b.md"));
+        graph.add_node(make_node("c.md"));
+        graph.add_node(make_node("d.md"));
+        graph.add_edge(make_edge("a.md", "b.md"));
+        graph.add_edge(make_edge("b.md", "c.md"));
+        graph.add_edge(make_edge("b.md", "d.md"));
+        graph.add_edge(make_edge("a.md", "c.md"));
+        graph.add_edge(make_edge("a.md", "d.md"));
+
+        let analysis = TransitiveReduction;
+        let result = analysis.run(&graph, Path::new("."));
+
+        assert_eq!(result.redundant_edges.len(), 2);
+        let targets: Vec<&str> = result
+            .redundant_edges
+            .iter()
+            .map(|r| r.target.as_str())
+            .collect();
+        assert!(targets.contains(&"c.md"));
+        assert!(targets.contains(&"d.md"));
+    }
+
+    #[test]
+    fn longer_chain() {
+        // A → B → C → D, A → D (redundant via B)
+        let mut graph = Graph::new();
+        graph.add_node(make_node("a.md"));
+        graph.add_node(make_node("b.md"));
+        graph.add_node(make_node("c.md"));
+        graph.add_node(make_node("d.md"));
+        graph.add_edge(make_edge("a.md", "b.md"));
+        graph.add_edge(make_edge("b.md", "c.md"));
+        graph.add_edge(make_edge("c.md", "d.md"));
+        graph.add_edge(make_edge("a.md", "d.md"));
+
+        let analysis = TransitiveReduction;
+        let result = analysis.run(&graph, Path::new("."));
+
+        assert_eq!(result.redundant_edges.len(), 1);
+        assert_eq!(result.redundant_edges[0].source, "a.md");
+        assert_eq!(result.redundant_edges[0].target, "d.md");
+        assert_eq!(result.redundant_edges[0].via, "b.md");
+    }
+
+    #[test]
+    fn self_loop_not_flagged() {
+        let mut graph = Graph::new();
+        graph.add_node(make_node("a.md"));
+        graph.add_edge(make_edge("a.md", "a.md"));
+
+        let analysis = TransitiveReduction;
+        let result = analysis.run(&graph, Path::new("."));
+
+        assert!(result.redundant_edges.is_empty());
+    }
+
+    #[test]
+    fn disconnected_components() {
+        // Component 1: A → B
+        // Component 2: C → D
+        // No redundancy
+        let mut graph = Graph::new();
+        graph.add_node(make_node("a.md"));
+        graph.add_node(make_node("b.md"));
+        graph.add_node(make_node("c.md"));
+        graph.add_node(make_node("d.md"));
+        graph.add_edge(make_edge("a.md", "b.md"));
+        graph.add_edge(make_edge("c.md", "d.md"));
+
+        let analysis = TransitiveReduction;
+        let result = analysis.run(&graph, Path::new("."));
+
+        assert!(result.redundant_edges.is_empty());
+    }
+
+    #[test]
+    fn edge_to_missing_node_skipped() {
+        let mut graph = Graph::new();
+        graph.add_node(make_node("a.md"));
+        graph.add_node(make_node("b.md"));
+        graph.add_edge(make_edge("a.md", "b.md"));
+        graph.add_edge(make_edge("a.md", "missing.md")); // target not in nodes
+
+        let analysis = TransitiveReduction;
+        let result = analysis.run(&graph, Path::new("."));
+
+        assert!(result.redundant_edges.is_empty());
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,6 +69,13 @@ pub enum Commands {
         files: Vec<String>,
     },
 
+    /// Run graph analyses and output structured results
+    Report {
+        /// Analyses to run (defaults to all)
+        #[arg(long = "analysis")]
+        analyses: Vec<String>,
+    },
+
     /// Check markdown structure for rule violations
     Check {
         /// Run only specific rules (can be repeated)

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,7 @@ impl Config {
             ("indirect-link", RuleSeverity::Off),
             ("lockfile-outdated", RuleSeverity::Warn),
             ("orphan", RuleSeverity::Off),
+            ("redundant-edge", RuleSeverity::Off),
             ("stale", RuleSeverity::Warn),
         ]
         .into_iter()

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -49,9 +49,14 @@ impl Diagnostic {
 
         match (&self.source, &self.target) {
             (Some(source), Some(target)) => {
+                let via_suffix = self
+                    .via
+                    .as_ref()
+                    .map(|v| format!(" via {v}"))
+                    .unwrap_or_default();
                 format!(
-                    "{severity}[{}]: {source} \u{2192} {target} ({})",
-                    self.rule, self.message
+                    "{severity}[{}]: {source} \u{2192} {target} ({}{})",
+                    self.rule, self.message, via_suffix
                 )
             }
             _ if self.path.is_some() => {
@@ -84,9 +89,14 @@ impl Diagnostic {
 
         match (&self.source, &self.target) {
             (Some(source), Some(target)) => {
+                let via_suffix = self
+                    .via
+                    .as_ref()
+                    .map(|v| format!(" via {cyan}{v}{reset}"))
+                    .unwrap_or_default();
                 format!(
-                    "{color}{severity_str}{reset}[{bold}{}{reset}]: {cyan}{source}{reset} \u{2192} {cyan}{target}{reset} ({})",
-                    self.rule, self.message
+                    "{color}{severity_str}{reset}[{bold}{}{reset}]: {cyan}{source}{reset} \u{2192} {cyan}{target}{reset} ({}{})",
+                    self.rule, self.message, via_suffix
                 )
             }
             _ if self.path.is_some() => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod analysis;
 mod cli;
 mod config;
 mod diagnostic;
@@ -78,6 +79,7 @@ fn try_main() -> Result<i32> {
             *recursive,
             *max_depth,
         ),
+        Commands::Report { analyses } => run_report(&root, cli.format, analyses),
         Commands::Impact { files } => run_impact(&root, cli.format, files),
         Commands::Graph {
             recursive,
@@ -136,6 +138,7 @@ encapsulation = "warn"
 indirect-link = "off"
 lockfile-outdated = "warn"
 orphan = "off"
+redundant-edge = "off"
 stale = "warn"
 
 # Per-rule path ignores (glob patterns)
@@ -151,6 +154,57 @@ stale = "warn"
 
     std::fs::write(&config_path, content)
         .with_context(|| format!("failed to write {}", config_path.display()))?;
+
+    Ok(0)
+}
+
+fn run_report(root: &Path, format: OutputFormat, analysis_filter: &[String]) -> Result<i32> {
+    use analysis::transitive_reduction::TransitiveReduction;
+    use analysis::Analysis;
+
+    let known_analyses = ["transitive-reduction"];
+
+    // Validate analysis names
+    for name in analysis_filter {
+        if !known_analyses.contains(&name.as_str()) {
+            anyhow::bail!("unknown analysis: \"{name}\"");
+        }
+    }
+
+    let scope_root = find_scope_root(root);
+    let config = Config::load(&scope_root)?;
+    let graph = build_graph(&scope_root, &config)?;
+
+    let run_all = analysis_filter.is_empty();
+
+    let mut results = serde_json::Map::new();
+
+    if run_all || analysis_filter.iter().any(|a| a == "transitive-reduction") {
+        let tr = TransitiveReduction;
+        let result = tr.run(&graph, &scope_root);
+
+        match format {
+            OutputFormat::Json => {
+                results.insert(tr.name().to_string(), serde_json::to_value(&result)?);
+            }
+            _ => {
+                if result.redundant_edges.is_empty() {
+                    println!("=== transitive-reduction ===");
+                    println!("no redundant edges");
+                } else {
+                    println!("=== transitive-reduction ===");
+                    for re in &result.redundant_edges {
+                        println!("{} \u{2192} {} (via {})", re.source, re.target, re.via);
+                    }
+                }
+            }
+        }
+    }
+
+    if matches!(format, OutputFormat::Json) {
+        let output = serde_json::json!({ "analyses": results });
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    }
 
     Ok(0)
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -7,6 +7,7 @@ pub mod encapsulation;
 pub mod indirect_link;
 pub mod lockfile_outdated;
 pub mod orphan;
+pub mod redundant_edge;
 pub mod stale;
 
 use crate::diagnostic::Diagnostic;
@@ -28,6 +29,7 @@ pub fn all_rules() -> Vec<Box<dyn Rule>> {
         Box::new(indirect_link::IndirectLinkRule),
         Box::new(lockfile_outdated::LockfileOutdatedRule),
         Box::new(orphan::OrphanRule),
+        Box::new(redundant_edge::RedundantEdgeRule),
         Box::new(stale::StaleRule),
     ]
 }

--- a/src/rules/redundant_edge.rs
+++ b/src/rules/redundant_edge.rs
@@ -1,0 +1,94 @@
+use super::Rule;
+use crate::analysis::transitive_reduction::TransitiveReduction;
+use crate::analysis::Analysis;
+use crate::diagnostic::Diagnostic;
+use crate::graph::Graph;
+use std::path::Path;
+
+pub struct RedundantEdgeRule;
+
+impl Rule for RedundantEdgeRule {
+    fn name(&self) -> &str {
+        "redundant-edge"
+    }
+
+    fn evaluate(&self, graph: &Graph, root: &Path) -> Vec<Diagnostic> {
+        let analysis = TransitiveReduction;
+        let result = analysis.run(graph, root);
+
+        result
+            .redundant_edges
+            .iter()
+            .map(|re| Diagnostic {
+                rule: "redundant-edge".into(),
+                message: "transitively redundant".into(),
+                source: Some(re.source.clone()),
+                target: Some(re.target.clone()),
+                via: Some(re.via.clone()),
+                fix: Some(format!(
+                    "{} links directly to {}, but already reaches it via {} \u{2014} remove the direct link",
+                    re.source, re.target, re.via
+                )),
+                ..Default::default()
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::{Edge, EdgeType, Node, NodeType};
+
+    fn make_node(path: &str) -> Node {
+        Node {
+            path: path.into(),
+            node_type: NodeType::Document,
+            hash: None,
+        }
+    }
+
+    fn make_edge(source: &str, target: &str) -> Edge {
+        Edge {
+            source: source.into(),
+            target: target.into(),
+            edge_type: EdgeType::Inline,
+        }
+    }
+
+    #[test]
+    fn produces_diagnostics_for_redundant_edges() {
+        let mut graph = Graph::new();
+        graph.add_node(make_node("a.md"));
+        graph.add_node(make_node("b.md"));
+        graph.add_node(make_node("c.md"));
+        graph.add_edge(make_edge("a.md", "b.md"));
+        graph.add_edge(make_edge("b.md", "c.md"));
+        graph.add_edge(make_edge("a.md", "c.md"));
+
+        let rule = RedundantEdgeRule;
+        let diagnostics = rule.evaluate(&graph, Path::new("."));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, "redundant-edge");
+        assert_eq!(diagnostics[0].source.as_deref(), Some("a.md"));
+        assert_eq!(diagnostics[0].target.as_deref(), Some("c.md"));
+        assert_eq!(diagnostics[0].via.as_deref(), Some("b.md"));
+        assert_eq!(diagnostics[0].message, "transitively redundant");
+    }
+
+    #[test]
+    fn no_diagnostics_when_no_redundancy() {
+        let mut graph = Graph::new();
+        graph.add_node(make_node("a.md"));
+        graph.add_node(make_node("b.md"));
+        graph.add_node(make_node("c.md"));
+        graph.add_edge(make_edge("a.md", "b.md"));
+        graph.add_edge(make_edge("b.md", "c.md"));
+
+        let rule = RedundantEdgeRule;
+        let diagnostics = rule.evaluate(&graph, Path::new("."));
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/tests/scenarios.rs
+++ b/tests/scenarios.rs
@@ -993,6 +993,221 @@ fn lockfile_contains_version() {
     assert!(lockfile.starts_with("lockfile_version = 1"));
 }
 
+// ── Redundant edge ────────────────────────────────────────────
+
+/// redundant-edge is off by default — no output even with redundant edges.
+#[test]
+fn redundant_edge_off_by_default() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.md"), "[b](b.md) [c](c.md)").unwrap();
+    fs::write(dir.path().join("b.md"), "[c](c.md)").unwrap();
+    fs::write(dir.path().join("c.md"), "# C").unwrap();
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "check"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("redundant-edge"),
+        "redundant-edge should be off by default"
+    );
+}
+
+/// redundant-edge enabled via drft.toml produces diagnostics.
+#[test]
+fn redundant_edge_enabled_via_config() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("drft.toml"),
+        "[rules]\nredundant-edge = \"warn\"\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("a.md"), "[b](b.md) [c](c.md)").unwrap();
+    fs::write(dir.path().join("b.md"), "[c](c.md)").unwrap();
+    fs::write(dir.path().join("c.md"), "# C").unwrap();
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "check"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("redundant-edge"),
+        "expected redundant-edge diagnostic, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("a.md"),
+        "expected source a.md in output, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("c.md"),
+        "expected target c.md in output, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("via"),
+        "expected via in output, got: {stdout}"
+    );
+}
+
+/// --rule redundant-edge overrides off to warn.
+#[test]
+fn redundant_edge_via_rule_flag() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.md"), "[b](b.md) [c](c.md)").unwrap();
+    fs::write(dir.path().join("b.md"), "[c](c.md)").unwrap();
+    fs::write(dir.path().join("c.md"), "# C").unwrap();
+
+    let output = drft_bin()
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "check",
+            "--rule",
+            "redundant-edge",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("redundant-edge"),
+        "expected redundant-edge diagnostic via --rule flag, got: {stdout}"
+    );
+}
+
+/// redundant-edge JSON output has expected fields.
+#[test]
+fn redundant_edge_json() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("drft.toml"),
+        "[rules]\nredundant-edge = \"warn\"\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("a.md"), "[b](b.md) [c](c.md)").unwrap();
+    fs::write(dir.path().join("b.md"), "[c](c.md)").unwrap();
+    fs::write(dir.path().join("c.md"), "# C").unwrap();
+
+    let output = drft_bin()
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+            "check",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    let diagnostics = v["diagnostics"].as_array().unwrap();
+    let redundant: Vec<&serde_json::Value> = diagnostics
+        .iter()
+        .filter(|d| d["rule"] == "redundant-edge")
+        .collect();
+    assert_eq!(redundant.len(), 1);
+    assert_eq!(redundant[0]["source"], "a.md");
+    assert_eq!(redundant[0]["target"], "c.md");
+    assert!(redundant[0]["via"].is_string());
+    assert!(redundant[0]["fix"].is_string());
+}
+
+// ── Report command ────────────────────────────────────────────
+
+#[test]
+fn report_text_output() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.md"), "[b](b.md) [c](c.md)").unwrap();
+    fs::write(dir.path().join("b.md"), "[c](c.md)").unwrap();
+    fs::write(dir.path().join("c.md"), "# C").unwrap();
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "report"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("transitive-reduction"),
+        "expected analysis header, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("a.md"),
+        "expected source in report, got: {stdout}"
+    );
+}
+
+#[test]
+fn report_json_output() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.md"), "[b](b.md) [c](c.md)").unwrap();
+    fs::write(dir.path().join("b.md"), "[c](c.md)").unwrap();
+    fs::write(dir.path().join("c.md"), "# C").unwrap();
+
+    let output = drft_bin()
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+            "report",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    let tr = &v["analyses"]["transitive-reduction"];
+    let edges = tr["redundant_edges"].as_array().unwrap();
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0]["source"], "a.md");
+    assert_eq!(edges[0]["target"], "c.md");
+}
+
+#[test]
+fn report_no_redundancy() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.md"), "[b](b.md)").unwrap();
+    fs::write(dir.path().join("b.md"), "# B").unwrap();
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "report"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("no redundant edges"),
+        "expected clean report, got: {stdout}"
+    );
+}
+
+#[test]
+fn report_unknown_analysis_exits_2() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.md"), "# A").unwrap();
+
+    let output = drft_bin()
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "report",
+            "--analysis",
+            "nonexistent",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+}
+
 // ── Containment escape ─────────────────────────────────────────
 
 /// Issue #9: ../  links should trigger containment rule.


### PR DESCRIPTION
## Summary

Closes #15.

- Introduces `src/analysis/` as a new layer that computes graph properties as structured data, separate from rule judgment. The **transitive reduction** analysis is the pilot case.
- Adds the `redundant-edge` rule (default: `off`) — a thin wrapper that maps analysis results to diagnostics.
- Adds the `drft report` command for exploring graph structure without pass/fail judgment.
- Extends diagnostic rendering to include `via` on edge diagnostics.
- Adds conceptual documentation in `docs/analyses/` explaining the graph theory and its application to file-based knowledge systems.

### New files
- `src/analysis/mod.rs` — `Analysis` trait with associated `Output` type
- `src/analysis/transitive_reduction.rs` — BFS reachability algorithm (7 unit tests)
- `src/rules/redundant_edge.rs` — rule wrapper (2 unit tests)
- `docs/analyses/README.md` — overview of the analysis layer
- `docs/analyses/transitive-reduction.md` — conceptual doc for transitive reduction

### Modified files
- `src/rules/mod.rs` — register redundant-edge rule
- `src/config.rs` — default severity `off`
- `src/diagnostic.rs` — `via` suffix in source→target rendering
- `src/cli.rs` — `Report` command variant
- `src/main.rs` — `mod analysis`, `run_report()`, updated init template
- `tests/scenarios.rs` — 8 new integration tests

## Test plan

- [x] 126 tests pass (83 unit + 43 integration)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `drft check` unchanged for existing rulesets
- [x] `drft check --rule redundant-edge` surfaces redundancies
- [x] `drft report` and `drft report --format json` produce expected output
- [x] `redundant-edge` defaults to `off`, activates via config or `--rule` flag