### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to drft are documented here.
 
-## Unreleased
+## 0.11.0 (2026-07-30)
+
+Closes the ways drft could report success while tracking nothing: a config that parsed but did nothing, a frontmatter graph that turned any path-shaped value into an edge, and a broken link that named a path nobody wrote.
 
 ### Breaking changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "drft-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drft-cli"
-version = "0.10.0"
+version = "0.11.0"
 categories = ["command-line-utilities", "development-tools"]
 edition = "2024"
 homepage = "https://github.com/johnmdonahue/drft-cli"

--- a/drft.lock
+++ b/drft.lock
@@ -22,7 +22,7 @@ hash = "b3:2a96e992de334b67fe25ad9bfd611a83ee491da2a51160d1ed6344a02b764042"
 
 [[node]]
 path = "CHANGELOG.md"
-hash = "b3:5d0d07dbf36e97a7151f862239d1f372e6915dd29064c5f3c5053f506f39a638"
+hash = "b3:eca2113b1320125cdbe4a1a15238a24816e3d4f27b926b29f283278e8a2081de"
 
 [[node]]
 path = "CLAUDE.md"
@@ -90,7 +90,7 @@ target_hash = "b3:6ce4d5c42026071af2b68201e9debff0112ad9d9d8d8fc75d16d562d5fc1a7
 
 [[node]]
 path = "Cargo.toml"
-hash = "b3:575a5f7fe39ed2343ef541b5702a74097d06d35ebf6b261212a73de3ae6679d5"
+hash = "b3:ea86dd27118321f13aec3b32d4fabd0ad030871998892586d53efdf1404f3811"
 
 [[node]]
 path = "LICENSE"


### PR DESCRIPTION
Releases #71, #72, #73 (merged in #78).

Closes the ways drft could report success while tracking nothing: a config that parsed but did nothing, a frontmatter graph that turned any path-shaped value into an edge, and a broken link that named a path nobody wrote.

## Breaking

**Unknown keys in `drft.toml` are now config errors** (#71). Extra keys in a `[graphs.*]` table, at the top level, or in a `[rules.*]` table were parsed and discarded, so a speculative option exited 0 having done nothing. All three now exit 2, naming the key and the accepted set.

A config carrying a typo'd or aspirational key was already not doing what it said — it now says so. Upgraders with such a key see a hard failure pointing at the line.

## New

- **`keys` scopes the frontmatter graph to named keys** (#73). Omitting it keeps shape detection, so existing configs are unaffected.
- **`unresolved-edge` names a wrong resolution base** (#72), with doc-relative resolution now documented in the README, the frontmatter reference, and the `drft init` template.

## Contents

```
d65a637 docs: releasing needs a lock; refresh drft.lock
dc7ee4e rules: name a wrong resolution base on unresolved-edge
ec35268 frontmatter: scope edges to named keys
11f1790 config: address review — path in rules error, prose fixes
4e7641a config: reject unknown keys in drft.toml
```

`RELEASING.md` also gained the `drft lock` step — `check` is a required status check and both files this PR edits are nodes in drft's own graph, so the release commit fails its own check without it. This PR is the first to follow that.

## Verification

- `cargo test` — 180 pass; clippy and fmt clean
- `drft check` exits 0 with the lock refreshed
- `npm/package.json` left alone — `publish.yml` syncs it from `Cargo.toml` at publish time
