### PR TITLE
docs: a directory link tracks the directory, not its contents

### DIFF
--- a/docs/parsers/markdown.md
+++ b/docs/parsers/markdown.md
@@ -74,6 +74,12 @@ files = ["**/*.md", "**/*.mdx"]
 default graphs — the markdown parser runs only where you declare it. See
 [configuration](../config.md) for the full graph schema.
 
+## Directory targets
+
+A link whose target is a directory (`[services](edge/)`) creates an edge to the directory node. Directories are nodes, so the link resolves — but they carry no hash, so nothing inside is tracked: editing `edge/src/main.rs` leaves the linking file clean, and `drft impact` on that file does not report it.
+
+This matters most where it reads like coverage. A layout table citing `` `edge/` ``, `` `tenant/` ``, `` `console/api/` `` looks to a reader like an inventory of those trees and tracks none of them. Point each link at the file carrying what the prose claims — `edge/src/main.rs` — and the promise becomes one drft can check.
+
 ## External URLs
 
 External links (`http://`, `https://`, `mailto:`, and other URI schemes) are emitted as raw edge targets. A URI target has no defining node, so the `unresolved-edge` rule treats it as an intentional external reference and does not flag it. Anchor-only links (`#heading`) are dropped, and fragments are stripped from targets (`file.md#section` → `file.md`) — both handled when the edge is built, not by the parser.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -40,6 +40,13 @@ derives the drift findings by joining the graph to the lockfile;
 | `unresolved-edge` | An edge target has no defining node (URIs excepted)            |
 | `detached-node`   | A node has no inbound or outbound edges (directories excepted) |
 
+**A link to a directory tracks the directory, not its contents.** Directories are
+nodes, so the edge resolves and `unresolved-edge` stays quiet — but directories
+carry no hash, so nothing inside one is tracked and no descendant's change makes
+the linking file stale. A doc citing `` `src/` `` reads as an inventory of that
+tree and is not one. Link the file that carries what the prose claims —
+`src/lib.rs` over `src/` — when you want the promise tracked.
+
 `unresolved-edge` carries a `hint` when the link text would resolve from the
 graph root but not from the declaring file. Links resolve relative to the file
 that declares them, so a root-relative path fails against a target nobody wrote

--- a/drft.lock
+++ b/drft.lock
@@ -46,7 +46,7 @@ target_hash = "b3:9907cb7e84e573adeefca75129e6a7f8514e3d28ca101cbb19fb55265083f0
 
 [[node.edge]]
 target = "docs/rules/README.md"
-target_hash = "b3:4f5a8674c50acec2e9478309e1b770aef880c99adec628e967ebce5153ebcbb3"
+target_hash = "b3:001783ea083536a80cc88600bce3816cc6c90106685e825fe3e23e29936d8232"
 
 [[node.edge]]
 target = "src/builders/mod.rs"
@@ -137,7 +137,7 @@ target_hash = "b3:9907cb7e84e573adeefca75129e6a7f8514e3d28ca101cbb19fb55265083f0
 
 [[node.edge]]
 target = "docs/rules/README.md"
-target_hash = "b3:4f5a8674c50acec2e9478309e1b770aef880c99adec628e967ebce5153ebcbb3"
+target_hash = "b3:001783ea083536a80cc88600bce3816cc6c90106685e825fe3e23e29936d8232"
 
 [[node]]
 path = "docs/config.md"
@@ -153,7 +153,7 @@ target_hash = "b3:ef2ebd19dbc6c8b7d88f9561c2afceed6c8db753fcd8f2c49e20194150986d
 
 [[node.edge]]
 target = "docs/rules/README.md"
-target_hash = "b3:4f5a8674c50acec2e9478309e1b770aef880c99adec628e967ebce5153ebcbb3"
+target_hash = "b3:001783ea083536a80cc88600bce3816cc6c90106685e825fe3e23e29936d8232"
 
 [[node.edge]]
 target = "src/cli.rs"
@@ -173,7 +173,7 @@ target_hash = "b3:ef2ebd19dbc6c8b7d88f9561c2afceed6c8db753fcd8f2c49e20194150986d
 
 [[node.edge]]
 target = "docs/parsers/markdown.md"
-target_hash = "b3:291302e9f0e404a834790daae6aa7c7b0dff465e9ca0c336c5732030e5bb5383"
+target_hash = "b3:71f1ce453d7db6746e4a8b9cc1e2bedd608589beb0340e697bc0ce931b9a7d1f"
 
 [[node.edge]]
 target = "src/parsers/mod.rs"
@@ -193,7 +193,7 @@ target_hash = "b3:5170b0ce6856f4583e22ca7cbdaf32520426f321305a0c3f63cc4e20e35ecb
 
 [[node]]
 path = "docs/parsers/markdown.md"
-hash = "b3:291302e9f0e404a834790daae6aa7c7b0dff465e9ca0c336c5732030e5bb5383"
+hash = "b3:71f1ce453d7db6746e4a8b9cc1e2bedd608589beb0340e697bc0ce931b9a7d1f"
 
 [[node.edge]]
 target = "docs/config.md"
@@ -209,7 +209,7 @@ target_hash = "b3:952fafe8eb3a776168da8ec935438fbd39de4599375f1c0e82334d3dd8d361
 
 [[node]]
 path = "docs/rules/README.md"
-hash = "b3:4f5a8674c50acec2e9478309e1b770aef880c99adec628e967ebce5153ebcbb3"
+hash = "b3:001783ea083536a80cc88600bce3816cc6c90106685e825fe3e23e29936d8232"
 
 [[node.edge]]
 target = "src/config.rs"


### PR DESCRIPTION
Addresses #74 as documentation rather than a rule. Reasoning below and on the issue.

## The behavior

Directories are nodes (since 0.9.0), so a link to one resolves and `unresolved-edge` stays quiet. But directories carry no hash, so nothing inside is tracked: editing `edge/src/main.rs` leaves the linking doc clean, and `drft impact` on that file reports nothing.

Nothing documented this, and the gap reads as coverage. A layout table citing `` `edge/` ``, `` `tenant/` ``, `` `console/api/` `` looks like an inventory of those trees and tracks none of them.

Now stated in the rules reference and the markdown parser reference, with the fix: point the link at the file that carries what the prose claims.

## Why not the rule #74 asked for

The issue offered propagate or flag. Neither earns its place.

**Propagate** — a directory edge going stale when any descendant changes — breaks the invariant that makes cycles safe: "staleness is computed locally, per node and per edge, with no recursive propagation." It also needs directory hashing or check-time edge expansion, and a doc linking `console/api/` would go stale on every file added anywhere under that tree. That is the oversized-output failure 0.12.0 just spent a release removing from `impact`.

**Flag** — a `directory-edge` finding — is cheap but low-value. It reports something the author can already see, since they typed the directory path. It fires on every directory link, most of which are ordinary navigation, so a repo with six service links carries six warnings that never resolve. Warnings that cannot be resolved get switched off: `detached-node` is `off` in this repo for exactly that reason ("a source repo has many legitimately unlinked files"). Adding a second rule with the same fate is not a fix.

The real gap was never per-link. The reporter found this by auditing reachability — "unreachable Rust files from 19 to 9" — which is a coverage question no per-edge finding answers.

## What should carry forward

`detached-node` is the rule that would have caught this, and it is off in every repo likely to hit it, because it cannot tell an unlinked doc (probably a gap) from an unlinked `Cargo.toml` (obviously fine). That coarseness is the durable issue and is filed separately.

## Verification

- `drft check` exits 0
- Four dependents reviewed: `docs/config.md`, `docs/parsers/README.md`, `docs/README.md`, `CONTRIBUTING.md` — all point at the changed references rather than restating them, so each promise still holds
- Locked with `drft lock` naming the two edited files and the four dependents that were read

Docs only; no release needed.
