### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to drft are documented here.
 
-## Unreleased
+## 0.12.0 (2026-07-30)
+
+Makes `drft impact` answer the question an edit actually asks. The output is a review list now, not a reachability dump.
 
 ### Breaking changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "drft-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drft-cli"
-version = "0.11.0"
+version = "0.12.0"
 categories = ["command-line-utilities", "development-tools"]
 edition = "2024"
 homepage = "https://github.com/johnmdonahue/drft-cli"

--- a/drft.lock
+++ b/drft.lock
@@ -22,7 +22,7 @@ hash = "b3:2a96e992de334b67fe25ad9bfd611a83ee491da2a51160d1ed6344a02b764042"
 
 [[node]]
 path = "CHANGELOG.md"
-hash = "b3:7c1881669b52e88ee5583a8d8b76fbd992bb34bd5ffdfbc1e5853555a2834d33"
+hash = "b3:a5e303f9b5387c6278f0819d81302166cc82a5221b4c6c66b01f29d47e678104"
 
 [[node]]
 path = "CLAUDE.md"
@@ -90,7 +90,7 @@ target_hash = "b3:6ce4d5c42026071af2b68201e9debff0112ad9d9d8d8fc75d16d562d5fc1a7
 
 [[node]]
 path = "Cargo.toml"
-hash = "b3:ea86dd27118321f13aec3b32d4fabd0ad030871998892586d53efdf1404f3811"
+hash = "b3:a9b2c945015c58a0aa655e52c76c08bf3adfb04dc13b76fb9fbb41923bb71b10"
 
 [[node]]
 path = "LICENSE"


### PR DESCRIPTION
Releases #75 (merged in #80).

Makes `drft impact` answer the question an edit actually asks. The output is a review list now, not a reachability dump.

## Breaking

**`drft impact` reports one hop by default.** It previously traversed unbounded, returning most of the graph on any repo where docs cross-reference normally — 21 of 29 nodes for one seed in the reported case. The default is now `--depth 1`: the files that name the seed directly, each a promise someone wrote down.

**This break is quiet.** Scripts calling `drft impact` keep working and silently return less, with no error — unlike 0.11.0's unknown-key change, which fails loudly at exit 2. `--depth all` restores the previous behavior exactly. Every result still carries `radius`, so a wider set is reported without being enumerated.

**`--depth all` spells the full reachable set.** `--depth 0` is a usage error pointing at `all` rather than a synonym for it — "0" reads as "traverse nothing", and a flag that silently means the opposite of what it says is worse than one that errors.

## Upgrade note

Anyone running `drft impact` from a hook or script gets a narrower result set after upgrading. That is the intent, but it is worth knowing before it happens rather than after. The drft skill pins `--depth 1` explicitly for this reason — correct on every version, before and after this release.

## Verification

- `cargo test` — 186 pass; clippy and fmt clean
- `drft check` exits 0 with the lock refreshed
- `npm/package.json` left alone — `publish.yml` syncs it from `Cargo.toml` at publish time
- Follows the `drft lock` step added to RELEASING.md in 0.11.0
