### PR TITLE
fs: walk dot-directories; honor only committed ignore sources

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -16,10 +16,17 @@ found while walking are ordinary files on disk, not graph boundaries.
 ignore = ["target/**", "drafts/**"]
 ```
 
-The `fs` graph walks every file under the graph root. `ignore` removes paths
-from that walk by glob; drft also respects `.gitignore` automatically. There is
-no `include` — the graph is everything under the root minus what `ignore` and
-`.gitignore` remove. drft excludes its own `drft.lock` from the graph.
+The `fs` graph walks every file under the graph root, including dot-directories
+like `.github/` — only version-control stores (`.git`, `.hg`, `.svn`, `.jj`) are
+pruned. `ignore` removes paths from that walk by glob; drft also respects
+`.gitignore` automatically. There is no `include` — the graph is everything
+under the root minus what `ignore` and `.gitignore` remove. drft excludes its
+own `drft.lock` from the graph.
+
+Only committed `.gitignore` rules count. For reproducibility, the graph never
+depends on machine-local or above-root state: your global gitignore, the
+per-clone `.git/info/exclude`, and ignore files in directories above the root
+are all disregarded.
 
 This top-level `ignore` is a **discovery** filter: matching paths never become
 nodes, so nothing links to them and nothing is validated against them. To keep

--- a/drft.lock
+++ b/drft.lock
@@ -62,7 +62,7 @@ target_hash = "b3:eb2f3748fa8b147fa1823efbe6bc77a2cf63369b0c180d7ca366f9bd2ceb98
 
 [[node.edge]]
 target = "src/sources/fs.rs"
-target_hash = "b3:661a31231e1c7efbe03d1b3c72c35885b2eefae1064f900bd9203ff32127316c"
+target_hash = "b3:5ceb21d8479e3b8c67955283a834bf020a96c4af6e52358239cf048e419aad2b"
 
 [[node.edge]]
 target = "src/util.rs"
@@ -90,7 +90,7 @@ target_hash = "b3:8d7418c6e44101f556bd8bb0852965e24ba8259cbd21a29d1f48c080f069d2
 
 [[node.edge]]
 target = "docs/config.md"
-target_hash = "b3:8ccc5c992603bfdd5ddee149716432c6023ab4c0a6335835292d3555b5aacbcf"
+target_hash = "b3:669806620d36f5b4c84c96aba4f2970813fb8cf9912f4f93a6e0725541517dc0"
 
 [[node.edge]]
 target = "https://github.com/johnmdonahue/drft-cli/releases"
@@ -109,7 +109,7 @@ hash = "b3:8d7418c6e44101f556bd8bb0852965e24ba8259cbd21a29d1f48c080f069d2e1"
 
 [[node.edge]]
 target = "docs/config.md"
-target_hash = "b3:8ccc5c992603bfdd5ddee149716432c6023ab4c0a6335835292d3555b5aacbcf"
+target_hash = "b3:669806620d36f5b4c84c96aba4f2970813fb8cf9912f4f93a6e0725541517dc0"
 
 [[node.edge]]
 target = "docs/parsers/README.md"
@@ -121,7 +121,7 @@ target_hash = "b3:951c94920bd8893eb50a5ab766db7140ac3ce141637fe334908e5e0d95e12d
 
 [[node]]
 path = "docs/config.md"
-hash = "b3:8ccc5c992603bfdd5ddee149716432c6023ab4c0a6335835292d3555b5aacbcf"
+hash = "b3:669806620d36f5b4c84c96aba4f2970813fb8cf9912f4f93a6e0725541517dc0"
 
 [[node.edge]]
 target = "docs/parsers/README.md"
@@ -161,7 +161,7 @@ hash = "b3:23258bd291ed24012764c7420bacc2a54433e5e9adc9b79f674253f946117531"
 
 [[node.edge]]
 target = "docs/config.md"
-target_hash = "b3:8ccc5c992603bfdd5ddee149716432c6023ab4c0a6335835292d3555b5aacbcf"
+target_hash = "b3:669806620d36f5b4c84c96aba4f2970813fb8cf9912f4f93a6e0725541517dc0"
 
 [[node.edge]]
 target = "src/parsers/frontmatter.rs"
@@ -173,7 +173,7 @@ hash = "b3:291302e9f0e404a834790daae6aa7c7b0dff465e9ca0c336c5732030e5bb5383"
 
 [[node.edge]]
 target = "docs/config.md"
-target_hash = "b3:8ccc5c992603bfdd5ddee149716432c6023ab4c0a6335835292d3555b5aacbcf"
+target_hash = "b3:669806620d36f5b4c84c96aba4f2970813fb8cf9912f4f93a6e0725541517dc0"
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
@@ -312,7 +312,7 @@ hash = "b3:9d41bb2e0217011f0994b694a78b94388280a41721706bc13292d5f4ede2f438"
 
 [[node]]
 path = "src/sources/fs.rs"
-hash = "b3:661a31231e1c7efbe03d1b3c72c35885b2eefae1064f900bd9203ff32127316c"
+hash = "b3:5ceb21d8479e3b8c67955283a834bf020a96c4af6e52358239cf048e419aad2b"
 
 [[node]]
 path = "src/sources/mod.rs"

--- a/src/sources/fs.rs
+++ b/src/sources/fs.rs
@@ -8,6 +8,13 @@ use std::path::Path;
 
 use crate::config::compile_globs;
 
+/// VCS metadata entries pruned from the walk. The hidden filter is off so that
+/// ordinary dot-directories (`.github/`, `.config/`) join the graph, but a
+/// version-control store is internal bookkeeping, never graph content — so it
+/// is excluded by name. ripgrep skips these via its hidden filter; drft keeps
+/// dot-dirs and names the exclusions instead.
+const VCS_DIRS: [&str; 4] = [".git", ".hg", ".svn", ".jj"];
+
 /// What kind of filesystem entry a [`SourceFile`] is. Derived from `lstat`, so a
 /// symlink-to-directory is [`Symlink`](NodeKind::Symlink) (indirection wins over
 /// target kind), and [`Dir`](NodeKind::Dir) always means a real directory.
@@ -34,6 +41,14 @@ pub struct SourceFile {
 /// yielding one [`SourceFile`] per file, symlink, and directory. Paths are
 /// relative to `root`, sorted.
 ///
+/// Hidden entries are *not* skipped: a dot-directory like `.github/` is part of
+/// the graph. The lone exception is VCS metadata ([`VCS_DIRS`]), pruned from
+/// traversal — `.git/` would otherwise flood the graph with internal state.
+///
+/// Only committed `.gitignore` rules prune the walk. The user's global
+/// gitignore, the per-clone `.git/info/exclude`, and ignore files above `root`
+/// are all ignored, so the graph depends only on what is committed at the root.
+///
 /// The walk does not follow symlinks: a symlink is a leaf node at its own path,
 /// never traversed through. Its relationship to its target is carried by the
 /// edge the builder emits, not by re-walking the target. So a symlink to a
@@ -47,7 +62,28 @@ pub fn walk(root: &Path, ignore: &[String]) -> Result<Vec<SourceFile>> {
 
     let mut files = Vec::new();
 
-    let walker = WalkBuilder::new(root).follow_links(false).build();
+    // Reproducibility over convenience: the graph must depend only on what is
+    // committed at the root, never on machine-local or above-root state. So,
+    // unlike ripgrep's defaults, drft honors committed `.gitignore` but not the
+    // user's global gitignore, the per-clone `.git/info/exclude`, or ignore
+    // files in directories above the declared root.
+    let walker = WalkBuilder::new(root)
+        .follow_links(false)
+        .hidden(false)
+        .parents(false)
+        .git_global(false)
+        .git_exclude(false)
+        .filter_entry(|entry| {
+            // With the hidden filter off, dot-directories are walked. Prune VCS
+            // metadata explicitly so it never enters the graph. `.git` can be a
+            // file (submodules, linked worktrees) as well as a directory, so
+            // match by name regardless of kind.
+            entry
+                .file_name()
+                .to_str()
+                .is_none_or(|name| !VCS_DIRS.contains(&name))
+        })
+        .build();
 
     for entry in walker {
         let entry = entry?;
@@ -204,6 +240,48 @@ mod tests {
         let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
         assert!(paths.contains(&"index.md"));
         assert!(!paths.iter().any(|p| p.contains("vendor")));
+    }
+
+    #[test]
+    fn ignore_files_above_root_do_not_prune_the_walk() {
+        // A git repo whose root sits *above* the graph root, with a gitignore
+        // that would exclude `keep.md`. Because `parents` is off, the rule above
+        // the declared root has no effect — the graph is self-contained.
+        let outer = TempDir::new().unwrap();
+        fs::create_dir(outer.path().join(".git")).unwrap();
+        fs::write(outer.path().join(".gitignore"), "keep.md\n").unwrap();
+        let root = outer.path().join("project");
+        fs::create_dir(&root).unwrap();
+        fs::write(root.join("keep.md"), "k").unwrap();
+
+        let files = walk(&root, &[]).unwrap();
+        assert!(
+            files.iter().any(|f| f.path == "keep.md"),
+            "an ignore rule above the root must not prune the walk"
+        );
+    }
+
+    #[test]
+    fn dot_dirs_are_walked_but_vcs_dirs_are_pruned() {
+        let dir = TempDir::new().unwrap();
+        // A real version-control store: pruned, contents and all.
+        fs::create_dir(dir.path().join(".git")).unwrap();
+        fs::write(dir.path().join(".git").join("HEAD"), "ref: x").unwrap();
+        // An ordinary dot-directory: part of the graph.
+        fs::create_dir(dir.path().join(".github")).unwrap();
+        fs::write(dir.path().join(".github").join("ci.yml"), "y").unwrap();
+
+        let files = walk(dir.path(), &[]).unwrap();
+        let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+
+        assert!(
+            !paths.iter().any(|p| p.starts_with(".git/") || *p == ".git"),
+            "VCS metadata must be pruned, got: {paths:?}"
+        );
+        assert!(
+            paths.contains(&".github") && paths.contains(&".github/ci.yml"),
+            "ordinary dot-directories must be walked, got: {paths:?}"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

The `fs` walk inherited the `ignore` crate's defaults, which (1) skip hidden entries and (2) apply machine-local ignore state. Both are wrong for a tool whose graph feeds a deterministic lockfile.

- **Hidden filter** silently dropped ordinary dot-directories (`.github/`, `.claude/`) from the graph.
- **`git_global` / `git_exclude` / parent-directory ignore files** made the graph depend on per-machine, uncommitted, and above-root state — the same repo could produce different graphs on different clones.

## Changes

- `.hidden(false)` — dot-directories are now graph content.
- `.filter_entry(...)` prunes only VCS stores (`.git`, `.hg`, `.svn`, `.jj`) by name. `.git` can be a *file* in submodules/worktrees, so the match is kind-agnostic.
- `.parents(false).git_global(false).git_exclude(false)` — only committed `.gitignore` plus the configured `ignore` globs prune the walk. The graph now depends solely on what is committed at the root.

Net behavior: the graph is everything committed under the root, minus committed `.gitignore` and `ignore` globs. `git_ignore` and `require_git` stay at defaults.

## Why

ripgrep's defaults optimize for "show me what I care about on this machine right now." drft has a lockfile and needs reproducibility, so machine-local/above-root ignore sources are the wrong default.

## Tests

- `dot_dirs_are_walked_but_vcs_dirs_are_pruned`
- `ignore_files_above_root_do_not_prune_the_walk`

Full suite passes, clippy clean. Verified on this repo: `.github/`, `.claude/`, `.gitignore` now appear as nodes; `.git/` pruned; `.scratch/` stays out via its own gitignore rule. Docs updated in `docs/config.md`.