### PR TITLE
docs: carve out baseline regeneration in the lock rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,12 @@ Do not suppress warnings by removing links, ignoring paths, or disabling rules �
 - **Never run bare `drft lock`.** It clears staleness across the whole graph, including files you never opened and work someone else has in flight. That launders an unreviewed state into a reviewed one, and the record that it was never read is gone.
 - **Never lock staleness you did not cause.** If `drft check` reports findings you cannot account for, stop and say so — those are the user's to inspect.
 
+The one bare lock that is correct is **regenerating a baseline**: no `drft.lock` exists, or a release requires every lockfile to be rewritten (0.8.0, 0.9.0, and 0.10.0 each did). There is no prior baseline to preserve, so nothing is being laundered. Ask first, and say that is what you are doing — it is the call the rule otherwise forbids.
+
+**A `stale-edge` clears from the declaring side.** An edge's recorded target hash lives on the file that wrote the link, so locking a changed source clears its own `stale-node` and leaves every inbound `stale-edge` standing. Those clear when you lock the dependent — the file whose promise you actually checked. Scoped locking therefore cannot wave off the review it exists to record.
+
+A file with **no dependents** has no promise to check. Its staleness is bookkeeping — lock it and move on.
+
 The workflow: impact upfront → plan includes dependents → edit → hook fires → review impacts inline → `drft lock <the files you touched>` → commit.
 
 ## Architecture

--- a/drft.lock
+++ b/drft.lock
@@ -26,7 +26,7 @@ hash = "b3:e618e0bd862d56006bd5eadd1ee0f7b1d3c91edd70a7e02b3cb6c21f7d2f1cbb"
 
 [[node]]
 path = "CLAUDE.md"
-hash = "b3:7283050e7e63d10a05532abc97b0dbba0cdbfcb1deaed9c2dd651ffc8e8c4a69"
+hash = "b3:0608a5e5ab70aa73b528d4a3402b712df92ca9913231a76046aa2e815474e8b7"
 
 [[node.edge]]
 target = "RELEASING.md"
@@ -102,7 +102,7 @@ hash = "b3:ca38d7ba3882ce9e2aee9678932862967cf9a3497b0ee1d79ec0aea6ef3def22"
 
 [[node.edge]]
 target = "CLAUDE.md"
-target_hash = "b3:7283050e7e63d10a05532abc97b0dbba0cdbfcb1deaed9c2dd651ffc8e8c4a69"
+target_hash = "b3:0608a5e5ab70aa73b528d4a3402b712df92ca9913231a76046aa2e815474e8b7"
 
 [[node.edge]]
 target = "docs/README.md"


### PR DESCRIPTION
Follow-up to #82, closing a gap in the scoped-lock rule and recording the property that makes it hold.

## The gap

#82 replaced "never run `drft lock`" with a scoped rule, but kept the bare form forbidden with no exception. That is wrong in one case: **regenerating a baseline.** When no `drft.lock` exists, or a release rewrites every lockfile, there is no prior baseline to preserve — nothing is being laundered because there is nothing to launder.

That is not hypothetical here. Three releases instruct exactly this:

- 0.8.0 — "Old lockfiles report as unparseable and point at `drft lock` to regenerate"
- 0.9.0 — "Lockfiles that recorded symlink hashes regenerate with `drft lock`"
- 0.10.0 — "Lockfiles regenerate with `drft lock` to capture the newly-visible nodes"

The drft skill words this as a *first-lock* exception, which is right for its context — it sets up new repos. That framing cannot arise in this repo, which has had a baseline for many releases. Format regeneration is the shape the same case takes here, so that is how it is written.

## The property worth recording

Scoped locking could look like a loophole: lock the file you changed, skip the review. It is not, and the reason is structural.

An edge's recorded target hash lives on the file that **declared** the link. So locking a changed source clears its own `stale-node` and leaves every inbound `stale-edge` standing. Those clear only when the dependent is locked — the file whose promise someone actually checked.

```
edit src.md   → stale-node: src.md  +  stale-edge: doc.md → src.md
lock src.md   → stale-node clears,     stale-edge PERSISTS
lock doc.md   → clean
```

The edge stays flagged until someone locks the doc they read. Scoped locking cannot wave off the review it exists to record.

The converse is also now stated: a file with no dependents has no promise to check, so its staleness is bookkeeping — lock it and move on. That is the case the old blanket ban charged a round trip for on every release.

## Verification

- Behavior above verified end-to-end on a scratch graph, not asserted from the format
- `README.md:99` is the only dependent of `CLAUDE.md`; it points at the file as "the agent instructions" without restating the rule, so the promise still holds — reviewed, no change needed
- Locked with `drft lock CLAUDE.md README.md` — the edited file and the dependent that was read
- `drft check` exits 0

Docs only; no release needed.
