### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to drft are documented here.
 
+## 0.10.0 (2026-06-24)
+
+### Breaking changes
+
+- **Dot-directories are now part of the graph.** The `fs` walk no longer skips hidden entries, so directories like `.github/` and `.claude/` and files like `.gitignore` become nodes. Only version-control stores (`.git`, `.hg`, `.svn`, `.jj`) are pruned, by name — `.git` matches whether it is a directory or a file (submodules and linked worktrees). Lockfiles regenerate with `drft lock` to capture the newly-visible nodes (#69).
+- **Only committed ignore sources prune the walk.** drft previously inherited the `ignore` crate's defaults, applying your global gitignore, the per-clone `.git/info/exclude`, and `.gitignore` files in directories above the graph root. These are now disabled: only the in-root `.gitignore` plus the configured `ignore` globs affect traversal, so the graph depends solely on what is committed at the root and is reproducible across clones (#69).
+
 ## 0.9.1 (2026-06-05)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "drft-cli"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drft-cli"
-version = "0.9.1"
+version = "0.10.0"
 categories = ["command-line-utilities", "development-tools"]
 edition = "2024"
 homepage = "https://github.com/johnmdonahue/drft-cli"

--- a/drft.lock
+++ b/drft.lock
@@ -2,7 +2,7 @@
 
 [[node]]
 path = "CHANGELOG.md"
-hash = "b3:5681b9316fd4180c92e1dcfb63e35ba9657bfd6cdb45d55710bcb5ade89601c1"
+hash = "b3:e8a283a172e1065e3c67835776aa64ca1d6e959d1a4c6bba5e7e4691635f5f1a"
 
 [[node]]
 path = "CLAUDE.md"
@@ -70,7 +70,7 @@ target_hash = "b3:fa42d587b5cd0a2a0253c7a8b7bbe54823632af99fd07791e54761411617c1
 
 [[node]]
 path = "Cargo.toml"
-hash = "b3:1b74206a05771bf7f021870f8570e4b1a00ec0ce96e58872b8ca2c92087bdafd"
+hash = "b3:575a5f7fe39ed2343ef541b5702a74097d06d35ebf6b261212a73de3ae6679d5"
 
 [[node]]
 path = "LICENSE"


### PR DESCRIPTION
Release **v0.10.0**.

Bumps `Cargo.toml` to `0.10.0`, adds the CHANGELOG section, and relocks `drft.lock`.

## Highlights (from #69)

**Breaking — graph membership changes:**

- **Dot-directories are now part of the graph.** The `fs` walk no longer skips hidden entries, so `.github/`, `.claude/`, `.gitignore`, etc. become nodes. Only version-control stores (`.git`, `.hg`, `.svn`, `.jj`) are pruned, by name. Lockfiles regenerate with `drft lock`.
- **Only committed ignore sources prune the walk.** The global gitignore, per-clone `.git/info/exclude`, and above-root `.gitignore` files are no longer applied — only the in-root `.gitignore` plus configured `ignore` globs. The graph is now reproducible across clones.

## Release steps after merge

Per RELEASING.md: tag `v0.10.0` on main and push to trigger build + publish.