### PR TITLE
lock: accept several paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to drft are documented here.
 
+## Unreleased
+
+### New
+
+- **`drft lock` accepts several paths.** `drft lock a.md b.md` locks exactly those nodes and their outbound edges, merging into the existing lockfile; with no arguments it still snapshots the whole graph. A lock asserts the locked state was reviewed, and the scoped form is what keeps that assertion narrow enough to be true — a bulk lock also clears staleness nobody looked at, including work another person has in flight. Accepting one path at a time pushed callers toward the bulk form for any multi-file change, which is the case where scoping matters most. Every path resolves before anything is written, so an unresolvable path fails the command (exit 2) rather than leaving a partial lock behind.
+
 ## 0.12.0 (2026-07-30)
 
 Makes `drft impact` answer the question an edit actually asks. The output is a review list now, not a reachability dump.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,13 @@ This repo runs drft on itself (`drft.toml` at root). A PreToolUse hook runs `drf
 
 Do not suppress warnings by removing links, ignoring paths, or disabling rules — fix the root cause (create missing files, fix broken references, restructure links).
 
-**Never run `drft lock` unless the user explicitly asks.** Locking acknowledges that the current state has been reviewed — it is the user's decision, not the agent's. Running lock unprompted clears staleness signals the user may want to inspect. If you believe a lock is warranted, say so and let the user decide.
+**Lock only what you reviewed, by name.** A lock asserts the locked state was read and is correct, so the assertion has to stay narrow enough to be true:
 
-The workflow: impact upfront → plan includes dependents → edit → hook fires → review impacts inline → user runs `drft lock` when satisfied → commit.
+- **You may** run `drft lock <path>...` for paths you edited this session, once you have reviewed their impacted dependents. Name every path.
+- **Never run bare `drft lock`.** It clears staleness across the whole graph, including files you never opened and work someone else has in flight. That launders an unreviewed state into a reviewed one, and the record that it was never read is gone.
+- **Never lock staleness you did not cause.** If `drft check` reports findings you cannot account for, stop and say so — those are the user's to inspect.
+
+The workflow: impact upfront → plan includes dependents → edit → hook fires → review impacts inline → `drft lock <the files you touched>` → commit.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ All rules default to `warn`. Override to `error` for CI enforcement or `off` to 
 | `drft check`  | Compare the graph against the lockfile for drift            |
 | `drft lock`   | Snapshot hashes to `drft.lock` for staleness tracking       |
 
+`drft lock` with no argument snapshots the whole graph. Given paths — `drft lock
+src/lib.rs docs/guide.md` — it locks only those nodes and their outbound edges,
+merging into the existing lockfile. A lock asserts the locked state was reviewed,
+so scope it to what you actually read: a bulk lock also clears staleness you
+never looked at, including someone else's unfinished work. Paths all resolve
+before anything is written, so a typo fails the command rather than leaving a
+partial lock behind.
+
 All commands support `--format json`. Run `drft --help` for the full flag reference.
 
 `drft impact` reports the files that name the seed **directly** — one hop. That is

--- a/drft.lock
+++ b/drft.lock
@@ -22,11 +22,11 @@ hash = "b3:2a96e992de334b67fe25ad9bfd611a83ee491da2a51160d1ed6344a02b764042"
 
 [[node]]
 path = "CHANGELOG.md"
-hash = "b3:a5e303f9b5387c6278f0819d81302166cc82a5221b4c6c66b01f29d47e678104"
+hash = "b3:8020e554ce5b60f7611118db05e56766159767abcc22b5dcd04d1505aa07e552"
 
 [[node]]
 path = "CLAUDE.md"
-hash = "b3:6d90954b99b54d30c16cad82217ea66432d7f6bf4f97b40920eb42cb8729e019"
+hash = "b3:7283050e7e63d10a05532abc97b0dbba0cdbfcb1deaed9c2dd651ffc8e8c4a69"
 
 [[node.edge]]
 target = "RELEASING.md"
@@ -98,11 +98,11 @@ hash = "b3:871c2fd5cdfe89fa6ff01664a1420bf40d0ab18c0e250e59a3ab27225f31bb0e"
 
 [[node]]
 path = "README.md"
-hash = "b3:772bc46594c3b43393bf5857e2c3579ff6e3cd5d6f56da0f840f7d4708eb6630"
+hash = "b3:ca38d7ba3882ce9e2aee9678932862967cf9a3497b0ee1d79ec0aea6ef3def22"
 
 [[node.edge]]
 target = "CLAUDE.md"
-target_hash = "b3:6d90954b99b54d30c16cad82217ea66432d7f6bf4f97b40920eb42cb8729e019"
+target_hash = "b3:7283050e7e63d10a05532abc97b0dbba0cdbfcb1deaed9c2dd651ffc8e8c4a69"
 
 [[node.edge]]
 target = "docs/README.md"
@@ -157,7 +157,7 @@ target_hash = "b3:4f5a8674c50acec2e9478309e1b770aef880c99adec628e967ebce5153ebcb
 
 [[node.edge]]
 target = "src/cli.rs"
-target_hash = "b3:04799134c71b1faaa9201f84e59119d5cab9d265225cf2d0fc3e369bd0c324c6"
+target_hash = "b3:d23b0f8d5686a9f340a4129384bac66abb10a8b5a6a12eabee05a409bf83907b"
 
 [[node.edge]]
 target = "src/config.rs"
@@ -268,7 +268,7 @@ hash = "b3:f56fdcddee36a2cc7c9c55b619b80c0571ca85e89334e06741b157d4315d84d4"
 
 [[node]]
 path = "src/cli.rs"
-hash = "b3:04799134c71b1faaa9201f84e59119d5cab9d265225cf2d0fc3e369bd0c324c6"
+hash = "b3:d23b0f8d5686a9f340a4129384bac66abb10a8b5a6a12eabee05a409bf83907b"
 
 [[node]]
 path = "src/compose.rs"
@@ -300,7 +300,7 @@ hash = "b3:b437206e0e16ea1a0643edda5d8b1ab7361816bb42222bc80e488e13329b0516"
 
 [[node]]
 path = "src/main.rs"
-hash = "b3:e78c039e5a3203783434034630d66bae9c3aa6f19519390a7b6989cbe68362b8"
+hash = "b3:297802b051fbd298663b74c0bfd217ba91ad11120d3df519eea680e1176659a7"
 
 [[node]]
 path = "src/model.rs"
@@ -368,7 +368,7 @@ hash = "b3:dc15abb7afc8314627fd1346ade4e129ad9796ddcbab651d82f342c15db03dfc"
 
 [[node]]
 path = "tests/lock.rs"
-hash = "b3:22b82141d34cc27e43b12d063c076c4334e773a02b7a6d87901e804b19b5c73f"
+hash = "b3:0038a8b5130180edccaa42ea447a03352eee911cef76bcbbea2e96179417e5e7"
 
 [[node]]
 path = "tests/output.rs"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,8 +31,8 @@ pub enum Commands {
 
     /// Snapshot the current state to drft.lock
     Lock {
-        /// Lock only this path and its outbound edges (default: lock the whole graph)
-        path: Option<String>,
+        /// Lock only these paths and their outbound edges (default: lock the whole graph)
+        paths: Vec<String>,
     },
 
     /// Export the dependency graph as composed JGF

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn try_main() -> Result<i32> {
 
     match &cli.command {
         Commands::Init => run_init(&root),
-        Commands::Lock { path } => run_lock(&root, path.as_deref()),
+        Commands::Lock { paths } => run_lock(&root, paths),
         Commands::Impact {
             paths,
             depth,
@@ -124,29 +124,42 @@ files = ["**/*.md"]
 }
 
 /// Snapshot the composed graph into `drft.lock`: node content hashes and each
-/// node's outbound edge target hashes. With a path, lock only that node (its
-/// bytes and its outbound edge targets), merging into the existing lockfile.
-fn run_lock(root: &Path, path: Option<&str>) -> Result<i32> {
+/// node's outbound edge target hashes. With paths, lock only those nodes (their
+/// bytes and their outbound edge targets), merging into the existing lockfile.
+///
+/// A lock is an assertion that the locked state was reviewed, so the scoped form
+/// exists to make that assertion narrow enough to be true — lock what you read,
+/// not whatever happens to be stale.
+fn run_lock(root: &Path, paths: &[String]) -> Result<i32> {
     let graph_root = find_graph_root(root);
     let config = Config::load(&graph_root)?;
     let set = graphs::build_set(&graph_root, &config)?;
     let composed = compose::compose(&set);
     let snapshot = lock::Lock::from_composed(&composed);
 
-    match path {
-        None => lock::write(&graph_root, &snapshot)?,
-        Some(path) => {
-            let node = resolve_node(&composed, root, &graph_root, path)?;
-            let mut existing = lock::read(&graph_root)?.unwrap_or_default();
-            let entry = snapshot
-                .nodes
-                .get(&node)
-                .expect("resolved node is in the snapshot")
-                .clone();
-            existing.nodes.insert(node, entry);
-            lock::write(&graph_root, &existing)?;
-        }
+    if paths.is_empty() {
+        lock::write(&graph_root, &snapshot)?;
+        return Ok(0);
     }
+
+    // Resolve every path before writing any of them. A typo in the third of five
+    // must not leave the first two locked: a partial lock claims some files were
+    // reviewed and drops the rest without saying so, which is worse than failing.
+    let nodes = paths
+        .iter()
+        .map(|p| resolve_node(&composed, root, &graph_root, p))
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut existing = lock::read(&graph_root)?.unwrap_or_default();
+    for node in nodes {
+        let entry = snapshot
+            .nodes
+            .get(&node)
+            .expect("resolved node is in the snapshot")
+            .clone();
+        existing.nodes.insert(node, entry);
+    }
+    lock::write(&graph_root, &existing)?;
     Ok(0)
 }
 

--- a/tests/lock.rs
+++ b/tests/lock.rs
@@ -118,3 +118,67 @@ fn deleted_file_reports_unresolved_and_removed_node() {
         "expected removed-node, got: {stdout}"
     );
 }
+
+/// Several paths lock in one invocation, leaving everything else stale. The
+/// scoped form exists so the assertion "this was reviewed" stays narrow enough
+/// to be true, and one-path-per-invocation pushed callers toward the bulk form.
+#[test]
+fn scoped_lock_accepts_several_paths() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    for name in ["a", "b", "c"] {
+        fs::write(dir.path().join(format!("{name}.md")), format!("# {name}")).unwrap();
+    }
+    lock(dir.path());
+
+    for name in ["a", "b", "c"] {
+        fs::write(
+            dir.path().join(format!("{name}.md")),
+            format!("# {name} edited"),
+        )
+        .unwrap();
+    }
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "lock", "a.md", "b.md"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let stdout = check(dir.path());
+    assert!(!stdout.contains("stale-node]: a.md"), "got: {stdout}");
+    assert!(!stdout.contains("stale-node]: b.md"), "got: {stdout}");
+    assert!(
+        stdout.contains("stale-node]: c.md"),
+        "c.md was not named and must stay stale, got: {stdout}"
+    );
+}
+
+/// Every path resolves before any is written. A partial lock would claim some
+/// files were reviewed and drop the rest without saying so.
+#[test]
+fn scoped_lock_writes_nothing_when_a_path_is_unresolvable() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("a.md"), "# a").unwrap();
+    lock(dir.path());
+    fs::write(dir.path().join("a.md"), "# a edited").unwrap();
+
+    let output = drft_bin()
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "lock",
+            "a.md",
+            "typo.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2), "unresolvable path exits 2");
+    let stdout = check(dir.path());
+    assert!(
+        stdout.contains("stale-node]: a.md"),
+        "a.md must not be locked when a later path fails, got: {stdout}"
+    );
+}


### PR DESCRIPTION
Makes the safe form of `drft lock` the ergonomic one, so the guidance around it can stop being a blanket prohibition.

## Why

A lock asserts the locked state was reviewed. That assertion is only honest if it is scoped to what someone actually read — and `drft lock` took a single optional path, so any multi-file change meant N invocations. Callers reached for bare `drft lock` instead, in exactly the case where scoping matters most.

The hazard is concrete. In a repo with work in flight, `drft check` mixes staleness from several sources:

```
error[stale-node]: skills/pr/SKILL.md        ← someone else's unfinished work
error[stale-node]: skills/pr/methodology.md  ← someone else's unfinished work
error[stale-node]: .claude/settings.json     ← mine
error[stale-node]: skills/drft/rule.md       ← mine
```

A bulk lock there declares all four reviewed. Two of them nobody opened, and the record that they were never read is gone.

## What changed

```
drft lock                      # whole graph, unchanged
drft lock a.md b.md src/lib.rs # exactly these nodes and their outbound edges
```

**Paths all resolve before anything is written.** A typo in the third of five fails the command at exit 2 rather than leaving the first two locked — a partial lock claims some files were reviewed and drops the rest without saying so.

## Guidance

This repo's `CLAUDE.md` moves from "never run `drft lock`" to a scoped rule:

- **May** `drft lock <path>...` for paths edited this session, after reviewing their dependents
- **Never** bare `drft lock` — it launders unreviewed state
- **Never** lock staleness you did not cause; stop and say so

The blanket ban was protecting something real, but naming the wrong thing. It cost a hard stop on every mechanical change — bumping `Cargo.toml` during a release makes it stale, and locking that asserts arithmetic, not a reading. Meanwhile it did nothing about the actual hazard, since "the human approves a bulk lock" is how the dangerous case happens too.

**The skill's copies of this rule are deliberately unchanged.** `skills/drft/rule.md` and `SKILL.md` install into repos running whatever drft version they have, where `drft lock a b` is a usage error until this ships. They follow after release — the same version-coupling care as `--depth 1` in 0.12.0.

## Not breaking

`drft lock` and `drft lock <path>` both behave exactly as before. Additive, so 0.13.0.

## Verification

- `cargo test` — 188 pass. New: multi-path locking leaves unnamed nodes stale, and an unresolvable path writes nothing.
- `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `dprint fmt` applied
- Verified end-to-end: `lock a.md b.md` leaves `c.md`/`d.md` stale; `lock c.md nope.md` exits 2 with `c.md` still stale
- `docs/config.md` is the only dependent of the changed files; its sole lock claim ("drft excludes its own `drft.lock` from the graph") is unaffected
