### PR TITLE
Release v0.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,4 @@ jobs:
       - run: cargo test
       - run: cargo run -- check
       - run: cargo run -- lock --check
+      - run: cargo bench --no-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to drft are documented here.
 
+## 0.5.1 (2026-04-01)
+
+Post-v0.5 audit — simplify graph, enforce frontmatter, remove noisy rules.
+
+### Breaking changes
+
+- **Removed rules**: `fragility`, `layer-violation`, and `redundant-edge` flagged properties inherent to tree-shaped filesystems. The underlying analyses remain in `drft report`.
+- **`orphan-node` semantics changed** — flags isolated nodes (in-degree 0 AND out-degree 0), not roots. Files with outbound links but no inbound links are entry points, not orphans.
+
+### Changes
+
+- **Frontmatter as dependency layer** — doc files use `sources:` YAML frontmatter instead of prose `## Source` sections. `schema-violation` enforces `required = ["sources"]` on `docs/**`.
+- **Removed artificial READMEs** — directory index files in `src/`, `tests/`, `benches/`, and `docs/` subdirectories that existed only to satisfy drft rules. Graph went from 103 nodes / 181 edges to 80 / 118.
+- **Simplified `drft.toml`** — removed all ignore rules (now zero), deduplicated config.
+- **Rewrote README** — leads with the mental model (links create obligations, lockfile is a checkpoint, graphs nest like directories).
+- **Added `docs/config.md`** — configuration reference with examples.
+- **CI: `cargo bench --no-run`** — catches benchmark compilation failures.
+
 ## 0.5.0 (2026-03-31)
 
 drft.toml as the sole graph marker — simpler mental model, no ordering constraints.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "drft-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drft-cli"
-version = "0.5.0"
+version = "0.5.1"
 categories = ["command-line-utilities", "development-tools"]
 edition = "2024"
 homepage = "https://github.com/johnmdonahue/drft-cli"


### PR DESCRIPTION
## Summary

Post-v0.5 audit release.

- Remove 3 rules (fragility, layer-violation, redundant-edge) that don't fit filesystem-based graphs
- Change orphan-node to flag isolated nodes, not roots
- Enforce `sources:` frontmatter on doc files via schema-violation
- Remove artificial READMEs, simplify drft.toml to zero ignore rules
- Rewrite README to lead with the mental model
- Add `docs/config.md` configuration reference
- Add `cargo bench --no-run` to CI

## Test plan

- [ ] CI passes (fmt, clippy, test, drft check, lock --check, bench --no-run)