### PR TITLE
impact: default to one hop, spell unbounded --depth all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to drft are documented here.
 
+## Unreleased
+
+### Breaking changes
+
+- **`drft impact` reports one hop by default** (#75). It previously traversed unbounded, which on a repo where docs cross-reference normally returns most of the graph — 21 of 29 nodes for one seed in the reported case. That is not a review list, and an oversized one trains its consumer to skip the output entirely, taking the real finding with it. The default is now `--depth 1`: the files that name the seed directly, each a promise someone wrote down. Every result still carries `radius`, so a wider set is reported without being enumerated. **This is a quiet change** — scripts calling `drft impact` keep working and silently return less. Pass `--depth all` to restore the previous behavior.
+- **`--depth all` spells the full reachable set.** `--depth <n>` still bounds traversal to n hops. `--depth 0` is now a usage error pointing at `all`, rather than being given the maximal meaning — "0" reads as "traverse nothing", and a flag that silently means the opposite of what it says is worse than one that errors.
+
 ## 0.11.0 (2026-07-30)
 
 Closes the ways drft could report success while tracking nothing: a config that parsed but did nothing, a frontmatter graph that turned any path-shaped value into an edge, and a broken link that named a path nobody wrote.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,9 @@ This repo runs drft on itself (`drft.toml` at root). A PreToolUse hook runs `drf
 
 ### Before you start: map the blast radius
 
-**Run `drft impact <files> --format json` on the files you plan to change before writing any code.** This is navigation, not verification. The output shows every file that transitively depends on the files you're about to touch — docs, examples, READMEs that reference the module, configs that name a rule. Use this to build the task list: impacted files are tasks, not afterthoughts. On wide changes (core types, rule renames, config schema), this step prevents a cleanup pass at the end.
+**Run `drft impact <files> --format json` on the files you plan to change before writing any code.** This is navigation, not verification. The output shows the files that name the ones you're about to touch — docs, examples, READMEs that reference the module, configs that name a rule. Use this to build the task list: impacted files are tasks, not afterthoughts. On wide changes (core types, rule renames, config schema), this step prevents a cleanup pass at the end.
+
+`impact` reports one hop by default. Each result carries a `radius` — the count of nodes behind it — so when a hit turns out to restate your change, widen with `--depth <n>`, or `--depth all` for the full reachable set on a rename sweep.
 
 ### During editing: respond to the hook
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ All rules default to `warn`. Override to `error` for CI enforcement or `off` to 
 
 All commands support `--format json`. Run `drft --help` for the full flag reference.
 
+`drft impact` reports the files that name the seed **directly** — one hop. That is
+the question an edit asks: each hit is a promise someone wrote down, so it lands
+a specific thing to check. Every result also carries a `radius`, the count of
+nodes reachable behind it, so a wider set is reported without being enumerated.
+Widen with `--depth <n>` when a hit turns out to restate the change, or
+`--depth all` for the full reachable set — what a rename sweep wants.
+
 ## Configuration
 
 `drft.toml` in the directory root:

--- a/drft.lock
+++ b/drft.lock
@@ -22,11 +22,11 @@ hash = "b3:2a96e992de334b67fe25ad9bfd611a83ee491da2a51160d1ed6344a02b764042"
 
 [[node]]
 path = "CHANGELOG.md"
-hash = "b3:eca2113b1320125cdbe4a1a15238a24816e3d4f27b926b29f283278e8a2081de"
+hash = "b3:7c1881669b52e88ee5583a8d8b76fbd992bb34bd5ffdfbc1e5853555a2834d33"
 
 [[node]]
 path = "CLAUDE.md"
-hash = "b3:4d61d069733ee001dad21c0427b392341ad9a95dc635fec331bebf1b14a2cf0e"
+hash = "b3:6d90954b99b54d30c16cad82217ea66432d7f6bf4f97b40920eb42cb8729e019"
 
 [[node.edge]]
 target = "RELEASING.md"
@@ -98,11 +98,11 @@ hash = "b3:871c2fd5cdfe89fa6ff01664a1420bf40d0ab18c0e250e59a3ab27225f31bb0e"
 
 [[node]]
 path = "README.md"
-hash = "b3:4d8528858aa9912b675205e0a0cbae24f7f0a8434e2efd0b3b37797a9b27596e"
+hash = "b3:772bc46594c3b43393bf5857e2c3579ff6e3cd5d6f56da0f840f7d4708eb6630"
 
 [[node.edge]]
 target = "CLAUDE.md"
-target_hash = "b3:4d61d069733ee001dad21c0427b392341ad9a95dc635fec331bebf1b14a2cf0e"
+target_hash = "b3:6d90954b99b54d30c16cad82217ea66432d7f6bf4f97b40920eb42cb8729e019"
 
 [[node.edge]]
 target = "docs/README.md"
@@ -157,7 +157,7 @@ target_hash = "b3:4f5a8674c50acec2e9478309e1b770aef880c99adec628e967ebce5153ebcb
 
 [[node.edge]]
 target = "src/cli.rs"
-target_hash = "b3:db5461193c01bd415b648451637b71a62ba28d41aeb456d90ae95744851c1783"
+target_hash = "b3:04799134c71b1faaa9201f84e59119d5cab9d265225cf2d0fc3e369bd0c324c6"
 
 [[node.edge]]
 target = "src/config.rs"
@@ -268,7 +268,7 @@ hash = "b3:f56fdcddee36a2cc7c9c55b619b80c0571ca85e89334e06741b157d4315d84d4"
 
 [[node]]
 path = "src/cli.rs"
-hash = "b3:db5461193c01bd415b648451637b71a62ba28d41aeb456d90ae95744851c1783"
+hash = "b3:04799134c71b1faaa9201f84e59119d5cab9d265225cf2d0fc3e369bd0c324c6"
 
 [[node]]
 path = "src/compose.rs"
@@ -300,7 +300,7 @@ hash = "b3:b437206e0e16ea1a0643edda5d8b1ab7361816bb42222bc80e488e13329b0516"
 
 [[node]]
 path = "src/main.rs"
-hash = "b3:ecb649d5a89b41cc981d4deab0717c0cf902891bd3675b9d6ce2de8b25d6d524"
+hash = "b3:e78c039e5a3203783434034630d66bae9c3aa6f19519390a7b6989cbe68362b8"
 
 [[node]]
 path = "src/model.rs"
@@ -360,7 +360,7 @@ hash = "b3:317ec95915031ee51e9bcd86da06b439d120fd13ef29509e02fe668fd4fbb2f5"
 
 [[node]]
 path = "tests/impact.rs"
-hash = "b3:e7d14f79bc3263af193d7744bbfb1bd65017788e97f764586ef5f4a3c3bd3408"
+hash = "b3:243dec1ecf1ac18d8ae70c074dc272fbc9ad2b60714807a0c7bd0f8dc2801e2d"
 
 [[node]]
 path = "tests/init.rs"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,9 +48,9 @@ pub enum Commands {
         #[arg(required = true)]
         paths: Vec<String>,
 
-        /// Limit traversal to this many hops
-        #[arg(long)]
-        depth: Option<usize>,
+        /// How many hops to traverse, or `all` for the full reachable set
+        #[arg(long, default_value = "1")]
+        depth: Depth,
 
         /// Traversal direction
         #[arg(long, default_value = "inbound")]
@@ -79,4 +79,79 @@ pub enum ColorChoice {
     Auto,
     Always,
     Never,
+}
+
+/// How far `impact` walks. Defaults to one hop: the files that name the seed
+/// directly, each of which is a promise someone wrote down. The full reachable
+/// set answers a graph-theory question rather than the one asked at an edit, so
+/// it has to be requested by name.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Depth {
+    All,
+    Hops(usize),
+}
+
+impl Depth {
+    /// The traversal bound: `None` is unbounded.
+    pub fn max_hops(self) -> Option<usize> {
+        match self {
+            Depth::All => None,
+            Depth::Hops(n) => Some(n),
+        }
+    }
+}
+
+impl std::str::FromStr for Depth {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.eq_ignore_ascii_case("all") {
+            return Ok(Depth::All);
+        }
+        match s.parse::<usize>() {
+            // `0` reads as "no traversal", so it must not quietly mean the
+            // opposite. Point at the spelling that does mean everything.
+            Ok(0) => Err(
+                "depth 0 would traverse nothing; use `--depth all` for the full reachable set"
+                    .into(),
+            ),
+            Ok(n) => Ok(Depth::Hops(n)),
+            Err(_) => Err(format!(
+                "invalid depth `{s}` (expected a positive number or `all`)"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn depth_parses_hops_and_all() {
+        assert_eq!(Depth::from_str("1").unwrap(), Depth::Hops(1));
+        assert_eq!(Depth::from_str("3").unwrap(), Depth::Hops(3));
+        assert_eq!(Depth::from_str("all").unwrap(), Depth::All);
+        assert_eq!(Depth::from_str("ALL").unwrap(), Depth::All);
+    }
+
+    #[test]
+    fn depth_zero_is_rejected_with_a_pointer_to_all() {
+        // `0` reads as "no traversal"; it must not silently mean the opposite.
+        let err = Depth::from_str("0").unwrap_err();
+        assert!(err.contains("--depth all"), "got: {err}");
+    }
+
+    #[test]
+    fn depth_rejects_nonsense() {
+        assert!(Depth::from_str("banana").is_err());
+        assert!(Depth::from_str("-1").is_err());
+    }
+
+    #[test]
+    fn max_hops_maps_all_to_unbounded() {
+        assert_eq!(Depth::All.max_hops(), None);
+        assert_eq!(Depth::Hops(2).max_hops(), Some(2));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use std::path::Path;
 
-use cli::{Cli, ColorChoice, Commands, Direction, OutputFormat};
+use cli::{Cli, ColorChoice, Commands, Depth, Direction, OutputFormat};
 use config::{Config, RuleSeverity};
 
 fn use_color(choice: ColorChoice, format: OutputFormat) -> bool {
@@ -252,7 +252,7 @@ fn run_impact(
     root: &Path,
     format: OutputFormat,
     paths: &[String],
-    depth: Option<usize>,
+    depth: Depth,
     direction: Direction,
 ) -> Result<i32> {
     let graph_root = find_graph_root(root);
@@ -269,7 +269,7 @@ fn run_impact(
         Direction::Outbound => impact::Direction::Outbound,
         Direction::Both => impact::Direction::Both,
     };
-    let impacted = impact::compute(&composed, &seeds, dir, depth);
+    let impacted = impact::compute(&composed, &seeds, dir, depth.max_hops());
 
     match format {
         OutputFormat::Json => {

--- a/tests/impact.rs
+++ b/tests/impact.rs
@@ -11,8 +11,16 @@ fn impact_shows_transitive_dependents() {
     fs::write(dir.path().join("setup.md"), "[config](config.md)").unwrap();
     fs::write(dir.path().join("config.md"), "# Config").unwrap();
 
+    // Transitive reach is `--depth all` now that the default is one hop.
     let output = drft_bin()
-        .args(["-C", dir.path().to_str().unwrap(), "impact", "config.md"])
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "impact",
+            "config.md",
+            "--depth",
+            "all",
+        ])
         .output()
         .unwrap();
 
@@ -23,6 +31,59 @@ fn impact_shows_transitive_dependents() {
         "index.md transitively depends on config.md"
     );
     assert!(output.status.success());
+}
+
+#[test]
+fn impact_defaults_to_one_hop() {
+    // The question asked at an edit is "what names this file directly" — each hit
+    // a promise someone wrote down. `index.md` sits a hop further back and is
+    // reported only by its radius, not enumerated.
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("index.md"), "[setup](setup.md)").unwrap();
+    fs::write(dir.path().join("setup.md"), "[config](config.md)").unwrap();
+    fs::write(dir.path().join("config.md"), "# Config").unwrap();
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "impact", "config.md"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("setup.md"),
+        "direct dependent, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("index.md"),
+        "depth-2 node should not be enumerated by default, got: {stdout}"
+    );
+    // The wider set is still signalled rather than hidden.
+    assert!(stdout.contains("radius"), "got: {stdout}");
+    assert!(output.status.success());
+}
+
+#[test]
+fn impact_depth_zero_is_a_usage_error() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("index.md"), "# Index").unwrap();
+
+    let output = drft_bin()
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "impact",
+            "index.md",
+            "--depth",
+            "0",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2), "usage errors exit 2");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--depth all"), "got: {stderr}");
 }
 
 #[test]


### PR DESCRIPTION
Closes #75.

Implements the issue's asks 1 and 3. Ask 2 was already shipped — `impact_radius` has been in the text formatter all along, as the reporter's own follow-up confirmed.

## Ask 1 — default to one hop

Unbounded traversal returns most of the graph on any repo where docs cross-reference normally: 21 of 29 nodes for one seed in the reported case. That is not a review list.

The habituation argument is what makes this worth a breaking change. An oversized result is worse than a narrow one — it teaches its consumer the output is skippable, and the one real finding gets skipped with the rest. Narrowing too far is recoverable with a flag; a default that trains people to ignore it is not.

Depth 1 is also the conceptually right number, not just a smaller one. "Files that name this seed directly" is a set with a meaning — each hit is a promise someone wrote down, so a change lands a specific thing to check. Depth 2 has no such story.

`radius` still rides every result, so a wider set is reported without being enumerated.

## Ask 3 — `--depth all`

The issue offered `--depth 0` **or** `--depth all`. **I rejected `--depth 0`.**

"0" reads as "traverse nothing." Giving it the maximal meaning is a trap: a user who types `--depth 0` expecting an empty result gets the entire graph. It is now a usage error that points at the right spelling:

```
$ drft impact src/config.rs --depth 0
error: invalid value '0' for '--depth <DEPTH>': depth 0 would traverse nothing;
       use `--depth all` for the full reachable set
```

Exit 2, matching the repo's usage-error convention.

## Breaking, and quietly so

Worth stating plainly, because it differs from the last release's break. #71 fails loudly — exit 2, names the key. This one is silent: scripts calling `drft impact` keep working and return less, with no error. That is the worse kind of change, so it is called out in the CHANGELOG as such rather than as a line item, and `--depth all` restores the previous behavior exactly.

## Docs

- `CLAUDE.md` said the output "shows every file that transitively depends" and told the agent to build a task list from it — the sentence the default change most directly falsifies. Rewritten, with the widening guidance added.
- `README.md` gained a paragraph on why one hop, what `radius` signals, and when to widen.
- `--help` now reads `How many hops to traverse, or \`all\` for the full reachable set [default: 1]`.

## Verification

- `cargo test` — 186 pass. New: four `Depth` parse tests, plus integration tests that the default stops at one hop while still printing `radius`, and that `--depth 0` exits 2 naming `all`.
- `impact_shows_transitive_dependents` now passes `--depth all` — it tests transitive reach, which is exactly what moved. That test flipping is the behavior change, visible in the diff.
- `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `dprint fmt` applied
- `drft.lock` intentionally not regenerated
