### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to drft are documented here.
 
-## Unreleased
+## 0.13.0 (2026-07-30)
+
+Makes the honest form of `drft lock` the convenient one, so agent guidance can scope the lock rather than ban it.
 
 ### New
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "drft-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drft-cli"
-version = "0.12.0"
+version = "0.13.0"
 categories = ["command-line-utilities", "development-tools"]
 edition = "2024"
 homepage = "https://github.com/johnmdonahue/drft-cli"

--- a/drft.lock
+++ b/drft.lock
@@ -22,7 +22,7 @@ hash = "b3:2a96e992de334b67fe25ad9bfd611a83ee491da2a51160d1ed6344a02b764042"
 
 [[node]]
 path = "CHANGELOG.md"
-hash = "b3:8020e554ce5b60f7611118db05e56766159767abcc22b5dcd04d1505aa07e552"
+hash = "b3:e618e0bd862d56006bd5eadd1ee0f7b1d3c91edd70a7e02b3cb6c21f7d2f1cbb"
 
 [[node]]
 path = "CLAUDE.md"
@@ -90,7 +90,7 @@ target_hash = "b3:6ce4d5c42026071af2b68201e9debff0112ad9d9d8d8fc75d16d562d5fc1a7
 
 [[node]]
 path = "Cargo.toml"
-hash = "b3:a9b2c945015c58a0aa655e52c76c08bf3adfb04dc13b76fb9fbb41923bb71b10"
+hash = "b3:6999c4af4db67a6f5a4c59cdb90d8d493bb33927ddeb6a5217bcc411d9505f50"
 
 [[node]]
 path = "LICENSE"


### PR DESCRIPTION
Releases the variadic `drft lock` from #82.

Makes the honest form of `drft lock` the convenient one, so agent guidance can scope the lock rather than ban it.

## New

**`drft lock` accepts several paths.** `drft lock a.md b.md` locks exactly those nodes and their outbound edges; with no arguments it still snapshots the whole graph. Every path resolves before anything is written, so an unresolvable path fails the command rather than leaving a partial lock behind.

Additive — both existing forms are unchanged.

## Why it unblocks the guidance

A lock asserts the locked state was reviewed. Scoping keeps that assertion true, but one-path-per-invocation meant any multi-file change took N calls, so callers reached for the bulk form in exactly the case where scoping matters most.

With the list form available, the agent rule moves from "never run `drft lock`" to "lock what you read, by name; never bare." `CLAUDE.md` in this repo already moved in #82. The skill's copies were held back because they install into repos on whatever version is present — `drft lock a b` is a usage error before this release. They can follow once this ships.

## The property that makes it self-enforcing

An edge's recorded target hash lives on the file that declared the link, so locking a changed source clears its own `stale-node` and leaves every inbound `stale-edge` standing. Those clear only when the dependent is locked — the file whose promise someone actually checked. Verified:

```
edit src.md   → stale-node: src.md  +  stale-edge: doc.md → src.md
lock src.md   → stale-node clears,     stale-edge PERSISTS
lock doc.md   → clean
```

Scoped locking cannot be used to wave off the review it exists to record.

## Verification

- `cargo test` — 188 pass; clippy and fmt clean
- `drft check` exits 0
- Locked with `drft lock Cargo.toml CHANGELOG.md` — the first use of the new rule, and the case the old blanket ban charged a round trip for: two files, no dependents, nothing to read
- `npm/package.json` left alone — `publish.yml` syncs it at publish time
