### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to drft are documented here.
 
+## 0.8.0 (2026-06-04)
+
+Rebuilt on a set-of-graphs substrate with an explicit composition step. drft now models a directory as a set of independent JGF graphs of bare-path nodes — `fs` (a node per file, typed and hashed), `markdown` (link edges), and `frontmatter` (edges plus metadata) — that a `compose` step merges by path. The `impact → edit → check → lock` loop is unchanged.
+
+### Breaking changes
+
+- **Config schema reshaped.** `drft.toml` is now `ignore` + `[graphs.*]` (source, filter, builder) + `[rules.*]` (severity, ignore). `include`, `exclude`, and `[parsers.*]` are removed. Each config declares exactly one graph root.
+- **Lockfile format changed.** `drft.lock` is path-keyed with a node hash and nested per-edge target hashes, no version field. Old lockfiles report as unparseable and point at `drft lock` to regenerate.
+- **Command surface rebuilt.** The surface is `init`, `graph` (composed by default, `--raw` for the graph set, `--depth`/`--direction` on impact), `impact`, `check`, and `lock` (bulk and scoped). The `parse`, `report`, and `config` commands are removed.
+- **Rule set is drift-focused.** Rules are `stale-node`, `stale-edge`, `new-edge`, `removed-edge`, `removed-node`, `unresolved-edge`, and `detached-node`. The structural-hygiene rules (`directed-cycle`, `fragmentation`, `schema-violation`, `symlink-edge`) are removed; cycles are now permitted.
+- **No migration path.** Pre-v1, this is a clean break — old `drft.toml`/`drft.lock` formats are not migrated.
+
+### New
+
+- **Set-of-graphs substrate** — `fs` is the base graph that walks every file, types it (`file`/`symlink`), and is the only graph drft auto-hashes. `markdown` and `frontmatter` add edges and metadata over the same paths.
+- **Composition by path** — `compose` merges the graph set: each graph's facts nest under `@<graph>` with a `_graphs` provenance list. Resolution is namespace presence — a path with no `@fs` block is unresolved.
+- **`drft graph --raw`** — emit the uncomposed graph set as JGF `{"graphs": [...]}` alongside the composed default.
+- **`drft init`** — scaffold a `drft.toml` for a new graph root.
+
+### Removed
+
+- The analyses and metrics subsystem, custom subprocess parsers and rules, the criterion benchmark harness, and the v0.7 docs and examples for those features.
+
 ## 0.7.0 (2026-04-12)
 
 Included vs referenced nodes — every edge target is a node. `include` controls what drft reads and hashes, not what exists in the graph.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ Rebuilt on a set-of-graphs substrate with an explicit composition step. drft now
 
 ### Breaking changes
 
-- **Config schema reshaped.** `drft.toml` is now `ignore` + `[graphs.*]` (source, filter, builder) + `[rules.*]` (severity, ignore). `include`, `exclude`, and `[parsers.*]` are removed. Each config declares exactly one graph root.
+- **Config schema reshaped.** `drft.toml` is now `ignore` + `[graphs.*]` (each with a `parser` and `files` globs) + `[rules.*]` (severity, ignore). `include`, `exclude`, and `[parsers.*]` are removed. The graph root is the directory containing `drft.toml`.
 - **Lockfile format changed.** `drft.lock` is path-keyed with a node hash and nested per-edge target hashes, no version field. Old lockfiles report as unparseable and point at `drft lock` to regenerate.
-- **Command surface rebuilt.** The surface is `init`, `graph` (composed by default, `--raw` for the graph set, `--depth`/`--direction` on impact), `impact`, `check`, and `lock` (bulk and scoped). The `parse`, `report`, and `config` commands are removed.
+- **Command surface rebuilt.** The surface is `init`, `graph` (composed by default, `--raw` for the raw graph set), `impact` (with `--depth` and `--direction`), `check`, and `lock` (bulk and scoped). The `parse`, `report`, and `config` commands are removed.
 - **Rule set is drift-focused.** Rules are `stale-node`, `stale-edge`, `new-edge`, `removed-edge`, `removed-node`, `unresolved-edge`, and `detached-node`. The structural-hygiene rules (`directed-cycle`, `fragmentation`, `schema-violation`, `symlink-edge`) are removed; cycles are now permitted.
 - **No migration path.** Pre-v1, this is a clean break — old `drft.toml`/`drft.lock` formats are not migrated.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "drft-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drft-cli"
-version = "0.7.0"
+version = "0.8.0"
 categories = ["command-line-utilities", "development-tools"]
 edition = "2024"
 homepage = "https://github.com/johnmdonahue/drft-cli"

--- a/drft.lock
+++ b/drft.lock
@@ -2,7 +2,7 @@
 
 [[node]]
 path = "CHANGELOG.md"
-hash = "b3:14c357d77b018dd20285b6aedc1ced17bfe3a146709400a6975359c25cbb1f83"
+hash = "b3:efaea353be70e7a259560fe7e13ddf19037d80f78e6cd77586d3968176f0cb38"
 
 [[node]]
 path = "CLAUDE.md"

--- a/drft.lock
+++ b/drft.lock
@@ -2,7 +2,7 @@
 
 [[node]]
 path = "CHANGELOG.md"
-hash = "b3:dcc37cad97f81c367c8e518adf6fb07951f00315ef059e3b9afc170a1583b231"
+hash = "b3:14c357d77b018dd20285b6aedc1ced17bfe3a146709400a6975359c25cbb1f83"
 
 [[node]]
 path = "CLAUDE.md"
@@ -70,7 +70,7 @@ target_hash = "b3:fa42d587b5cd0a2a0253c7a8b7bbe54823632af99fd07791e54761411617c1
 
 [[node]]
 path = "Cargo.toml"
-hash = "b3:e8bc6a0535e89bbdec8e074cb7d4e09ece1d0db091d86377134c4568148701b8"
+hash = "b3:d8974e38a6103f50d42ea9f65d996e153452fde027ae32bdb617e445e13af4c7"
 
 [[node]]
 path = "LICENSE"


### PR DESCRIPTION
Release v0.8.0 — bumps `Cargo.toml` to `0.8.0` and adds the `0.8.0` CHANGELOG section. Per RELEASING.md, this lands the version bump; the `v0.8.0` tag goes on `main` after merge.

## Changelog

drft is rebuilt on a set-of-graphs substrate with an explicit composition step (the v0.8 work merged in #62). See `CHANGELOG.md` for the full entry.

### Breaking changes
- Config schema reshaped: `ignore` + `[graphs.*]` + `[rules.*]`; `include`/`exclude`/`[parsers.*]` removed.
- Lockfile format changed (path-keyed, no version field); old lockfiles report unparseable and point at `drft lock`.
- Command surface rebuilt: `init`, `graph`, `impact`, `check`, `lock`; `parse`/`report`/`config` removed.
- Drift-focused rule set; structural-hygiene rules removed and cycles permitted.
- No migration path (pre-v1 clean break).

### New
- Set-of-graphs substrate (`fs` base graph + `markdown`/`frontmatter`).
- Composition by path with `@<graph>` namespacing and `_graphs` provenance.
- `drft graph --raw` and `drft init`.

### Removed
- Analyses/metrics subsystem, custom subprocess parsers/rules, the criterion bench, and v0.7 docs/examples for those features.

## After merge
```
git checkout main && git pull
git tag v0.8.0
git push origin v0.8.0
```