### PR TITLE
frontmatter: scope edges to named keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to drft are documented here.
 
 ### Breaking changes
 
-- **Unknown keys in `drft.toml` are now config errors** (#71). Extra keys in a `[graphs.*]` table, at the top level, or in a `[rules.*]` table were previously parsed and discarded, so a speculative option like `keys = ["sources"]` exited 0 having done nothing. All three now fail with exit 2, naming the key and the accepted set. A config carrying a typo'd or aspirational key was already not doing what it said; it now says so. Unknown rule _names_ still only warn — that path is unchanged.
+- **Unknown keys in `drft.toml` are now config errors** (#71). Extra keys in a `[graphs.*]` table, at the top level, or in a `[rules.*]` table were previously parsed and discarded, so a speculative option like `include_keys = ["sources"]` exited 0 having done nothing. All three now fail with exit 2, naming the key and the accepted set. A config carrying a typo'd or aspirational key was already not doing what it said; it now says so. Unknown rule _names_ still only warn — that path is unchanged.
+
+### New
+
+- **`keys` scopes the frontmatter graph to named keys** (#73). The parser classified by value shape, so any path-shaped frontmatter value became an edge whatever key it sat under — an API route (`route: /customers`) or a glob naming the files a rule governs both read as derivations. `keys = ["sources"]` on a `[graphs.*]` table using the `frontmatter` parser restricts edges to values reachable through those keys; a matched key contributes its whole subtree, and the key matches at any depth. Omitting `keys` keeps shape detection, so existing configs are unaffected. This replaces the two workarounds that were available: a `files` allowlist only works when the collision is tree-separable, and a rule-level `ignore` on `unresolved-edge` suppresses genuinely broken `sources:` paths along with the false ones. `keys` scopes edges only — metadata still captures the whole block.
 
 ## 0.10.0 (2026-06-24)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ drft builds a **set of independent graphs** and merges them by path:
 
 - **`fs`** — walks the tree under the root (minus `ignore` and `.gitignore`), typing each file, symlink, and directory as a node and hashing the ones with content. This is the identity space.
 - **`markdown`** — link edges from `[text](path)` body links.
-- **`frontmatter`** — edges from frontmatter link-target values, plus the parsed frontmatter block as node metadata.
+- **`frontmatter`** — edges from frontmatter link-target values, plus the parsed frontmatter block as node metadata. Set `keys = ["sources"]` to scope edges to named keys instead of every path-shaped value.
 
 Composition merges the set into one graph, and `drft check` reads it to emit drift findings:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -52,10 +52,17 @@ parser = "frontmatter"
 files = ["**/*.md"]
 ```
 
-| Field    | Required | Default       | Description                                                   |
-| -------- | -------- | ------------- | ------------------------------------------------------------- |
-| `parser` | yes      | —             | How to interpret the files (see [parsers](parsers/README.md)) |
-| `files`  | no       | `["**/*.md"]` | Globs scoping which files the parser reads                    |
+| Field    | Required | Default        | Description                                                        |
+| -------- | -------- | -------------- | ------------------------------------------------------------------ |
+| `parser` | yes      | —              | How to interpret the files (see [parsers](parsers/README.md))      |
+| `files`  | no       | `["**/*.md"]`  | Globs scoping which files the parser reads                         |
+| `keys`   | no       | shape detected | `frontmatter` only — the frontmatter keys whose values yield edges |
+
+`keys` names what the graph tracks, so a path-shaped value under an unrelated key
+(`route: /customers`) is not mistaken for a derivation. Omit it to classify by
+value shape across the whole block. It applies to the `frontmatter` parser only —
+`markdown` has no keyed structure — and declaring it elsewhere, or as an empty
+list, is a config error. See [the frontmatter parser](parsers/frontmatter.md#scoping-to-keys).
 
 These are the only accepted keys. Any other key is a config error naming the key
 and the accepted set. A graph table that parses is read as a graph that works, so

--- a/docs/parsers/frontmatter.md
+++ b/docs/parsers/frontmatter.md
@@ -33,6 +33,23 @@ This means `sources: setup.md` and `sources: ../shared/glossary.md` are detected
 
 Frontmatter that is not well-formed YAML contributes no edges or metadata. drft detects link drift, not YAML validity, so it stays silent on malformed frontmatter rather than reporting it.
 
+### Scoping to keys
+
+Shape detection classifies by value, so any path-shaped value becomes an edge whatever key it sits under. An API route (`route: /customers`) and a glob naming the files a rule governs (`paths: ["api/**"]`) both look like paths and neither is a derivation. Declare `keys` to name the keys that yield edges:
+
+```toml
+[graphs.frontmatter]
+parser = "frontmatter"
+files = ["**/*.md"]
+keys = ["sources"]
+```
+
+Only values reachable through one of those keys become edges. A matched key hands over its whole subtree, so lists and nested maps under `sources:` still yield every path beneath them, and the key is matched at any depth — `meta.sources` is found too. Values under every other key are left alone.
+
+Scoping picks the key; the shape heuristic above still applies within it, so prose under `sources:` is still rejected. `keys` scopes edges only — [metadata](#metadata) always captures the whole block.
+
+Omitting `keys` keeps shape detection over the entire block. Prefer `keys` where the frontmatter carries anything besides derivations: it fixes the false edges without suppressing `unresolved-edge`, which is the only finding that reports a typo'd source. A rule-level `ignore` would silence both.
+
 ## Metadata
 
 The parser attaches the parsed frontmatter block to the file's node. In the composed graph it nests under the graph's `@<name>` namespace — `@frontmatter` for a graph named `frontmatter` — alongside the file's `@fs` facts.
@@ -45,6 +62,7 @@ Declare a graph that uses the frontmatter parser:
 [graphs.frontmatter]
 parser = "frontmatter"
 files = ["**/*.md"]
+keys = ["sources"] # optional
 ```
 
-`files` scopes which files the parser reads (default `["**/*.md"]`). See [configuration](../config.md) for the full graph schema.
+`files` scopes which files the parser reads (default `["**/*.md"]`); `keys` scopes which frontmatter keys yield edges (see [scoping to keys](#scoping-to-keys)). See [configuration](../config.md) for the full graph schema.

--- a/src/builders/frontmatter.rs
+++ b/src/builders/frontmatter.rs
@@ -11,12 +11,19 @@ use crate::parsers::Parser;
 use crate::parsers::frontmatter::FrontmatterParser;
 
 /// Build the `frontmatter` graph fragment from text files, labeled `label`.
-/// `filter` scopes which paths the builder reads (`None` reads all). The
+/// `filter` scopes which paths the builder reads (`None` reads all); `keys`
+/// scopes which frontmatter keys yield edges (`None` uses shape detection). The
 /// fragment carries edges plus a node per file whose frontmatter parses to an
 /// object.
-pub fn build(label: &str, texts: &[(String, String)], filter: Option<GlobSet>) -> Graph {
+pub fn build(
+    label: &str,
+    texts: &[(String, String)],
+    filter: Option<GlobSet>,
+    keys: Option<Vec<String>>,
+) -> Graph {
     let parser = FrontmatterParser {
         file_filter: filter,
+        keys,
     };
     let mut graph = Graph::labeled(label);
 
@@ -56,7 +63,7 @@ mod tests {
             "analysis.md",
             "---\ntitle: Analysis\nstatus: draft\nsources:\n  - ./data/notes.md\n---\n\n# Body\n",
         )]);
-        let graph = build("frontmatter", &t, None);
+        let graph = build("frontmatter", &t, None, None);
         assert_eq!(graph.label.as_deref(), Some("frontmatter"));
 
         let meta = &graph.nodes["analysis.md"].metadata;
@@ -70,7 +77,7 @@ mod tests {
     #[test]
     fn no_node_without_frontmatter() {
         let t = texts(&[("plain.md", "# Just a heading\n")]);
-        let graph = build("frontmatter", &t, None);
+        let graph = build("frontmatter", &t, None, None);
         assert!(graph.nodes.is_empty());
         assert!(graph.edges.is_empty());
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,9 @@ pub enum RuleSeverity {
 pub struct GraphConfig {
     pub files: Vec<String>,
     pub parser: String,
+    /// `frontmatter` only: the keys whose values yield edges. `None` keeps
+    /// shape detection over the whole block.
+    pub keys: Option<Vec<String>>,
 }
 
 /// `deny_unknown_fields` so a key the parser does not support is a hard error
@@ -45,6 +48,7 @@ pub struct GraphConfig {
 struct RawGraph {
     files: Option<Vec<String>>,
     parser: String,
+    keys: Option<Vec<String>>,
 }
 
 // ── Rule config ────────────────────────────────────────────────
@@ -153,6 +157,9 @@ const BUILTIN_RULES: &[&str] = &[
 /// a parser) and is intentionally absent — `parser = "fs"` is rejected.
 const KNOWN_PARSERS: &[&str] = &["markdown", "frontmatter"];
 
+/// Parsers that accept `keys`. Markdown has no keyed structure to scope.
+const PARSERS_WITH_KEYS: &[&str] = &["frontmatter"];
+
 /// Graph names reserved for drft's implicit graphs. Declaring one would collide
 /// with the core `@fs` namespace at compose and overwrite its `type`/`hash`.
 const RESERVED_GRAPH_NAMES: &[&str] = &["fs"];
@@ -206,11 +213,27 @@ impl Config {
                         KNOWN_PARSERS.join(", ")
                     );
                 }
+                // `keys` scopes a keyed structure; only the frontmatter parser has
+                // one. Accepting it elsewhere would reintroduce exactly the silent
+                // no-op that made it unfindable in the first place (#71).
+                if raw.keys.is_some() && !PARSERS_WITH_KEYS.contains(&raw.parser.as_str()) {
+                    anyhow::bail!(
+                        "`keys` is not supported by the \"{}\" parser in graph \"{name}\" (supported: {})",
+                        raw.parser,
+                        PARSERS_WITH_KEYS.join(", ")
+                    );
+                }
+                if raw.keys.as_ref().is_some_and(Vec::is_empty) {
+                    anyhow::bail!(
+                        "`keys` is empty in graph \"{name}\" — the graph would track nothing (omit it for shape detection)"
+                    );
+                }
                 config.graphs.insert(
                     name,
                     GraphConfig {
                         files: raw.files.unwrap_or_else(|| vec![DEFAULT_FILES.to_string()]),
                         parser: raw.parser,
+                        keys: raw.keys,
                     },
                 );
             }
@@ -418,17 +441,77 @@ mod tests {
     #[test]
     fn unknown_graph_key_errors() {
         // A key the parser does not support must not parse and do nothing — the
-        // near-miss spellings (`keys`, `fields`, `include_keys`) are the likely
-        // case, so the error names the key and the accepted set.
+        // near-miss spellings (`fields`, `include_keys`) are the likely case, so
+        // the error names the key and the accepted set.
         let dir = TempDir::new().unwrap();
         fs::write(
             dir.path().join("drft.toml"),
-            "[graphs.x]\nparser = \"frontmatter\"\nkeys = [\"sources\"]\n",
+            "[graphs.x]\nparser = \"frontmatter\"\ninclude_keys = [\"sources\"]\n",
         )
         .unwrap();
         let err = format!("{:#}", Config::load(dir.path()).unwrap_err());
-        assert!(err.contains("unknown field `keys`"), "got: {err}");
+        assert!(err.contains("unknown field `include_keys`"), "got: {err}");
         assert!(err.contains("files"), "expected set not named: {err}");
+    }
+
+    #[test]
+    fn frontmatter_graph_accepts_keys() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("drft.toml"),
+            "[graphs.fm]\nparser = \"frontmatter\"\nkeys = [\"sources\"]\n",
+        )
+        .unwrap();
+        let config = Config::load(dir.path()).unwrap();
+        assert_eq!(
+            config.graphs["fm"].keys.as_deref(),
+            Some(&["sources".to_string()][..])
+        );
+    }
+
+    #[test]
+    fn keys_omitted_is_shape_detection() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("drft.toml"),
+            "[graphs.fm]\nparser = \"frontmatter\"\n",
+        )
+        .unwrap();
+        assert!(
+            Config::load(dir.path()).unwrap().graphs["fm"]
+                .keys
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn keys_on_markdown_parser_errors() {
+        // Markdown has no keyed structure — accepting `keys` there would be the
+        // silent no-op this option exists to remove.
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("drft.toml"),
+            "[graphs.md]\nparser = \"markdown\"\nkeys = [\"sources\"]\n",
+        )
+        .unwrap();
+        let err = format!("{:#}", Config::load(dir.path()).unwrap_err());
+        assert!(
+            err.contains("not supported by the \"markdown\" parser"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn empty_keys_errors() {
+        // `keys = []` would scope the graph to nothing — always a mistake.
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("drft.toml"),
+            "[graphs.fm]\nparser = \"frontmatter\"\nkeys = []\n",
+        )
+        .unwrap();
+        let err = format!("{:#}", Config::load(dir.path()).unwrap_err());
+        assert!(err.contains("track nothing"), "got: {err}");
     }
 
     #[test]

--- a/src/graphs/mod.rs
+++ b/src/graphs/mod.rs
@@ -54,7 +54,12 @@ pub fn build_set(root: &Path, config: &Config) -> Result<GraphSet> {
         let files = compile_globs(&graph.files)?;
         match graph.parser.as_str() {
             "markdown" => graphs.push(builders::markdown::build(name, &texts, files)),
-            "frontmatter" => graphs.push(builders::frontmatter::build(name, &texts, files)),
+            "frontmatter" => graphs.push(builders::frontmatter::build(
+                name,
+                &texts,
+                files,
+                graph.keys.clone(),
+            )),
             // Parser names are validated at config load (`KNOWN_PARSERS`); an
             // unknown parser cannot reach here.
             other => unreachable!("unvalidated parser \"{other}\""),

--- a/src/parsers/frontmatter.rs
+++ b/src/parsers/frontmatter.rs
@@ -109,6 +109,12 @@ fn strip_code(content: &str) -> String {
 pub struct FrontmatterParser {
     /// File routing filter. None = receives all File nodes.
     pub file_filter: Option<globset::GlobSet>,
+    /// Keys whose values yield edges. `None` falls back to shape detection over
+    /// the whole block, which cannot tell a derivation (`sources:`) from a value
+    /// that merely looks like a path (`route: /customers`). Naming the keys lets
+    /// the config say what the graph tracks. Scopes edges only — metadata always
+    /// captures the entire block.
+    pub keys: Option<Vec<String>>,
 }
 
 impl Parser for FrontmatterParser {
@@ -134,7 +140,14 @@ impl Parser for FrontmatterParser {
         };
 
         let mut candidates = Vec::new();
-        collect_links(root, &mut candidates);
+        match &self.keys {
+            Some(keys) => {
+                let wanted: std::collections::HashSet<&str> =
+                    keys.iter().map(String::as_str).collect();
+                collect_scoped(root, &wanted, &mut candidates);
+            }
+            None => collect_links(root, &mut candidates),
+        }
         let links = candidates
             .into_iter()
             .filter(|(value, _)| is_link_candidate(value))
@@ -181,6 +194,37 @@ fn collect_links(node: &MarkedYaml, out: &mut Vec<(String, usize)>) {
             }
         }
         YamlData::Tagged(_, inner) => collect_links(inner, out),
+        _ => {}
+    }
+}
+
+/// Collect scalars reachable only through one of `keys`. A matched key hands its
+/// whole subtree to `collect_links`, so a nested map or list under `sources:`
+/// still yields every path beneath it. Unmatched keys are still descended into,
+/// so a key nested under an unrelated one is found — the key is what scopes the
+/// walk, not its depth. A scalar reached under no matched key yields nothing.
+fn collect_scoped(
+    node: &MarkedYaml,
+    keys: &std::collections::HashSet<&str>,
+    out: &mut Vec<(String, usize)>,
+) {
+    match &node.data {
+        YamlData::Sequence(items) => {
+            for item in items {
+                collect_scoped(item, keys, out);
+            }
+        }
+        YamlData::Mapping(map) => {
+            for (key, value) in map {
+                match &key.data {
+                    YamlData::Value(Scalar::String(k)) if keys.contains(k.as_ref()) => {
+                        collect_links(value, out)
+                    }
+                    _ => collect_scoped(value, keys, out),
+                }
+            }
+        }
+        YamlData::Tagged(_, inner) => collect_scoped(inner, keys, out),
         _ => {}
     }
 }
@@ -232,7 +276,10 @@ mod tests {
     use super::*;
 
     fn parse(content: &str) -> ParseResult {
-        let parser = FrontmatterParser { file_filter: None };
+        let parser = FrontmatterParser {
+            file_filter: None,
+            keys: None,
+        };
         parser.parse("test.md", content)
     }
 
@@ -283,6 +330,86 @@ mod tests {
         assert!(result.metadata.is_none());
     }
 
+    /// Parse with `keys` scoping, returning the edge targets.
+    fn scoped(content: &str, keys: &[&str]) -> Vec<String> {
+        let parser = FrontmatterParser {
+            file_filter: None,
+            keys: Some(keys.iter().map(|k| k.to_string()).collect()),
+        };
+        parser
+            .parse("doc.md", content)
+            .links
+            .into_iter()
+            .map(|l| l.target)
+            .collect()
+    }
+
+    #[test]
+    fn keys_scope_excludes_other_keys() {
+        // The two real collisions from #73: an API route and a rule's glob scope,
+        // both path-shaped, neither a derivation.
+        let content = "---\nsources:\n  - ../src/lib.rs\nroute: /customers\npaths:\n  - \"api/openapi.yaml\"\n---\n";
+        assert_eq!(scoped(content, &["sources"]), vec!["../src/lib.rs"]);
+    }
+
+    #[test]
+    fn keys_scope_takes_whole_subtree() {
+        // A matched key hands its entire subtree over, so nesting under it still
+        // yields every path beneath.
+        let content = "---\nsources:\n  primary:\n    - ../a.rs\n  secondary: ../b.rs\n---\n";
+        let mut got = scoped(content, &["sources"]);
+        got.sort();
+        assert_eq!(got, vec!["../a.rs", "../b.rs"]);
+    }
+
+    #[test]
+    fn keys_scope_finds_nested_key() {
+        // The key scopes the walk, not its depth — `sources` under an unrelated
+        // parent is still found.
+        let content = "---\nmeta:\n  sources:\n    - ../a.rs\n---\n";
+        assert_eq!(scoped(content, &["sources"]), vec!["../a.rs"]);
+    }
+
+    #[test]
+    fn keys_scope_keeps_line_numbers() {
+        let content = "---\ntitle: T\nsources:\n  - ../a.rs\n---\n";
+        let parser = FrontmatterParser {
+            file_filter: None,
+            keys: Some(vec!["sources".to_string()]),
+        };
+        let links = parser.parse("doc.md", content).links;
+        assert_eq!(links[0].line, Some(4));
+    }
+
+    #[test]
+    fn keys_scope_still_shape_filters() {
+        // Scoping picks the key; `is_link_candidate` still rejects prose under it.
+        let content = "---\nsources:\n  - ../a.rs\n  - not a path at all\n---\n";
+        assert_eq!(scoped(content, &["sources"]), vec!["../a.rs"]);
+    }
+
+    #[test]
+    fn keys_scope_leaves_metadata_whole() {
+        // `keys` scopes edges only — the metadata namespace keeps the full block.
+        let content = "---\ntitle: T\nroute: /customers\nsources:\n  - ../a.rs\n---\n";
+        let parser = FrontmatterParser {
+            file_filter: None,
+            keys: Some(vec!["sources".to_string()]),
+        };
+        let meta = parser.parse("doc.md", content).metadata.unwrap();
+        assert_eq!(meta["title"], "T");
+        assert_eq!(meta["route"], "/customers");
+    }
+
+    #[test]
+    fn no_keys_scope_is_shape_detection() {
+        // The default is unchanged: every path-shaped value is a candidate.
+        let content = "---\nroute: /customers\nsources:\n  - ../a.rs\n---\n";
+        let mut got: Vec<String> = parse(content).links.into_iter().map(|l| l.target).collect();
+        got.sort();
+        assert_eq!(got, vec!["../a.rs", "/customers"]);
+    }
+
     #[test]
     fn frontmatter_skips_non_paths() {
         let content = "---\ntitle: My Document\nversion: 1.0\ntags:\n  - rust\n  - cli\n---\n";
@@ -329,7 +456,10 @@ mod tests {
 
     #[test]
     fn no_filter_matches_everything() {
-        let parser = FrontmatterParser { file_filter: None };
+        let parser = FrontmatterParser {
+            file_filter: None,
+            keys: None,
+        };
         assert!(parser.matches("index.md"));
         assert!(parser.matches("main.rs"));
     }
@@ -340,6 +470,7 @@ mod tests {
         builder.add(globset::Glob::new("*.md").unwrap());
         let parser = FrontmatterParser {
             file_filter: Some(builder.build().unwrap()),
+            keys: None,
         };
         assert!(parser.matches("index.md"));
         assert!(!parser.matches("main.rs"));

--- a/tests/parsers.rs
+++ b/tests/parsers.rs
@@ -40,3 +40,39 @@ fn frontmatter_sources_create_edges() {
         "frontmatter dependency should trigger staleness, got: {stdout}"
     );
 }
+
+/// `keys` scoping drops path-shaped values under other keys while keeping the
+/// finding that reports a typo'd source. That combination is the point: the
+/// rule-level `ignore` workaround silences both, so it cannot express this.
+#[test]
+fn frontmatter_keys_scope_edges_without_hiding_broken_sources() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("drft.toml"),
+        "[graphs.frontmatter]\nparser = \"frontmatter\"\nfiles = [\"**/*.md\"]\nkeys = [\"sources\"]\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("real.md"), "# Real").unwrap();
+    // `route` is an API route, not a file — a false edge under shape detection.
+    // `sources` points at a file that does not exist — a genuine broken source.
+    fs::write(
+        dir.path().join("doc.md"),
+        "---\nroute: /customers\nsources:\n  - ./missing.md\n---\n\n# Doc\n",
+    )
+    .unwrap();
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "check"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !stdout.contains("/customers"),
+        "`route` is outside `keys` and must not yield an edge, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("unresolved-edge") && stdout.contains("missing.md"),
+        "a broken `sources` path must still be reported, got: {stdout}"
+    );
+}


### PR DESCRIPTION
Closes #73. **Stacked on #76** — targets `fix/deny-unknown-graph-keys`, so review that first. Retarget to `main` once #76 merges.

The frontmatter parser classified candidates by value shape, so any path-shaped value became an edge whatever key it sat under. `keys` lets the config name what the graph tracks.

```toml
[graphs.frontmatter]
parser = "frontmatter"
files = ["**/*.md"]
keys = ["sources"]
```

## Why not the existing workarounds

Both were available and both are worse:

- A **`files` allowlist** works only when the collision is tree-separable. It is not, in general.
- A **rule-level `ignore`** on `unresolved-edge` silences the false edges *and* a genuinely broken `sources:` path in the same file — and `unresolved-edge` is the only finding that reports a typo'd source.

That second point is the design constraint, so it has an integration test (`frontmatter_keys_scope_edges_without_hiding_broken_sources`). End-to-end on the #73 repro:

```
### WITHOUT keys (shape detection):
warn[unresolved-edge]: .claude/rules/api.md:4 → .claude/rules/api/openapi.yaml
warn[unresolved-edge]: docs/index.md:4 → /customers

### WITH keys = ["sources"]:
  (no unresolved-edge findings)

### a genuinely broken source is STILL caught:
warn[unresolved-edge]: docs/index.md:3 → src/typo.rs
```

## Design calls worth a look

Three decisions the issue left open:

1. **A matched key contributes its whole subtree.** Nested maps and lists under `sources:` still yield every path beneath them.
2. **Keys match at any depth.** `meta.sources` is found, not just top-level `sources`. The key scopes the walk, not its position. The alternative — top-level only — is simpler but silently misses a nested declaration, which is the failure mode this option exists to remove.
3. **`keys` on the `markdown` parser is an error, and so is `keys = []`.** Markdown has no keyed structure, so accepting it would reintroduce the silent no-op #71 just removed. An empty list would scope the graph to nothing.

Say the word if you want any of these to go the other way.

## Compatibility

Omitting `keys` keeps shape detection, so existing configs are unaffected. `keys` scopes edges only — metadata still captures the whole block.

## Verification

- `cargo test` — 173 pass, including 7 parser unit tests (exclusion, whole-subtree, nested key, line numbers preserved, shape filter still applies within a matched key, metadata untouched, default unchanged), 4 config tests, and the integration test above
- `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `dprint fmt` applied
- Docs: a "Scoping to keys" section in `docs/parsers/frontmatter.md`, the graph schema table in `docs/config.md`, the README parser line, and a CHANGELOG entry. The #71 CHANGELOG entry used `keys = ["sources"]` as its example of a bogus option — swapped for `include_keys`, since `keys` is now real.
- `drft.lock` intentionally not regenerated
