### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to drft are documented here.
 
+## 0.4.0 (2026-03-31)
+
+Graph model redesign — explicit graph declaration, pure rules, parser metadata, and enriched impact analysis.
+
+### Breaking changes
+- **Graph declaration**: `include`/`exclude` replaces implicit parser-glob union. `ignore` renamed to `exclude`.
+- **Node types**: `Source` → `File`, `Resource` removed. Three types: File, External, Graph.
+- **Rule renames**: `broken-link` → `dangling-edge`, `cycle` → `directed-cycle`, `containment` → `boundary-violation`, `encapsulation` → `encapsulation-violation`, `orphan` → `orphan-node`, `indirect-link` → `symlink-edge`, `directory-link` → `directory-edge`.
+- **Parser contract**: `glob` replaced by `files` (array of globs), `types` replaced by `options` (arbitrary structured data). Parsers return raw link strings — graph builder owns normalization.
+- **Edge model simplified**: `RawLink`/`EdgeType` removed. Edge = `{ source, target, link?, parser }`.
+- **RuleContext**: reduced to `{ graph: &EnrichedGraph, options }`. No filesystem access, no config.
+- **Lockfile**: regenerated with new node types.
+
+### New features
+- **`drft parse`** command: raw parser output for debugging script parsers and the options envelope protocol.
+- **Frontmatter parser**: standalone built-in parser for YAML frontmatter (links + structured metadata).
+- **Schema-violation rule**: validates node metadata against glob-scoped schemas with required/allowed fields. First consumer of parser metadata and rule options.
+- **Impact-radius analysis**: per-node blast zone (transitive dependents, depth, direct count).
+- **Enriched `drft impact`**: output annotated with depth, impact_radius, and betweenness; sorted by review priority.
+- **Rule options**: `[rules.<name>.options]` for arbitrary structured data passed through to rules.
+- **Parser options**: `[parsers.<name>.options]` passed to script parsers as JSON envelope on stdin.
+- **Script rule enrichment**: script rules receive `{ graph, options }` with all 12 analyses.
+
+### Fixes
+- Replace deprecated `serde_yaml` with maintained `serde_yml` fork.
+- Deterministic metadata merge across parser namespaces (sorted by key).
+- Warning on invalid glob patterns in schema-violation options.
+- `drft graph --dot` replaces `--format dot` (DOT output is graph-only).
+
 ## 0.3.0 (2026-03-30)
 
 Major architecture overhaul: drft is now a structural integrity checker for any linked file system, not just markdown.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "drft-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drft-cli"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 description = "A structural integrity checker for linked file systems"
 license = "MIT"

--- a/drft.lock
+++ b/drft.lock
@@ -6,7 +6,7 @@ hash = "b3:79ebd4adcd3a64c09ba8cac4915f00f7ed9677dfdbb9ef676056ccf92ae3a2a2"
 
 [nodes."CHANGELOG.md"]
 type = "file"
-hash = "b3:589ee07f003b7ec4ca5dac762b233cad6e2ce7a84944d49cca158153bb91700e"
+hash = "b3:e531805c1cf1c5f894d0ad1612d9602c0688560d7b31059889b5523bebad1398"
 
 [nodes."CLAUDE.md"]
 type = "file"


### PR DESCRIPTION
## Summary

Version bump and changelog for v0.4.0 — graph model redesign.

See CHANGELOG.md for the full list of breaking changes, new features, and fixes. The code shipped in PR #25; this PR is version + changelog only.

## After merge

```bash
git checkout main && git pull
git tag v0.4.0
git push origin v0.4.0
```