### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to drft are documented here.
 
+## 0.9.0 (2026-06-05)
+
+Directories and symlinks get a proper place in the graph, link edges learn where they live, and the `impact`/`check`/rules surface gets sharper.
+
+### Breaking changes
+
+- **`drft impact` requires a path.** Running `impact` with no argument is now a usage error (exit 2). It previously defaulted to the impact of all currently-stale sources, which conflated a structural query with a lock-derived one. The drift blast-radius use case is deferred, not abandoned.
+- **Symlinks are untrackable indirection.** The `fs` walk no longer follows symlinks: a symlink is a leaf node with an edge to its target, and is never hashed — staleness propagates through the edge to the target. Lockfiles that recorded symlink hashes regenerate with `drft lock`. This also closes a leak where a symlink to a directory outside the graph root pulled outside files into the graph as nodes.
+
+### New
+
+- **Directory nodes.** The `fs` walk emits a node per directory (typed `directory`, hash-less). A link to an existing directory now resolves instead of flagging `unresolved-edge`; a link to a missing one still flags. Directories are never hashed, locked, or flagged `detached-node`.
+- **Link line numbers.** Markdown and frontmatter link edges record the 1-based source line(s) where the link appears as `lines` metadata — surfaced in `drft graph`, in `drft impact` fix instructions (`review guide.md:3,5 …`), and on `drft check` edge findings (`README.md:50 → src/lib.rs`, including `unresolved-edge`). Line numbers are graph-only and never locked, so a link moving lines is not drift.
+- **Global `[rules].ignore`.** An `ignore` set directly under `[rules]` applies to every rule, unioned with each rule's own. Unlike the top-level `ignore`, matched paths stay in the graph — links to them resolve and they keep drift hashes — so you can stop validating a group you depend on but don't own while keeping the transitive-staleness signal on your own files.
+
+### Changed
+
+- **Frontmatter YAML engine** switched from `serde_yml` (a continuation of the unmaintained `serde_yaml`) to `saphyr` (maintained, pure-safe Rust, with source spans — the source of frontmatter line numbers). Metadata output is unchanged. Malformed frontmatter is now skipped silently instead of printing a YAML warning — drft checks link drift, not YAML validity.
+
 ## 0.8.0 (2026-06-04)
 
 Rebuilt on a set-of-graphs substrate with an explicit composition step. drft now models a directory as a set of independent JGF graphs of bare-path nodes — `fs` (a node per file, typed and hashed), `markdown` (link edges), and `frontmatter` (edges plus metadata) — that a `compose` step merges by path. The `impact → edit → check → lock` loop is unchanged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "drft-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drft-cli"
-version = "0.8.0"
+version = "0.9.0"
 categories = ["command-line-utilities", "development-tools"]
 edition = "2024"
 homepage = "https://github.com/johnmdonahue/drft-cli"

--- a/drft.lock
+++ b/drft.lock
@@ -2,7 +2,7 @@
 
 [[node]]
 path = "CHANGELOG.md"
-hash = "b3:efaea353be70e7a259560fe7e13ddf19037d80f78e6cd77586d3968176f0cb38"
+hash = "b3:c09988b18009a12ee24285787eb733aab4fbc8f9063f3aa0ec7c845d25b8ad67"
 
 [[node]]
 path = "CLAUDE.md"
@@ -70,7 +70,7 @@ target_hash = "b3:fa42d587b5cd0a2a0253c7a8b7bbe54823632af99fd07791e54761411617c1
 
 [[node]]
 path = "Cargo.toml"
-hash = "b3:9f4ba29cddf43201b0864996f8c43f36d6e648bb36cbb15011c3307855ec0258"
+hash = "b3:e1e4834f9e84aa57bc3d73d281dbe71c0d58f8d4a59524d89bf933981408415a"
 
 [[node]]
 path = "LICENSE"


### PR DESCRIPTION
Release **v0.9.0**. Tag on main after merge (`git tag v0.9.0 && git push origin v0.9.0`) — cargo-dist + crates.io/npm publish are automated from the tag.

Bundles the work from #64. Highlights (full notes in `CHANGELOG.md`):

### Breaking
- **`drft impact` requires a path** — no-arg is now a usage error (exit 2).
- **Symlinks are untrackable indirection** — no longer followed or hashed; closes an out-of-root content leak. Lockfiles with symlink hashes regenerate with `drft lock`.

### New
- **Directory nodes** — links to directories resolve; directories never hashed/locked/`detached-node`.
- **Link line numbers** — `lines` edge metadata surfaced in `graph`, `impact` (`review guide.md:3,5 …`), and `check` (`README.md:50 → src/lib.rs`).
- **Global `[rules].ignore`** — silence a group you depend on but don't own, keeping transitive-staleness on your files.

### Changed
- **Frontmatter YAML engine** `serde_yml` → `saphyr`; malformed frontmatter skipped silently.
