### PR TITLE
Add drft config show command

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ drft report --format json degree  # machine-readable output
 
 See [analyses documentation](docs/analyses/README.md) for the full list.
 
+### `drft config`
+
+Show the resolved configuration (defaults filled in).
+
+```bash
+drft config show              # resolved config as TOML
+drft config show --format json # machine-readable
+drft config show --recursive  # config for each graph in the tree
+```
+
 ### `drft init`
 
 Create a default `drft.toml` config file.

--- a/drft.lock
+++ b/drft.lock
@@ -22,7 +22,7 @@ hash = "b3:f457f74fbd0a183398a3e8d88c9e3fa6dc8205ba092ede3d2fcaacbde6959f92"
 
 [nodes."README.md"]
 type = "file"
-hash = "b3:687e0fcaeb957c6e5ba59cde9fd9ca6cbc769c891ffd93538e02a352deb14738"
+hash = "b3:2f41105db160c8704df94b5d22b8d00c4bb3f5641893be34fc345bfa15055cd3"
 
 [nodes."RELEASING.md"]
 type = "file"
@@ -278,7 +278,7 @@ hash = "b3:f9b05887e9a822bc7070280ba542359b56d89e6f2a17ccb52355808a02f99a16"
 
 [nodes."src/README.md"]
 type = "file"
-hash = "b3:fc1b28b2fce2a3dd0251c3c5cfec719e74f093e95969ff6d6ab881aa68fc121e"
+hash = "b3:56360a3a099763b7211ebec19f775bb578d56c1b8736aed36dfffcaea29cdf77"
 
 [nodes."src/analyses/README.md"]
 type = "file"
@@ -338,11 +338,11 @@ hash = "b3:3d4d575126d8a2c3044ea98213af2f284ec32169c5ede5d6a36dc7689eac2296"
 
 [nodes."src/cli.rs"]
 type = "file"
-hash = "b3:b9be430d7db557a72ce65e845af0ce4b334a9cd48d1a07bf8fb49ea218c7e841"
+hash = "b3:878f2048460978e93ef4602de13b02659d86972c34e3f69e66ba95bf48325bad"
 
 [nodes."src/config.rs"]
 type = "file"
-hash = "b3:fb3511f523a022a5b57714ef59f328426b1e41d468e59d30e8710c1719fed99a"
+hash = "b3:3f4ed84deaf282bb49859af57b969b80add9c5d59ff3065b91de842ad011a262"
 
 [nodes."src/diagnostic.rs"]
 type = "file"
@@ -366,7 +366,7 @@ hash = "b3:63c60b10aa1f9c726e960fe4f0e00e000518b730fc8079b397286e6f6e44356e"
 
 [nodes."src/main.rs"]
 type = "file"
-hash = "b3:5b95d6be378afab172dab3b3f35ccd709d095a836a7d75b539b038de5d5452be"
+hash = "b3:eb9f676b6d921ddb3f88e3d2d9ce17445198105d4c288ab81398ffbd7a2d46ca"
 
 [nodes."src/metrics.rs"]
 type = "file"
@@ -458,7 +458,7 @@ hash = "b3:cccfc752cf240f1b805e6b92700439b7616474377287ffda9d3256613cb91ca5"
 
 [nodes."tests/README.md"]
 type = "file"
-hash = "b3:052df3b0788ba7e2059318d0b6c4b0a96abc13f378aec3c7bbf9f66e10f6c6f0"
+hash = "b3:a381f87142eac25629c35467438d70f10c1ddcaee4ca089562a67ac0a2aefab3"
 
 [nodes."tests/check.rs"]
 type = "file"
@@ -467,6 +467,10 @@ hash = "b3:dbba3ed581064f584508b143446e32dc2e2fbb502e14fcfdd3ac274a84e27711"
 [nodes."tests/common/mod.rs"]
 type = "file"
 hash = "b3:2d229609bd5598d5ca83de9d55a84fbcd29e54cb545ef562295ff9c483e5cd2e"
+
+[nodes."tests/config.rs"]
+type = "file"
+hash = "b3:d1ddb31a2536df4e4d475ca60f57213003b444d70d869f6bd8f958869c010d78"
 
 [nodes."tests/custom_rules.rs"]
 type = "file"

--- a/src/README.md
+++ b/src/README.md
@@ -4,7 +4,7 @@ Core modules for the drft CLI.
 
 ## Entry points
 
-- [main.rs](main.rs) — command dispatch, `run_parse`, `run_graph`, `run_check`, `run_report`, `run_lock`, etc.
+- [main.rs](main.rs) — command dispatch, `run_parse`, `run_graph`, `run_check`, `run_report`, `run_lock`, `run_config_show`, etc.
 - [cli.rs](cli.rs) — clap-derived CLI definition and argument parsing
 - [lib.rs](lib.rs) — library crate root, re-exports public modules
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -78,6 +78,12 @@ pub enum Commands {
         names: Vec<String>,
     },
 
+    /// Show resolved configuration
+    Config {
+        #[command(subcommand)]
+        action: ConfigAction,
+    },
+
     /// Check structure for rule violations
     Check {
         /// Run only specific rules (can be repeated)
@@ -95,6 +101,20 @@ pub enum Commands {
         /// Watch for changes and re-check
         #[arg(long, short = 'w')]
         watch: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum ConfigAction {
+    /// Print the resolved configuration (defaults filled in)
+    Show {
+        /// Show config for each graph in the tree
+        #[arg(long, short = 'r')]
+        recursive: bool,
+
+        /// Max graph nesting depth for --recursive
+        #[arg(long, requires = "recursive")]
+        max_depth: Option<usize>,
     },
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use globset::{Glob, GlobSet, GlobSetBuilder};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -30,13 +30,17 @@ pub enum RuleSeverity {
 /// Supports shorthand (`markdown = true`) and expanded table form
 /// (`[parsers.markdown]` with fields). Parser-specific options go
 /// under `[parsers.<name>.options]` and are passed through to the parser.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ParserConfig {
     /// Which File nodes to send to this parser. None = all File nodes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub files: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u64>,
     /// Arbitrary options passed through to the parser (not interpreted by drft).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<toml::Value>,
 }
 
@@ -136,7 +140,7 @@ impl From<RawParserValue> for Option<ParserConfig> {
 
 // ── Interface config ───────────────────────────────────────────
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InterfaceConfig {
     pub files: Vec<String>,
     #[serde(default)]
@@ -159,6 +163,44 @@ pub struct RuleConfig {
     pub options: Option<toml::Value>,
     pub(crate) files_compiled: Option<GlobSet>,
     pub(crate) ignore_compiled: Option<GlobSet>,
+}
+
+impl Serialize for RuleConfig {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        // Count how many fields to serialize (skip empty/default fields for cleaner output)
+        let mut len = 1; // severity always present
+        if !self.files.is_empty() {
+            len += 1;
+        }
+        if !self.ignore.is_empty() {
+            len += 1;
+        }
+        if self.command.is_some() {
+            len += 1;
+        }
+        if self.options.is_some() {
+            len += 1;
+        }
+        let mut map = serializer.serialize_map(Some(len))?;
+        map.serialize_entry("severity", &self.severity)?;
+        if !self.files.is_empty() {
+            map.serialize_entry("files", &self.files)?;
+        }
+        if !self.ignore.is_empty() {
+            map.serialize_entry("ignore", &self.ignore)?;
+        }
+        if let Some(ref command) = self.command {
+            map.serialize_entry("command", command)?;
+        }
+        if let Some(ref options) = self.options {
+            map.serialize_entry("options", options)?;
+        }
+        map.end()
+    }
 }
 
 impl RuleConfig {
@@ -223,18 +265,21 @@ fn default_warn() -> RuleSeverity {
 
 // ── Config ─────────────────────────────────────────────────────
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Config {
     /// Glob patterns declaring which filesystem paths become File nodes.
     /// Default: `["*.md"]`.
     pub include: Vec<String>,
     /// Glob patterns removed from the graph (applied after `include`).
     /// Also respects `.gitignore`.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub exclude: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub interface: Option<InterfaceConfig>,
     pub parsers: HashMap<String, ParserConfig>,
     pub rules: HashMap<String, RuleConfig>,
     /// Directory containing the drft.toml this config was loaded from.
+    #[serde(skip)]
     pub config_dir: Option<std::path::PathBuf>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use std::path::{Path, PathBuf};
 
-use cli::{Cli, ColorChoice, Commands, OutputFormat};
+use cli::{Cli, ColorChoice, Commands, ConfigAction, OutputFormat};
 use config::{Config, RuleSeverity};
 use diagnostic::Diagnostic;
 use graph::build_graph;
@@ -67,6 +67,12 @@ fn try_main() -> Result<i32> {
 
     match &cli.command {
         Commands::Init => run_init(&root),
+        Commands::Config { action } => match action {
+            ConfigAction::Show {
+                recursive,
+                max_depth,
+            } => run_config_show(&root, cli.format, *recursive, *max_depth),
+        },
         Commands::Lock {
             check,
             recursive,
@@ -141,6 +147,110 @@ include = ["*.md"]
         .with_context(|| format!("failed to write {}", config_path.display()))?;
 
     Ok(0)
+}
+
+fn run_config_show(
+    root: &Path,
+    format: OutputFormat,
+    recursive: bool,
+    max_depth: Option<usize>,
+) -> Result<i32> {
+    if recursive {
+        match format {
+            OutputFormat::Json => {
+                let mut entries = Vec::new();
+                collect_configs_recursive(root, ".", max_depth, &mut entries)?;
+                println!("{}", serde_json::to_string_pretty(&entries)?);
+            }
+            OutputFormat::Text => {
+                print_configs_recursive(root, ".", max_depth, true)?;
+            }
+        }
+    } else {
+        let config = Config::load(root)?;
+        match format {
+            OutputFormat::Json => {
+                println!("{}", serde_json::to_string_pretty(&config)?);
+            }
+            OutputFormat::Text => {
+                let toml_str = toml::to_string_pretty(&config)
+                    .context("failed to serialize config as TOML")?;
+                print!("{}", toml_str);
+            }
+        }
+    }
+    Ok(0)
+}
+
+fn normalize_label(root: &Path, child_dir: &Path) -> String {
+    child_dir
+        .strip_prefix(root)
+        .unwrap_or(child_dir)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn collect_configs_recursive(
+    root: &Path,
+    label: &str,
+    max_depth: Option<usize>,
+    entries: &mut Vec<serde_json::Value>,
+) -> Result<()> {
+    let config = Config::load(root)?;
+    let mut value = serde_json::to_value(&config)?;
+    if let serde_json::Value::Object(ref mut map) = value {
+        map.insert("path".to_string(), serde_json::json!(label));
+    }
+    entries.push(value);
+
+    if max_depth == Some(0) {
+        return Ok(());
+    }
+
+    let next_depth = max_depth.map(|d| d.saturating_sub(1));
+    let child_graphs = find_lockable_graphs(root)?;
+    for child_dir in &child_graphs {
+        let relative = normalize_label(root, child_dir);
+        let child_label = if label == "." {
+            relative
+        } else {
+            format!("{label}/{relative}")
+        };
+        collect_configs_recursive(child_dir, &child_label, next_depth, entries)?;
+    }
+    Ok(())
+}
+
+fn print_configs_recursive(
+    root: &Path,
+    label: &str,
+    max_depth: Option<usize>,
+    first: bool,
+) -> Result<()> {
+    let config = Config::load(root)?;
+    if !first {
+        println!();
+    }
+    println!("# {}", label);
+    let toml_str = toml::to_string_pretty(&config).context("failed to serialize config as TOML")?;
+    print!("{}", toml_str);
+
+    if max_depth == Some(0) {
+        return Ok(());
+    }
+
+    let next_depth = max_depth.map(|d| d.saturating_sub(1));
+    let child_graphs = find_lockable_graphs(root)?;
+    for child_dir in &child_graphs {
+        let relative = normalize_label(root, child_dir);
+        let child_label = if label == "." {
+            relative
+        } else {
+            format!("{label}/{relative}")
+        };
+        print_configs_recursive(child_dir, &child_label, next_depth, false)?;
+    }
+    Ok(())
 }
 
 fn run_lock(

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,6 +5,7 @@ Integration tests for drft CLI commands. Each file exercises one command or feat
 ## Commands
 
 - [check.rs](check.rs) — `drft check`: broken links, cycles, directory edges, orphans, rule filtering
+- [config.rs](config.rs) — `drft config show`: defaults, custom config, JSON, recursive
 - [graph.rs](graph.rs) — `drft graph`: JGF output, recursive multi-graph
 - [impact.rs](impact.rs) — `drft impact`: transitive dependents
 - [init.rs](init.rs) — `drft init`: config scaffolding

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,0 +1,180 @@
+mod common;
+use common::drft_bin;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn config_show_defaults() {
+    let dir = TempDir::new().unwrap();
+    // No drft.toml — should show defaults
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "config", "show"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "expected exit code 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Defaults include *.md
+    assert!(
+        stdout.contains("*.md"),
+        "expected default include '*.md' in output: {stdout}"
+    );
+    // Default parser is markdown
+    assert!(
+        stdout.contains("[parsers.markdown]"),
+        "expected markdown parser section: {stdout}"
+    );
+    // Default rules should be present
+    assert!(
+        stdout.contains("dangling-edge"),
+        "expected dangling-edge rule: {stdout}"
+    );
+}
+
+#[test]
+fn config_show_with_config() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("drft.toml"),
+        r#"
+include = ["*.md", "*.yaml"]
+exclude = ["drafts/*"]
+
+[parsers.markdown]
+
+[rules]
+stale = "error"
+orphan-node = "off"
+"#,
+    )
+    .unwrap();
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "config", "show"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "expected exit code 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("*.yaml"),
+        "expected *.yaml in include: {stdout}"
+    );
+    assert!(
+        stdout.contains("drafts/*"),
+        "expected drafts/* in exclude: {stdout}"
+    );
+}
+
+#[test]
+fn config_show_json_format() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("drft.toml"),
+        r#"
+include = ["*.md"]
+
+[rules]
+stale = "error"
+"#,
+    )
+    .unwrap();
+
+    let output = drft_bin()
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "config",
+            "show",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "expected exit code 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("expected valid JSON: {e}\n{stdout}"));
+    assert_eq!(parsed["include"][0], "*.md");
+    assert_eq!(parsed["rules"]["stale"]["severity"], "error");
+    // Should not have a path field when not recursive
+    assert!(
+        parsed.get("path").is_none(),
+        "non-recursive should not have path"
+    );
+}
+
+#[test]
+fn config_show_recursive() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("drft.toml"),
+        "include = [\"*.md\"]\n[rules]\nstale = \"error\"\n",
+    )
+    .unwrap();
+
+    // Create a child graph
+    let child = dir.path().join("sub");
+    fs::create_dir(&child).unwrap();
+    fs::write(
+        child.join("drft.toml"),
+        "[rules]\ndangling-edge = \"error\"\n",
+    )
+    .unwrap();
+
+    let output = drft_bin()
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "config",
+            "show",
+            "--recursive",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "expected exit code 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Should contain labels for both graphs
+    assert!(
+        stdout.contains("# ."),
+        "expected root label '# .': {stdout}"
+    );
+    assert!(
+        stdout.contains("# sub"),
+        "expected child label '# sub': {stdout}"
+    );
+}
+
+#[test]
+fn config_show_recursive_json() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), "include = [\"*.md\"]\n").unwrap();
+
+    let child = dir.path().join("child");
+    fs::create_dir(&child).unwrap();
+    fs::write(child.join("drft.toml"), "[rules]\nstale = \"error\"\n").unwrap();
+
+    let output = drft_bin()
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "config",
+            "show",
+            "--recursive",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "expected exit code 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Recursive JSON emits a single array of config objects
+    let parsed: Vec<serde_json::Value> =
+        serde_json::from_str(&stdout).expect("expected valid JSON array");
+    assert_eq!(parsed.len(), 2, "expected 2 graphs in array");
+    assert_eq!(parsed[0]["path"], ".", "expected root path");
+    assert_eq!(parsed[1]["path"], "child", "expected child path");
+}


### PR DESCRIPTION
## Summary

Closes #30.

- `drft config show` — prints the resolved config (defaults filled in) as TOML
- `drft config show --format json` — JSON output
- `drft config show --recursive` — shows config for each graph in the tree, labeled by path
- `--max-depth` supported for recursive mode

Adds `Serialize` to `Config`, `ParserConfig`, `InterfaceConfig`, and `RuleConfig` (manual impl to skip compiled `GlobSet` fields).

## Test plan

- [ ] `cargo test` — 5 new integration tests in `tests/config.rs`
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `drft check` on repo itself (expected orphan warning for new test file)