### PR TITLE
impact/lock: resolve path argument relative to cwd (#66)

### DIFF
--- a/drft.lock
+++ b/drft.lock
@@ -276,7 +276,7 @@ hash = "b3:b437206e0e16ea1a0643edda5d8b1ab7361816bb42222bc80e488e13329b0516"
 
 [[node]]
 path = "src/main.rs"
-hash = "b3:e160d305be0c1a34d8de3a0e46f31f51d1f17a53ce5538c62cae573fea92555c"
+hash = "b3:2f759f730a307505783b9b02db9269747b15fd1a8d3bb7e566f0956697d3bc39"
 
 [[node]]
 path = "src/model.rs"
@@ -336,7 +336,7 @@ hash = "b3:317ec95915031ee51e9bcd86da06b439d120fd13ef29509e02fe668fd4fbb2f5"
 
 [[node]]
 path = "tests/impact.rs"
-hash = "b3:47c2c6763725ac81b966d0aee0a3b1e8c453d0077bfcfd38cbe022a623deb3b1"
+hash = "b3:e7d14f79bc3263af193d7744bbfb1bd65017788e97f764586ef5f4a3c3bd3408"
 
 [[node]]
 path = "tests/init.rs"

--- a/drft.lock
+++ b/drft.lock
@@ -276,7 +276,7 @@ hash = "b3:b437206e0e16ea1a0643edda5d8b1ab7361816bb42222bc80e488e13329b0516"
 
 [[node]]
 path = "src/main.rs"
-hash = "b3:8da77cc0d2271570f97e874797d051595fc0d927c21f4ca8060ac7625c62991c"
+hash = "b3:e160d305be0c1a34d8de3a0e46f31f51d1f17a53ce5538c62cae573fea92555c"
 
 [[node]]
 path = "src/model.rs"
@@ -336,7 +336,7 @@ hash = "b3:317ec95915031ee51e9bcd86da06b439d120fd13ef29509e02fe668fd4fbb2f5"
 
 [[node]]
 path = "tests/impact.rs"
-hash = "b3:d94d0061695fbd10b57373435202c2a497fba9c2d7f69e780bb1dacb3035a48e"
+hash = "b3:47c2c6763725ac81b966d0aee0a3b1e8c453d0077bfcfd38cbe022a623deb3b1"
 
 [[node]]
 path = "tests/init.rs"

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,7 @@ fn run_lock(root: &Path, path: Option<&str>) -> Result<i32> {
     match path {
         None => lock::write(&graph_root, &snapshot)?,
         Some(path) => {
-            let node = resolve_node(&composed, path)?;
+            let node = resolve_node(&composed, root, &graph_root, path)?;
             let mut existing = lock::read(&graph_root)?.unwrap_or_default();
             let entry = snapshot
                 .nodes
@@ -146,17 +146,66 @@ fn run_lock(root: &Path, path: Option<&str>) -> Result<i32> {
     Ok(0)
 }
 
-/// Resolve a user-supplied path to a node in the composed graph, trying a
-/// `.md` suffix as a fallback. Errors if no matching node exists.
-fn resolve_node(composed: &drft::model::Graph, path: &str) -> Result<String> {
-    if composed.nodes.contains_key(path) {
-        return Ok(path.to_string());
+/// Resolve a user-supplied path to a node key in the composed graph.
+///
+/// Nodes are keyed by graph-root-relative path, but the argument is relative to
+/// the current directory (`root`) like any other CLI path — so it is resolved
+/// against `root`, normalized, and made relative to `graph_root` before lookup.
+/// This makes the command cwd-agnostic: the same file resolves whether given
+/// project-relative from a subdirectory or root-relative from the top. A `.md`
+/// suffix is tried as a fallback, and the raw argument is tried last for back
+/// compatibility. On a miss, a node whose key ends with the argument is
+/// suggested.
+fn resolve_node(
+    composed: &drft::model::Graph,
+    root: &Path,
+    graph_root: &Path,
+    path: &str,
+) -> Result<String> {
+    let mut candidates = Vec::new();
+    if let Some(key) = graph_key(root, graph_root, path) {
+        candidates.push(format!("{key}.md"));
+        candidates.push(key);
     }
-    let with_ext = format!("{path}.md");
-    if composed.nodes.contains_key(&with_ext) {
-        return Ok(with_ext);
+    candidates.push(format!("{path}.md"));
+    candidates.push(path.to_string());
+
+    for candidate in &candidates {
+        if composed.nodes.contains_key(candidate) {
+            return Ok(candidate.clone());
+        }
     }
-    anyhow::bail!("node not found: \"{path}\"")
+
+    // Suggest a node whose key ends with the given path (e.g. a bare filename or
+    // a project-relative suffix) — the common "right file, wrong prefix" miss.
+    let needle = path.trim_start_matches("./");
+    let suffix = format!("/{needle}");
+    match composed
+        .nodes
+        .keys()
+        .find(|k| k.as_str() == needle || k.ends_with(&suffix))
+    {
+        Some(hit) => anyhow::bail!("node not found: \"{path}\" — did you mean \"{hit}\"?"),
+        None => anyhow::bail!("node not found: \"{path}\""),
+    }
+}
+
+/// Resolve `arg` (relative to the current directory `root`, or absolute) to a
+/// graph-root-relative node key. Normalization is lexical — `.`/`..` are
+/// resolved without touching the filesystem, so symlink node identities are
+/// preserved. Returns `None` when the path resolves outside `graph_root`.
+fn graph_key(root: &Path, graph_root: &Path, arg: &str) -> Option<String> {
+    let candidate = Path::new(arg);
+    let abs = if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        root.join(candidate)
+    };
+    let abs = drft::util::normalize_relative_path(&abs.to_string_lossy());
+    let graph_root = drft::util::normalize_relative_path(&graph_root.to_string_lossy());
+    let rel = Path::new(&abs).strip_prefix(&graph_root).ok()?;
+    let key = rel.to_string_lossy().replace('\\', "/");
+    (!key.is_empty()).then_some(key)
 }
 
 fn run_graph(root: &Path, raw: bool) -> Result<i32> {
@@ -188,7 +237,7 @@ fn run_impact(
 
     let seeds: Vec<String> = paths
         .iter()
-        .map(|p| resolve_node(&composed, p))
+        .map(|p| resolve_node(&composed, root, &graph_root, p))
         .collect::<Result<_>>()?;
 
     let dir = match direction {

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,7 +155,8 @@ fn run_lock(root: &Path, path: Option<&str>) -> Result<i32> {
 /// project-relative from a subdirectory or root-relative from the top. A `.md`
 /// suffix is tried as a fallback, and the raw argument is tried last for back
 /// compatibility. On a miss, a node whose key ends with the argument is
-/// suggested.
+/// suggested — but only when the suffix match is unambiguous (otherwise the
+/// candidates are listed, so an arbitrary pick is never presented as "the" one).
 fn resolve_node(
     composed: &drft::model::Graph,
     root: &Path,
@@ -176,17 +177,36 @@ fn resolve_node(
         }
     }
 
-    // Suggest a node whose key ends with the given path (e.g. a bare filename or
+    // Suggest nodes whose key ends with the given path (e.g. a bare filename or
     // a project-relative suffix) — the common "right file, wrong prefix" miss.
-    let needle = path.trim_start_matches("./");
+    // Normalize the needle so it matches the graph's forward-slash keys, and only
+    // present a single suggestion when it's unambiguous.
+    let needle = drft::util::normalize_relative_path(path);
     let suffix = format!("/{needle}");
-    match composed
+    let matches: Vec<&String> = composed
         .nodes
         .keys()
-        .find(|k| k.as_str() == needle || k.ends_with(&suffix))
-    {
-        Some(hit) => anyhow::bail!("node not found: \"{path}\" — did you mean \"{hit}\"?"),
-        None => anyhow::bail!("node not found: \"{path}\""),
+        .filter(|k| k.as_str() == needle || k.ends_with(&suffix))
+        .collect();
+    match matches.as_slice() {
+        [] => anyhow::bail!("node not found: \"{path}\""),
+        [hit] => anyhow::bail!("node not found: \"{path}\" — did you mean \"{hit}\"?"),
+        many => {
+            let shown = many
+                .iter()
+                .take(5)
+                .map(|k| format!("\"{k}\""))
+                .collect::<Vec<_>>();
+            let more = if many.len() > shown.len() {
+                format!(", and {} more", many.len() - shown.len())
+            } else {
+                String::new()
+            };
+            anyhow::bail!(
+                "node not found: \"{path}\" — multiple matches: {}{more}",
+                shown.join(", ")
+            )
+        }
     }
 }
 

--- a/tests/impact.rs
+++ b/tests/impact.rs
@@ -224,7 +224,38 @@ fn impact_missing_path_suggests_suffix_match() {
     assert_eq!(output.status.code(), Some(2));
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("projects/api/domain-model.md"),
-        "expected a suffix suggestion, got: {stderr}"
+        stderr.contains("did you mean") && stderr.contains("projects/api/domain-model.md"),
+        "expected a single suffix suggestion, got: {stderr}"
+    );
+}
+
+/// An ambiguous bare filename (same name under multiple dirs) lists the matches
+/// rather than confidently suggesting an arbitrary one.
+#[test]
+fn impact_ambiguous_suffix_lists_matches() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(
+        dir.path().join("index.md"),
+        "[a](a/README.md) [b](b/README.md)",
+    )
+    .unwrap();
+    for d in ["a", "b"] {
+        fs::create_dir_all(dir.path().join(d)).unwrap();
+        fs::write(dir.path().join(d).join("README.md"), "# Readme").unwrap();
+    }
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "impact", "README.md"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("multiple matches")
+            && stderr.contains("a/README.md")
+            && stderr.contains("b/README.md"),
+        "expected both matches listed, not a single guess, got: {stderr}"
     );
 }

--- a/tests/impact.rs
+++ b/tests/impact.rs
@@ -159,3 +159,72 @@ fn impact_md_extension_fallback() {
     assert!(stdout.contains("index.md"));
     assert!(output.status.success());
 }
+
+/// Regression (#66): a path argument resolves relative to the current directory,
+/// not as a literal graph key — so running from a subdirectory with a
+/// project-relative path finds the node, matching `git log <path>` behavior.
+#[test]
+fn impact_resolves_path_relative_to_cwd() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(
+        dir.path().join("index.md"),
+        "[model](projects/api/domain-model.md)",
+    )
+    .unwrap();
+    let sub = dir.path().join("projects/api");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(sub.join("domain-model.md"), "# Domain model").unwrap();
+
+    // Run from inside the project subdir with a project-relative path (no -C).
+    let output = drft_bin()
+        .current_dir(&sub)
+        .args(["impact", "domain-model.md"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected cwd-relative path to resolve, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("index.md"),
+        "expected index.md as a dependent, got: {stdout}"
+    );
+}
+
+/// A genuinely absent path errors (exit 2) and suggests a node whose key ends
+/// with the given argument.
+#[test]
+fn impact_missing_path_suggests_suffix_match() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(
+        dir.path().join("index.md"),
+        "[model](projects/api/domain-model.md)",
+    )
+    .unwrap();
+    let sub = dir.path().join("projects/api");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(sub.join("domain-model.md"), "# Domain model").unwrap();
+
+    // Bare filename from the root: can't resolve, but should suggest the match.
+    let output = drft_bin()
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "impact",
+            "domain-model.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("projects/api/domain-model.md"),
+        "expected a suffix suggestion, got: {stderr}"
+    );
+}


### PR DESCRIPTION
Closes #66.

`drft impact <path>` (and `lock <path>`) used the raw argument as the graph node key, but nodes are keyed graph-root-relative — so running from a subdirectory with a project-relative path reported `node not found` for a file that exists and is in the graph.

## Fix

`resolve_node` now normalizes the argument the way every other path-taking CLI does:

```
arg → resolve against cwd → normalize . / .. (lexical, no fs touch) → make relative to graph root → look up
```

Lexical (not canonicalizing) normalization preserves symlink node identities. The `.md` suffix fallback and a raw-argument lookup are still tried, so existing usage is unaffected. Both `impact` and `lock` get the fix (they share `resolve_node`), per the ticket's note.

On a miss, the error now suggests a node whose key ends with the argument — the typical "right file, wrong prefix" case:

```
node not found: "domain-model.md" — did you mean "projects/api/domain-model.md"?
```

## Acceptance (all met)

- ✅ `drft impact <path>` returns the same result regardless of cwd or whether the path is project-relative or root-relative.
- ✅ A genuinely absent path still errors (exit 2), with a suffix-based suggestion.
- ✅ Regression test covering the run-from-subdirectory case (plus one for the suggestion).

Gate green: full test suite + clippy + fmt + `drft check`.
