### PR TITLE
Release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to drft are documented here.
 
+## 0.6.1 (2026-04-08)
+
+Edge detection hardening — proper URI validation and frontmatter parsing, full JGF export.
+
+### Fixes
+
+- **False positive URI detection** — `is_uri` replaced hand-rolled RFC 3986 scheme check with the `url` crate (WHATWG URL Standard). YAML values like `name: foo bar` no longer match as URIs.
+- **Frontmatter link extraction** — replaced line-by-line string splitting with `serde_yml` tree walking. YAML mapping keys within lists (e.g., `- name: foo bar`) are correctly ignored — only values are examined.
+- **Extension heuristic cap** — bumped from 4 to 6 characters, covering `.swift`, `.proto`, `.patch`, `.class`, and similar.
+
+### New features
+
+- **Full JGF export** — `drft graph --format json` now includes all internal graph data: node `graph` membership, `is_graph` flag, parser metadata (e.g., frontmatter YAML payload), and graph-level `interface` and `target_properties` in `graph.metadata`.
+
 ## 0.6.0 (2026-04-08)
 
 Node/edge model refinement — scope as a first-class concept, JGF compliance, directory traversal prevention.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,8 +311,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "drft-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -329,6 +340,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
+ "url",
 ]
 
 [[package]]
@@ -381,6 +393,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fsevent-sys"
@@ -465,10 +486,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "ignore"
@@ -630,6 +754,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +851,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +888,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -979,6 +1124,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,6 +1150,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1026,6 +1194,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1102,6 +1280,24 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1433,6 +1629,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,6 +1671,60 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drft-cli"
-version = "0.6.0"
+version = "0.6.1"
 categories = ["command-line-utilities", "development-tools"]
 edition = "2024"
 homepage = "https://github.com/johnmdonahue/drft-cli"
@@ -32,6 +32,7 @@ serde_json = "1"
 serde_yml = "0.0.12"
 thiserror = "2"
 toml = "0.8"
+url = "2.5.8"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -56,7 +56,7 @@ Only two things are dropped: empty targets and anchor-only targets (no file to r
 
 ### 2. Detect URIs
 
-`is_uri()` checks if a target has a URI scheme per [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986): `[a-zA-Z][a-zA-Z0-9+.-]*:`. Any valid scheme is recognized without maintaining an explicit list.
+`is_uri()` uses the [`url`](https://docs.rs/url) crate (WHATWG URL Standard) to parse the target, then accepts it as a URI if it has authority (`://`) or uses a known opaque scheme (`mailto`, `tel`, `data`, `urn`, `javascript`).
 
 URI targets skip path resolution (they're not relative file paths) and become External nodes.
 
@@ -142,11 +142,36 @@ The JSON graph output follows the [JGF v2.0](https://jsongraphformat.info/) sche
 }
 ```
 
-Node metadata includes `type`, `hash`, and `included`:
+Node metadata includes `type`, `hash`, `graph`, `is_graph`, `included`, and any parser-extracted metadata keyed by parser name:
 
 ```json
 {
-  "metadata": { "type": "file", "hash": "b3:...", "included": true }
+  "metadata": {
+    "type": "file",
+    "hash": "b3:...",
+    "graph": ".",
+    "included": true,
+    "frontmatter": { "title": "Setup", "sources": ["../shared/glossary.md"] }
+  }
+}
+```
+
+Graph-level metadata includes `interface` (when configured) and `target_properties` (filesystem properties of edge targets):
+
+```json
+{
+  "graph": {
+    "id": ".",
+    "directed": true,
+    "metadata": {
+      "interface": ["README.md"],
+      "target_properties": {
+        "setup.md": { "is_symlink": false, "is_directory": false }
+      }
+    },
+    "nodes": {},
+    "edges": []
+  }
 }
 ```
 
@@ -154,7 +179,7 @@ Node metadata includes `type`, `hash`, and `included`:
 
 | Function                        | Purpose                                                   |
 | ------------------------------- | --------------------------------------------------------- |
-| `is_uri(target)`                | Check if target is a URI (RFC 3986 scheme detection)      |
+| `is_uri(target)`                | Check if target is a URI (WHATWG URL parsing + scheme filter) |
 | `graph.target_props(target)`    | Get filesystem properties for a target                    |
 | `graph.is_file_node(path)`      | Check if a path is a File node (capability check)         |
 | `graph.is_included_node(path)`  | Check if a node was matched by `include` (scope check)    |

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -177,13 +177,13 @@ Graph-level metadata includes `interface` (when configured) and `target_properti
 
 ## Utilities
 
-| Function                        | Purpose                                                   |
-| ------------------------------- | --------------------------------------------------------- |
+| Function                        | Purpose                                                       |
+| ------------------------------- | ------------------------------------------------------------- |
 | `is_uri(target)`                | Check if target is a URI (WHATWG URL parsing + scheme filter) |
-| `graph.target_props(target)`    | Get filesystem properties for a target                    |
-| `graph.is_file_node(path)`      | Check if a path is a File node (capability check)         |
-| `graph.is_included_node(path)`  | Check if a node was matched by `include` (scope check)    |
-| `graph.is_internal_edge(&edge)` | Check if both endpoints are included (derived from nodes) |
+| `graph.target_props(target)`    | Get filesystem properties for a target                        |
+| `graph.is_file_node(path)`      | Check if a path is a File node (capability check)             |
+| `graph.is_included_node(path)`  | Check if a node was matched by `include` (scope check)        |
+| `graph.is_internal_edge(&edge)` | Check if both endpoints are included (derived from nodes)     |
 
 ## Lockfile
 

--- a/docs/parsers/frontmatter.md
+++ b/docs/parsers/frontmatter.md
@@ -27,9 +27,9 @@ template: docs/templates/page.md
 ---
 ```
 
-The parser uses a heuristic to distinguish file paths from plain string values: a value is treated as a path if it has a file extension (contains a `.` in the last path component). Numeric values (e.g., `1.0`), values that start with `{`, `[`, `"`, or `'`, and URIs are skipped.
+The parser uses `serde_yml` to parse the YAML structure, then collects all string leaf values and filters them through a heuristic: a value is treated as a link if it has an explicit path prefix (`./`, `../`, `/`), is a valid URI, or has a plausible file extension (1-6 alphanumeric characters after the last dot, not all digits). Non-string types (numbers, booleans, null) are skipped by the YAML parser. Strings with spaces are rejected as prose.
 
-This means `sources: setup.md` and `sources: ../shared/glossary.md` are detected, but `title: My Document` and `version: 1.0` are not.
+This means `sources: setup.md` and `sources: ../shared/glossary.md` are detected, but `title: My Document` and `version: 1.0` are not. YAML mapping keys within lists (e.g., `- name: foo bar`) are correctly ignored — only values are examined.
 
 ## Metadata
 

--- a/drft.lock
+++ b/drft.lock
@@ -82,7 +82,7 @@ hash = "b3:8cad0b7321ef2a411b436f91e8cd572ca315597d6dfc6bdd7e46d90a4f20a3fc"
 
 [nodes."docs/graph.md"]
 type = "file"
-hash = "b3:878fbcbea68a8543f971e0b185425636414320c56dd799ecaf3a44e9a43de1fc"
+hash = "b3:805e062a9f7732c2bdd0f3fed3bd27b17c33946c98a030eb3847ddc578b97014"
 
 [nodes."docs/parsers/README.md"]
 type = "file"

--- a/drft.lock
+++ b/drft.lock
@@ -310,7 +310,7 @@ hash = "b3:8a0a213d2c8f0667c6f3a3002ab95744e988526d2324cbed8511722d51a5f9cd"
 
 [nodes."src/graph.rs"]
 type = "file"
-hash = "b3:246ff852a6f80bb7530036f6e5e7e05fad47938ab3747c38876ee7081f554a87"
+hash = "b3:77370abc16be1d56e566d4b0195cb4520d6c15cad39f8d53ab56de0185b218a7"
 
 [nodes."src/lockfile.rs"]
 type = "file"
@@ -318,7 +318,7 @@ hash = "b3:0fc4597b4c96efd0694bb101efece099c88f7f1eb71432dc2aa61dbe353d531a"
 
 [nodes."src/main.rs"]
 type = "file"
-hash = "b3:611e827209675573c6251b49871a30c4af6d8ba5fccc5fb7f13d877fbddada06"
+hash = "b3:b7fcd2ec3060a90f1d148008e0f70a9b04fea5181a014c62d69ce9514fb09723"
 
 [nodes."src/metrics.rs"]
 type = "file"

--- a/drft.lock
+++ b/drft.lock
@@ -310,7 +310,7 @@ hash = "b3:8a0a213d2c8f0667c6f3a3002ab95744e988526d2324cbed8511722d51a5f9cd"
 
 [nodes."src/graph.rs"]
 type = "file"
-hash = "b3:240c868bc7a0f384bb369657c5d050d4518c60cdf87a45efe114e330d2c7167f"
+hash = "b3:246ff852a6f80bb7530036f6e5e7e05fad47938ab3747c38876ee7081f554a87"
 
 [nodes."src/lockfile.rs"]
 type = "file"
@@ -318,7 +318,7 @@ hash = "b3:0fc4597b4c96efd0694bb101efece099c88f7f1eb71432dc2aa61dbe353d531a"
 
 [nodes."src/main.rs"]
 type = "file"
-hash = "b3:005712d114a6c48fcf545f80a76b1abfd7791a596071c90a1f2030494d5ed0c4"
+hash = "b3:611e827209675573c6251b49871a30c4af6d8ba5fccc5fb7f13d877fbddada06"
 
 [nodes."src/metrics.rs"]
 type = "file"
@@ -330,7 +330,7 @@ hash = "b3:edd9afac31f40c2c581d8ccc0daa79e6399c986f5b9d78e11861a9ab56405754"
 
 [nodes."src/parsers/frontmatter.rs"]
 type = "file"
-hash = "b3:ba88ca27a06e3b7e8f6b29346bd6a8801dd0860bb0d5fc3e055b3bc4b251d13a"
+hash = "b3:03b3f4775e67858fa4f10ae2872ad02612ee0bfc8ed9225207a2d796324de437"
 
 [nodes."src/parsers/markdown.rs"]
 type = "file"

--- a/drft.lock
+++ b/drft.lock
@@ -82,7 +82,7 @@ hash = "b3:8cad0b7321ef2a411b436f91e8cd572ca315597d6dfc6bdd7e46d90a4f20a3fc"
 
 [nodes."docs/graph.md"]
 type = "file"
-hash = "b3:d28e36ea22bcdf44ddc597c9299c9737f96a8f3122f0208ceda19cb5ce026e22"
+hash = "b3:878fbcbea68a8543f971e0b185425636414320c56dd799ecaf3a44e9a43de1fc"
 
 [nodes."docs/parsers/README.md"]
 type = "file"
@@ -94,7 +94,7 @@ hash = "b3:944489f9d11ef3836e15cc1256ce0a832e1426a5944b51bc8c27c2c22d0e627e"
 
 [nodes."docs/parsers/frontmatter.md"]
 type = "file"
-hash = "b3:aa8190d174272766f8cd83b9ccec5636b02fc735df8276077a9c00b37854f2f6"
+hash = "b3:d32546ad2a462e93e576b3cf1bf2345ab533b84a6f197176ad3de883fa54462d"
 
 [nodes."docs/parsers/markdown.md"]
 type = "file"
@@ -219,6 +219,9 @@ type = "file"
 hash = "b3:482518ecf2ae9eb07ddbb55f420df6ce48bd360f453f94b05575fc1ecde65671"
 graph = "examples/with-config"
 
+[nodes."https://docs.rs/url"]
+type = "external"
+
 [nodes."https://en.wikipedia.org/wiki/Betweenness_centrality"]
 type = "external"
 
@@ -235,9 +238,6 @@ type = "external"
 type = "external"
 
 [nodes."https://jsongraphformat.info/"]
-type = "external"
-
-[nodes."https://www.rfc-editor.org/rfc/rfc3986"]
 type = "external"
 
 [nodes."src/analyses/betweenness.rs"]
@@ -310,7 +310,7 @@ hash = "b3:8a0a213d2c8f0667c6f3a3002ab95744e988526d2324cbed8511722d51a5f9cd"
 
 [nodes."src/graph.rs"]
 type = "file"
-hash = "b3:5abcc3e55f7091a55c3d2d9d6f54197299fffb4980e93cc8bc6e23c4ea12f45b"
+hash = "b3:240c868bc7a0f384bb369657c5d050d4518c60cdf87a45efe114e330d2c7167f"
 
 [nodes."src/lockfile.rs"]
 type = "file"
@@ -318,7 +318,7 @@ hash = "b3:0fc4597b4c96efd0694bb101efece099c88f7f1eb71432dc2aa61dbe353d531a"
 
 [nodes."src/main.rs"]
 type = "file"
-hash = "b3:5d82555beeece6596ede7763832737b536b83fa98d86ae8023cfc56a83ce46f2"
+hash = "b3:005712d114a6c48fcf545f80a76b1abfd7791a596071c90a1f2030494d5ed0c4"
 
 [nodes."src/metrics.rs"]
 type = "file"
@@ -330,7 +330,7 @@ hash = "b3:edd9afac31f40c2c581d8ccc0daa79e6399c986f5b9d78e11861a9ab56405754"
 
 [nodes."src/parsers/frontmatter.rs"]
 type = "file"
-hash = "b3:140962a8b3d49ad695fc2b265c00e2463bcc66a010500896bba5ceb4ac4d5e17"
+hash = "b3:ba88ca27a06e3b7e8f6b29346bd6a8801dd0860bb0d5fc3e055b3bc4b251d13a"
 
 [nodes."src/parsers/markdown.rs"]
 type = "file"

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -6,22 +6,22 @@ use crate::config::Config;
 use crate::discovery::{discover, find_child_graphs};
 use crate::parsers;
 
-/// Check if a target string is a URI (has a scheme per RFC 3986).
-/// A scheme is `[a-zA-Z][a-zA-Z0-9+.-]*:` — e.g., `http:`, `mailto:`, `ftp:`, `tel:`.
+/// Check if a target string is a valid URI.
+///
+/// Uses the `url` crate (WHATWG URL Standard) for parsing, then filters to
+/// URIs that either have authority (`://`) or use a known opaque scheme.
+/// Without this filter, any `word:stuff` passes WHATWG parsing — e.g.,
+/// YAML values like `name: foo` would be treated as URIs with scheme `name`.
 pub fn is_uri(target: &str) -> bool {
-    let bytes = target.as_bytes();
-    if bytes.is_empty() || !bytes[0].is_ascii_alphabetic() {
-        return false;
-    }
-    for &b in &bytes[1..] {
-        if b == b':' {
-            return true;
+    match url::Url::parse(target) {
+        Ok(url) => {
+            if url.has_authority() {
+                return true;
+            }
+            matches!(url.scheme(), "mailto" | "tel" | "data" | "urn" | "javascript")
         }
-        if !b.is_ascii_alphanumeric() && b != b'+' && b != b'-' && b != b'.' {
-            return false;
-        }
+        Err(_) => false,
     }
-    false
 }
 
 #[derive(
@@ -70,10 +70,11 @@ pub struct Edge {
 
 /// Filesystem properties of an edge target, probed during graph building.
 /// Stored per-target on the Graph, not per-edge.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct TargetProperties {
     pub is_symlink: bool,
     pub is_directory: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symlink_target: Option<String>,
 }
 
@@ -813,7 +814,6 @@ mod tests {
         assert!(is_uri("ftp://files.example.com"));
         assert!(is_uri("tel:+1234567890"));
         assert!(is_uri("ssh://git@github.com"));
-        assert!(is_uri("custom+scheme://foo"));
     }
 
     #[test]
@@ -823,7 +823,18 @@ mod tests {
         assert!(!is_uri("../parent.md"));
         assert!(!is_uri("#heading"));
         assert!(!is_uri(""));
-        assert!(!is_uri("path/with:colon.md")); // colon after slash = not a scheme
+        assert!(!is_uri("path/with:colon.md"));
+    }
+
+    #[test]
+    fn is_uri_rejects_bare_schemes() {
+        // WHATWG parses any `word:stuff` as a valid URL, so we require
+        // authority (://) or a known opaque scheme (mailto, tel, etc.)
+        assert!(!is_uri("name: foo bar bazz"));
+        assert!(!is_uri("status: draft"));
+        assert!(!is_uri("title: My Document"));
+        assert!(!is_uri("name:foo"));
+        assert!(!is_uri("x:y"));
     }
 
     #[test]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -18,7 +18,10 @@ pub fn is_uri(target: &str) -> bool {
             if url.has_authority() {
                 return true;
             }
-            matches!(url.scheme(), "mailto" | "tel" | "data" | "urn" | "javascript")
+            matches!(
+                url.scheme(),
+                "mailto" | "tel" | "data" | "urn" | "javascript"
+            )
         }
         Err(_) => false,
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -814,6 +814,7 @@ mod tests {
         assert!(is_uri("ftp://files.example.com"));
         assert!(is_uri("tel:+1234567890"));
         assert!(is_uri("ssh://git@github.com"));
+        assert!(is_uri("custom+scheme://foo"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -717,10 +717,7 @@ fn run_graph(
                 if !g.target_properties.is_empty() {
                     let sorted: std::collections::BTreeMap<&String, &graph::TargetProperties> =
                         g.target_properties.iter().collect();
-                    graph_meta.insert(
-                        "target_properties".into(),
-                        serde_json::json!(sorted),
-                    );
+                    graph_meta.insert("target_properties".into(), serde_json::json!(sorted));
                 }
 
                 let mut graph_obj = serde_json::Map::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -676,8 +676,10 @@ fn run_graph(
                         meta.insert("is_graph".into(), serde_json::json!(true));
                     }
                     meta.insert("included".into(), serde_json::json!(n.included));
-                    for (key, value) in &n.metadata {
-                        meta.insert(key.clone(), value.clone());
+                    let mut metadata_keys: Vec<&String> = n.metadata.keys().collect();
+                    metadata_keys.sort();
+                    for key in metadata_keys {
+                        meta.insert(key.clone(), n.metadata[key].clone());
                     }
                     nodes.insert(n.path.clone(), serde_json::json!({ "metadata": meta }));
                 }
@@ -713,9 +715,11 @@ fn run_graph(
                     graph_meta.insert("interface".into(), serde_json::json!(g.interface));
                 }
                 if !g.target_properties.is_empty() {
+                    let sorted: std::collections::BTreeMap<&String, &graph::TargetProperties> =
+                        g.target_properties.iter().collect();
                     graph_meta.insert(
                         "target_properties".into(),
-                        serde_json::json!(g.target_properties),
+                        serde_json::json!(sorted),
                     );
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use drft::rules;
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use cli::{Cli, ColorChoice, Commands, ConfigAction, OutputFormat};
@@ -612,7 +613,7 @@ fn run_graph(
         let mut all_edges = Vec::new();
         for g in &graphs {
             let prefix = if g.id == "." { "" } else { g.id.as_str() };
-            for (path, _, _, _) in &g.nodes {
+            for NodeExport { path, .. } in &g.nodes {
                 let full = if prefix.is_empty() {
                     path.clone()
                 } else {
@@ -653,24 +654,32 @@ fn run_graph(
             .iter()
             .map(|g| {
                 let mut nodes = serde_json::Map::new();
-                let mut sorted: Vec<&(String, graph::NodeType, Option<String>, bool)> =
-                    g.nodes.iter().collect();
-                sorted.sort_by(|a, b| a.0.cmp(&b.0));
+                let mut sorted: Vec<&NodeExport> = g.nodes.iter().collect();
+                sorted.sort_by(|a, b| a.path.cmp(&b.path));
                 // Build a lookup for included status to compute edge.internal
                 let included: std::collections::HashSet<&str> = g
                     .nodes
                     .iter()
-                    .filter(|(_, _, _, inc)| *inc)
-                    .map(|(p, _, _, _)| p.as_str())
+                    .filter(|n| n.included)
+                    .map(|n| n.path.as_str())
                     .collect();
-                for (path, node_type, hash, inc) in &*sorted {
+                for n in &*sorted {
                     let mut meta = serde_json::Map::new();
-                    meta.insert("type".into(), serde_json::json!(node_type));
-                    if let Some(h) = hash {
+                    meta.insert("type".into(), serde_json::json!(n.node_type));
+                    if let Some(h) = &n.hash {
                         meta.insert("hash".into(), serde_json::json!(h));
                     }
-                    meta.insert("included".into(), serde_json::json!(inc));
-                    nodes.insert(path.clone(), serde_json::json!({ "metadata": meta }));
+                    if let Some(gr) = &n.graph {
+                        meta.insert("graph".into(), serde_json::json!(gr));
+                    }
+                    if n.is_graph {
+                        meta.insert("is_graph".into(), serde_json::json!(true));
+                    }
+                    meta.insert("included".into(), serde_json::json!(n.included));
+                    for (key, value) in &n.metadata {
+                        meta.insert(key.clone(), value.clone());
+                    }
+                    nodes.insert(n.path.clone(), serde_json::json!({ "metadata": meta }));
                 }
 
                 let mut edges: Vec<serde_json::Value> = g
@@ -699,12 +708,26 @@ fn run_graph(
                         .then_with(|| a["target"].as_str().cmp(&b["target"].as_str()))
                 });
 
-                serde_json::json!({
-                    "id": g.id,
-                    "directed": true,
-                    "nodes": nodes,
-                    "edges": edges,
-                })
+                let mut graph_meta = serde_json::Map::new();
+                if !g.interface.is_empty() {
+                    graph_meta.insert("interface".into(), serde_json::json!(g.interface));
+                }
+                if !g.target_properties.is_empty() {
+                    graph_meta.insert(
+                        "target_properties".into(),
+                        serde_json::json!(g.target_properties),
+                    );
+                }
+
+                let mut graph_obj = serde_json::Map::new();
+                graph_obj.insert("id".into(), serde_json::json!(g.id));
+                graph_obj.insert("directed".into(), serde_json::json!(true));
+                if !graph_meta.is_empty() {
+                    graph_obj.insert("metadata".into(), serde_json::Value::Object(graph_meta));
+                }
+                graph_obj.insert("nodes".into(), serde_json::json!(nodes));
+                graph_obj.insert("edges".into(), serde_json::json!(edges));
+                serde_json::Value::Object(graph_obj)
             })
             .collect();
 
@@ -719,10 +742,22 @@ fn run_graph(
     Ok(0)
 }
 
+struct NodeExport {
+    path: String,
+    node_type: graph::NodeType,
+    hash: Option<String>,
+    graph: Option<String>,
+    is_graph: bool,
+    included: bool,
+    metadata: HashMap<String, serde_json::Value>,
+}
+
 struct GraphExport {
     id: String,
-    nodes: Vec<(String, graph::NodeType, Option<String>, bool)>, // path, type, hash, included
+    nodes: Vec<NodeExport>,
     edges: Vec<(String, String, Option<String>, String)>, // source, target (node ID), reference, parser
+    interface: Vec<String>,
+    target_properties: HashMap<String, graph::TargetProperties>,
 }
 
 /// Collect JGF graph(s) from a graph root and optionally its children.
@@ -749,16 +784,17 @@ fn collect_jgf_graphs(
         g
     };
 
-    let nodes: Vec<(String, graph::NodeType, Option<String>, bool)> = g
+    let nodes: Vec<NodeExport> = g
         .nodes
         .iter()
-        .map(|(path, node)| {
-            (
-                path.clone(),
-                node.node_type,
-                node.hash.clone(),
-                node.included,
-            )
+        .map(|(path, node)| NodeExport {
+            path: path.clone(),
+            node_type: node.node_type,
+            hash: node.hash.clone(),
+            graph: node.graph.clone(),
+            is_graph: node.is_graph,
+            included: node.included,
+            metadata: node.metadata.clone(),
         })
         .collect();
 
@@ -776,10 +812,15 @@ fn collect_jgf_graphs(
         })
         .collect();
 
+    let interface = g.interface.clone();
+    let target_properties = g.target_properties.clone();
+
     let mut graphs = vec![GraphExport {
         id: id.to_string(),
         nodes,
         edges,
+        interface,
+        target_properties,
     }];
 
     if recursive && max_depth != Some(0) {

--- a/src/parsers/frontmatter.rs
+++ b/src/parsers/frontmatter.rs
@@ -152,7 +152,10 @@ fn extract_frontmatter_links(content: &str) -> Vec<String> {
 
     let yaml: serde_yml::Value = match serde_yml::from_str(yaml_str) {
         Ok(v) => v,
-        Err(_) => return Vec::new(),
+        Err(e) => {
+            eprintln!("warn: frontmatter parser: invalid YAML: {e}");
+            return Vec::new();
+        }
     };
 
     let mut links = Vec::new();

--- a/src/parsers/frontmatter.rs
+++ b/src/parsers/frontmatter.rs
@@ -15,13 +15,13 @@ fn is_link_candidate(value: &str) -> bool {
     if value.contains(' ') {
         return false;
     }
-    // Must have a plausible file extension: dot followed by 1-4 alphanumeric
+    // Must have a plausible file extension: dot followed by 1-6 alphanumeric
     // chars that aren't all digits (rejects v2.0, e.g., Dr.)
     let basename = value.rsplit('/').next().unwrap_or(value);
     if let Some(dot_pos) = basename.rfind('.') {
         let ext = &basename[dot_pos + 1..];
         !ext.is_empty()
-            && ext.len() <= 4
+            && ext.len() <= 6
             && ext.chars().all(|c| c.is_ascii_alphanumeric())
             && !ext.chars().all(|c| c.is_ascii_digit())
     } else {
@@ -134,56 +134,51 @@ impl Parser for FrontmatterParser {
 /// inside fenced code block examples.
 fn extract_frontmatter_links(content: &str) -> Vec<String> {
     let content = &strip_code(content);
-    let mut links = Vec::new();
 
     if !content.starts_with("---") {
-        return links;
+        return Vec::new();
     }
 
     let rest = &content[3..];
     let end = match rest.find("\n---") {
         Some(idx) => idx,
-        None => return links,
+        None => return Vec::new(),
     };
 
-    let frontmatter = &rest[..end];
-
-    for line in frontmatter.lines() {
-        let line = line.trim();
-
-        let value = if let Some(stripped) = line.strip_prefix("- ") {
-            stripped.trim()
-        } else if let Some((_key, val)) = line.split_once(':') {
-            val.trim()
-        } else {
-            continue;
-        };
-
-        if value.is_empty() {
-            continue;
-        }
-
-        if value.starts_with('{')
-            || value.starts_with('[')
-            || value.starts_with('"')
-            || value.starts_with('\'')
-        {
-            continue;
-        }
-
-        // Skip numeric values (e.g., "1.0") — not file paths
-        if value.parse::<f64>().is_ok() {
-            continue;
-        }
-
-        if !is_link_candidate(value) {
-            continue;
-        }
-
-        links.push(value.to_string());
+    let yaml_str = &rest[..end];
+    if yaml_str.trim().is_empty() {
+        return Vec::new();
     }
 
+    let yaml: serde_yml::Value = match serde_yml::from_str(yaml_str) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut links = Vec::new();
+    collect_string_leaves(&yaml, &mut links);
+    links.retain(|v| is_link_candidate(v));
     links
+}
+
+/// Recursively collect all string leaf values from a YAML structure.
+/// Skips keys (only visits values) and non-string types (numbers, bools, null).
+fn collect_string_leaves(value: &serde_yml::Value, out: &mut Vec<String>) {
+    match value {
+        serde_yml::Value::String(s) => out.push(s.clone()),
+        serde_yml::Value::Sequence(seq) => {
+            for item in seq {
+                collect_string_leaves(item, out);
+            }
+        }
+        serde_yml::Value::Mapping(map) => {
+            for (_key, val) in map {
+                collect_string_leaves(val, out);
+            }
+        }
+        serde_yml::Value::Tagged(tagged) => collect_string_leaves(&tagged.value, out),
+        _ => {}
+    }
 }
 
 /// Parse YAML frontmatter into a JSON value for node metadata.
@@ -383,5 +378,14 @@ mod tests {
         let result = parse(content);
         assert_eq!(result.links.len(), 1);
         assert_eq!(result.links[0], "/usr/local/config.toml");
+    }
+
+    #[test]
+    fn yaml_list_values_not_parsed_as_uris() {
+        // Regression: `- name: foo bar bazz` was split on `- ` to get
+        // `name: foo bar bazz`, which the old is_uri matched as scheme `name:`
+        let content = "---\ntags:\n  - name: foo bar bazz\n  - status: draft\n---\n";
+        let result = parse(content);
+        assert!(result.links.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- **Fix false positive URI detection** — `is_uri` replaced hand-rolled RFC 3986 scheme check with the `url` crate (WHATWG URL Standard). YAML values like `name: foo bar` no longer match as URIs with scheme `name:`.
- **Fix frontmatter link extraction** — replaced line-by-line string splitting with `serde_yml` tree walking. YAML mapping keys within lists (e.g., `- name: foo bar`) are correctly ignored — only values are examined.
- **Full JGF export** — `drft graph --format json` now includes all internal graph data: node `graph`/`is_graph`, parser metadata (frontmatter YAML payload), and graph-level `interface`/`target_properties`.
- **Extension heuristic cap** — bumped from 4 to 6 characters, covering `.swift`, `.proto`, `.patch`, `.class`.

## Test plan
- [x] All 246 tests pass (190 unit + 56 integration)
- [x] Regression tests for YAML key-value false positives in `is_uri` and frontmatter parser
- [x] Clippy clean
- [x] `drft check` clean after lock
- [x] Verified JGF output includes new fields