### PR TITLE
config: reject unknown keys in drft.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to drft are documented here.
 
+## Unreleased
+
+### Breaking changes
+
+- **Unknown keys in `drft.toml` are now config errors** (#71). Extra keys in a `[graphs.*]` table, at the top level, or in a `[rules.*]` table previously parsed and were discarded, so a speculative option like `keys = ["sources"]` exited 0 having done nothing. All three now fail with exit 2, naming the key and the accepted set. A config carrying a typo'd or aspirational key was already not doing what it said; it now says so. Unknown rule _names_ still only warn — that path is unchanged.
+
 ## 0.10.0 (2026-06-24)
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to drft are documented here.
 
 ### Breaking changes
 
-- **Unknown keys in `drft.toml` are now config errors** (#71). Extra keys in a `[graphs.*]` table, at the top level, or in a `[rules.*]` table previously parsed and were discarded, so a speculative option like `keys = ["sources"]` exited 0 having done nothing. All three now fail with exit 2, naming the key and the accepted set. A config carrying a typo'd or aspirational key was already not doing what it said; it now says so. Unknown rule _names_ still only warn — that path is unchanged.
+- **Unknown keys in `drft.toml` are now config errors** (#71). Extra keys in a `[graphs.*]` table, at the top level, or in a `[rules.*]` table were previously parsed and discarded, so a speculative option like `keys = ["sources"]` exited 0 having done nothing. All three now fail with exit 2, naming the key and the accepted set. A config carrying a typo'd or aspirational key was already not doing what it said; it now says so. Unknown rule _names_ still only warn — that path is unchanged.
 
 ## 0.10.0 (2026-06-24)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -57,6 +57,10 @@ files = ["**/*.md"]
 | `parser` | yes      | —             | How to interpret the files (see [parsers](parsers/README.md)) |
 | `files`  | no       | `["**/*.md"]` | Globs scoping which files the parser reads                    |
 
+These are the only accepted keys. Any other key is a config error naming the key
+and the accepted set — a graph table that parses is a graph that works, so a
+parser option drft does not have fails loudly instead of being discarded.
+
 The graph's name is its compose-time namespace: its facts nest under `@<name>`
 in the composed graph. A name must not contain `@`, start with `_`, or be `fs` —
 all reserved. `fs` is always built without being declared, and is a provider
@@ -93,5 +97,9 @@ not theirs." (`ignore` is a reserved key here; no rule may be named `ignore`.)
 | ---------- | -------- | ------- | ----------------------------------------------- |
 | `severity` | no       | `warn`  | `"error"`, `"warn"`, or `"off"`                 |
 | `ignore`   | no       | none    | Globs — suppress findings whose subject matches |
+
+Any other key in a `[rules.<name>]` table is a config error. An unknown rule
+_name_ only warns, since both fields default and a misspelled rule would
+otherwise configure nothing in silence.
 
 See [rules](rules/README.md) for the full set.

--- a/docs/config.md
+++ b/docs/config.md
@@ -58,8 +58,8 @@ files = ["**/*.md"]
 | `files`  | no       | `["**/*.md"]` | Globs scoping which files the parser reads                    |
 
 These are the only accepted keys. Any other key is a config error naming the key
-and the accepted set — a graph table that parses is a graph that works, so a
-parser option drft does not have fails loudly instead of being discarded.
+and the accepted set. A graph table that parses is read as a graph that works, so
+an option drft does not support fails loudly rather than being silently discarded.
 
 The graph's name is its compose-time namespace: its facts nest under `@<name>`
 in the composed graph. A name must not contain `@`, start with `_`, or be `fs` —

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,7 +37,11 @@ pub struct GraphConfig {
     pub parser: String,
 }
 
+/// `deny_unknown_fields` so a key the parser does not support is a hard error
+/// rather than a silent discard. A graph table that parses is read as a graph
+/// that works — a speculative `keys = [...]` must not exit 0 doing nothing.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawGraph {
     files: Option<Vec<String>>,
     parser: String,
@@ -71,6 +75,11 @@ impl RuleConfig {
 
 /// Serde helper: a rule is either a bare severity (`stale-node = "error"`) or a
 /// table (`[rules.stale-node]` with `severity` and `ignore`).
+///
+/// The table variant cannot use `deny_unknown_fields` — an untagged enum reports
+/// a rejected variant as "data did not match any variant", which names neither
+/// the bad key nor the known set. Capturing the leftovers instead lets `load`
+/// raise the same precise error the graph tables give.
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum RawRuleValue {
@@ -80,8 +89,13 @@ enum RawRuleValue {
         severity: RuleSeverity,
         #[serde(default)]
         ignore: Vec<String>,
+        #[serde(flatten)]
+        unknown: BTreeMap<String, toml::Value>,
     },
 }
+
+/// Fields a `[rules.*]` table accepts, for the unknown-key error.
+const RULE_TABLE_FIELDS: &str = "`severity` or `ignore`";
 
 fn default_warn() -> RuleSeverity {
     RuleSeverity::Warn
@@ -117,7 +131,7 @@ pub struct Config {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct RawConfig {
     ignore: Option<Vec<String>>,
     graphs: Option<HashMap<String, RawGraph>>,
@@ -210,7 +224,16 @@ impl Config {
             for (name, value) in raw_rules.rules {
                 let rule_config = match value {
                     RawRuleValue::Severity(severity) => RuleConfig::new(severity, Vec::new())?,
-                    RawRuleValue::Table { severity, ignore } => {
+                    RawRuleValue::Table {
+                        severity,
+                        ignore,
+                        unknown,
+                    } => {
+                        if let Some(key) = unknown.keys().next() {
+                            anyhow::bail!(
+                                "unknown field `{key}` in rules.{name}, expected {RULE_TABLE_FIELDS}"
+                            );
+                        }
                         RuleConfig::new(severity, ignore)
                             .with_context(|| format!("invalid globs in rules.{name}"))?
                     }
@@ -387,6 +410,60 @@ mod tests {
         assert!(config.is_rule_ignored("unresolved-edge", "vendor/x.md"));
         // It does not touch paths outside the group.
         assert!(!config.is_rule_ignored("stale-node", "yours.md"));
+    }
+
+    #[test]
+    fn unknown_graph_key_errors() {
+        // A key the parser does not support must not parse and do nothing — the
+        // near-miss spellings (`keys`, `fields`, `include_keys`) are the likely
+        // case, so the error names the key and the accepted set.
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("drft.toml"),
+            "[graphs.x]\nparser = \"frontmatter\"\nkeys = [\"sources\"]\n",
+        )
+        .unwrap();
+        let err = format!("{:#}", Config::load(dir.path()).unwrap_err());
+        assert!(err.contains("unknown field `keys`"), "got: {err}");
+        assert!(err.contains("files"), "expected set not named: {err}");
+    }
+
+    #[test]
+    fn unknown_top_level_key_errors() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("drft.toml"), "ignores = [\"target/**\"]\n").unwrap();
+        let err = format!("{:#}", Config::load(dir.path()).unwrap_err());
+        assert!(err.contains("unknown field `ignores`"), "got: {err}");
+    }
+
+    #[test]
+    fn unknown_rule_table_key_errors() {
+        // The untagged enum accepts any table (both fields default), so a typo'd
+        // key silently parsed as an all-defaults rule before the leftovers were
+        // captured. Distinct from an unknown *rule name*, which only warns.
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("drft.toml"),
+            "[rules.stale-node]\nseverty = \"error\"\n",
+        )
+        .unwrap();
+        let err = format!("{:#}", Config::load(dir.path()).unwrap_err());
+        assert!(err.contains("unknown field `severty`"), "got: {err}");
+        assert!(err.contains("rules.stale-node"), "got: {err}");
+    }
+
+    #[test]
+    fn known_rule_table_keys_still_parse() {
+        // Guard against the flatten capture swallowing the real fields.
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("drft.toml"),
+            "[rules.detached-node]\nseverity = \"error\"\nignore = [\"README.md\"]\n",
+        )
+        .unwrap();
+        let config = Config::load(dir.path()).unwrap();
+        assert_eq!(config.rules["detached-node"].severity, RuleSeverity::Error);
+        assert!(config.is_rule_ignored("detached-node", "README.md"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -229,9 +229,12 @@ impl Config {
                         ignore,
                         unknown,
                     } => {
+                        // Raised after parsing, so it carries the config path the
+                        // serde-level errors get from the `failed to parse` context.
                         if let Some(key) = unknown.keys().next() {
                             anyhow::bail!(
-                                "unknown field `{key}` in rules.{name}, expected {RULE_TABLE_FIELDS}"
+                                "failed to parse {}: unknown field `{key}` in rules.{name}, expected {RULE_TABLE_FIELDS}",
+                                config_path.display()
                             );
                         }
                         RuleConfig::new(severity, ignore)


### PR DESCRIPTION
Closes #71.

Unknown keys in `drft.toml` parsed and were discarded, so a speculative option like `keys = ["sources"]` exited 0 having done nothing. For an agent consumer that is worse than a hard error: a config that parses is read as a config that works.

## What changed

| Surface | Before | Now |
| :-- | :-- | :-- |
| `[graphs.*]` unknown key | parsed, discarded, exit 0 | exit 2, names key + accepted set |
| top-level unknown key | parsed, discarded, exit 0 | exit 2 |
| `[rules.*]` unknown key | parsed as an all-defaults rule, exit 0 | exit 2 |

The issue's "did you mean" bonus needs no custom code — serde names the accepted set and toml adds line/column:

```
TOML parse error at line 4, column 1
  |
4 | keys = ["sources"]
  | ^^^^
unknown field `keys`, expected `files` or `parser`
```

## The rule tables had the same hole

#71 notes that rule tables already reject unknown keys, citing `severity = "erorr"`. That is a bad *value*. A bad *key* — `severty = "error"` — parsed silently: both fields default, so the untagged `Table` variant matches any table.

`deny_unknown_fields` cannot fix that one. On an untagged enum a rejected variant collapses to `data did not match any variant of untagged enum RawRuleValue`, which names neither the offending key nor the known set. The leftover keys are captured with `flatten` instead, so `[rules.*]` raises the same precise error the graph tables now give.

Unknown rule *names* still warn rather than error — unchanged.

## Breaking

A config carrying a typo'd or aspirational key was already not doing what it said; it now says so, at exit 2. CHANGELOG has an `Unreleased` breaking-changes entry.

## Verification

- `cargo test` — 128 pass, including four new config cases (unknown graph key, unknown top-level key, unknown rule-table key, and a guard that the flatten capture does not swallow the real `severity`/`ignore` fields)
- `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `dprint fmt` applied
- `docs/config.md` documents the behavior under both schema tables; `drft.lock` is intentionally not regenerated
