### PR TITLE
Release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to drft are documented here.
 
+## 0.9.1 (2026-06-05)
+
+### Fixed
+
+- **`drft impact` / `drft lock` path arguments resolve relative to the current directory** (#66). A project-relative path given from inside a subdirectory is now resolved against the current directory and converted to the graph-root-relative node key, instead of being matched verbatim — so the same file resolves whether given project-relative from a subdir or root-relative from the top, matching `git log <path>` behavior. On a miss, the error suggests the node whose key matches the given suffix (or lists candidates when the suffix is ambiguous).
+
 ## 0.9.0 (2026-06-05)
 
 Directories and symlinks get a proper place in the graph, link edges learn where they live, and the `impact`/`check`/rules surface gets sharper.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "drft-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drft-cli"
-version = "0.9.0"
+version = "0.9.1"
 categories = ["command-line-utilities", "development-tools"]
 edition = "2024"
 homepage = "https://github.com/johnmdonahue/drft-cli"

--- a/drft.lock
+++ b/drft.lock
@@ -2,7 +2,7 @@
 
 [[node]]
 path = "CHANGELOG.md"
-hash = "b3:c09988b18009a12ee24285787eb733aab4fbc8f9063f3aa0ec7c845d25b8ad67"
+hash = "b3:5681b9316fd4180c92e1dcfb63e35ba9657bfd6cdb45d55710bcb5ade89601c1"
 
 [[node]]
 path = "CLAUDE.md"
@@ -70,7 +70,7 @@ target_hash = "b3:fa42d587b5cd0a2a0253c7a8b7bbe54823632af99fd07791e54761411617c1
 
 [[node]]
 path = "Cargo.toml"
-hash = "b3:e1e4834f9e84aa57bc3d73d281dbe71c0d58f8d4a59524d89bf933981408415a"
+hash = "b3:1b74206a05771bf7f021870f8570e4b1a00ec0ce96e58872b8ca2c92087bdafd"
 
 [[node]]
 path = "LICENSE"


### PR DESCRIPTION
Release **v0.9.1** — a patch with the cwd-path fix from #66. Tag on main after merge (`git tag v0.9.1 && git push origin v0.9.1`); cargo-dist + crates.io/npm publish are automated from the tag.

### Fixed
- **`drft impact` / `drft lock` resolve path arguments relative to the current directory** (#66) — a project-relative path from a subdirectory now resolves to the right node instead of "node not found", with a unique-match "did you mean …?" suggestion (and a candidate list when ambiguous).

Full notes in `CHANGELOG.md`.
