### PR TITLE
lock: accept multiple paths and drop removed nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ All rules default to `warn`. Override to `error` for CI enforcement or `off` to 
 
 All commands support `--format json`. Run `drft --help` for the full flag reference.
 
+`drft lock` takes paths to lock a subset: `drft lock a.md b.md` snapshots only those nodes and merges them into the existing lockfile, leaving every other entry untouched. Locking a path whose file has been deleted drops its entry — how you clear a `removed-node` finding once you have reviewed the deletion. Paths that resolve are written even when another path in the same call does not; the unresolved ones are reported and set a non-zero exit.
+
 ## Configuration
 
 `drft.toml` in the directory root:

--- a/drft.lock
+++ b/drft.lock
@@ -78,7 +78,7 @@ hash = "b3:871c2fd5cdfe89fa6ff01664a1420bf40d0ab18c0e250e59a3ab27225f31bb0e"
 
 [[node]]
 path = "README.md"
-hash = "b3:b1dd0cb88330edec3385703c91b9787b6a5f7dad2fea0b102bd217a0f2b1d0ae"
+hash = "b3:a2e9a07ec1772fa38a111baa73c7d00495c3bee4b2ceca34fb92afaa25167167"
 
 [[node.edge]]
 target = "CLAUDE.md"
@@ -133,7 +133,7 @@ target_hash = "b3:951c94920bd8893eb50a5ab766db7140ac3ce141637fe334908e5e0d95e12d
 
 [[node.edge]]
 target = "src/cli.rs"
-target_hash = "b3:db5461193c01bd415b648451637b71a62ba28d41aeb456d90ae95744851c1783"
+target_hash = "b3:4f62d6d515191a5476259fd9e06f9a748c74970b54398b9e5cb1b1e41d61c2a9"
 
 [[node.edge]]
 target = "src/config.rs"
@@ -244,7 +244,7 @@ hash = "b3:047dd43a1fc67586928b89dd4ea2a8ea37710008f9dff03c98dc78116240f4d8"
 
 [[node]]
 path = "src/cli.rs"
-hash = "b3:db5461193c01bd415b648451637b71a62ba28d41aeb456d90ae95744851c1783"
+hash = "b3:4f62d6d515191a5476259fd9e06f9a748c74970b54398b9e5cb1b1e41d61c2a9"
 
 [[node]]
 path = "src/compose.rs"
@@ -276,7 +276,7 @@ hash = "b3:b437206e0e16ea1a0643edda5d8b1ab7361816bb42222bc80e488e13329b0516"
 
 [[node]]
 path = "src/main.rs"
-hash = "b3:2f759f730a307505783b9b02db9269747b15fd1a8d3bb7e566f0956697d3bc39"
+hash = "b3:579bb4db05d8f2c4f5fa2574a9c8a2d8688c2d2c366c295b2976f7a2af5dea69"
 
 [[node]]
 path = "src/model.rs"
@@ -344,7 +344,7 @@ hash = "b3:dc15abb7afc8314627fd1346ade4e129ad9796ddcbab651d82f342c15db03dfc"
 
 [[node]]
 path = "tests/lock.rs"
-hash = "b3:22b82141d34cc27e43b12d063c076c4334e773a02b7a6d87901e804b19b5c73f"
+hash = "b3:30bf1f8b45d895bda42f1307e1361927eb1d7c66399700d6b1ab74e17f2e25cb"
 
 [[node]]
 path = "tests/output.rs"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,8 +31,10 @@ pub enum Commands {
 
     /// Snapshot the current state to drft.lock
     Lock {
-        /// Lock only this path and its outbound edges (default: lock the whole graph)
-        path: Option<String>,
+        /// Lock only these paths and their outbound edges (default: lock the whole
+        /// graph). A path that is locked but no longer on disk is dropped — the way
+        /// a removed-node finding is reviewed.
+        paths: Vec<String>,
     },
 
     /// Export the dependency graph as composed JGF

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn try_main() -> Result<i32> {
 
     match &cli.command {
         Commands::Init => run_init(&root),
-        Commands::Lock { path } => run_lock(&root, path.as_deref()),
+        Commands::Lock { paths } => run_lock(&root, paths),
         Commands::Impact {
             paths,
             depth,
@@ -120,49 +120,76 @@ files = ["**/*.md"]
 }
 
 /// Snapshot the composed graph into `drft.lock`: node content hashes and each
-/// node's outbound edge target hashes. With a path, lock only that node (its
-/// bytes and its outbound edge targets), merging into the existing lockfile.
-fn run_lock(root: &Path, path: Option<&str>) -> Result<i32> {
+/// node's outbound edge target hashes. With no paths, lock the whole graph. With
+/// paths, lock only those nodes (their bytes and outbound edge targets), merging
+/// into the existing lockfile — and drop the entry for a path that is locked but
+/// no longer in the graph, which is how a `removed-node` finding is reviewed and
+/// cleared. Resolution is tolerant: paths that resolve are written, unresolved
+/// paths are reported, and the command exits non-zero only if some path missed.
+fn run_lock(root: &Path, paths: &[String]) -> Result<i32> {
     let graph_root = find_graph_root(root);
     let config = Config::load(&graph_root)?;
     let set = graphs::build_set(&graph_root, &config)?;
     let composed = compose::compose(&set);
     let snapshot = lock::Lock::from_composed(&composed);
 
-    match path {
-        None => lock::write(&graph_root, &snapshot)?,
-        Some(path) => {
-            let node = resolve_node(&composed, root, &graph_root, path)?;
-            let mut existing = lock::read(&graph_root)?.unwrap_or_default();
-            let entry = snapshot
-                .nodes
-                .get(&node)
-                .expect("resolved node is in the snapshot")
-                .clone();
-            existing.nodes.insert(node, entry);
-            lock::write(&graph_root, &existing)?;
+    if paths.is_empty() {
+        lock::write(&graph_root, &snapshot)?;
+        return Ok(0);
+    }
+
+    let mut existing = lock::read(&graph_root)?.unwrap_or_default();
+    let mut changed = false;
+    let mut misses = Vec::new();
+
+    for path in paths {
+        match resolve_lock_target(&composed, &existing, root, &graph_root, path) {
+            Some(LockTarget::Live(node)) => match snapshot.nodes.get(&node) {
+                Some(entry) => {
+                    existing.nodes.insert(node, entry.clone());
+                    changed = true;
+                }
+                // A directory (or other hash-less, edge-less node) carries nothing
+                // that can drift, so it is never a lock entry — nothing to lock.
+                None => eprintln!("nothing to lock: {node} (no content to snapshot)"),
+            },
+            Some(LockTarget::Removed(node)) => {
+                existing.nodes.remove(&node);
+                changed = true;
+                eprintln!("unlocked removed node: {node}");
+            }
+            None => misses.push(path.as_str()),
         }
     }
-    Ok(0)
+
+    if changed {
+        lock::write(&graph_root, &existing)?;
+    }
+
+    for path in &misses {
+        eprintln!("{}", not_found_message(&composed, Some(&existing), path));
+    }
+    Ok(if misses.is_empty() { 0 } else { 2 })
 }
 
-/// Resolve a user-supplied path to a node key in the composed graph.
+/// What a lock path resolves to: a node still in the graph (re-snapshot it), or a
+/// node present only in the lockfile because its file is gone (drop it — the
+/// reviewed-deletion case that clears a `removed-node` finding).
+enum LockTarget {
+    Live(String),
+    Removed(String),
+}
+
+/// Candidate node keys for a user-supplied path, most-specific first.
 ///
 /// Nodes are keyed by graph-root-relative path, but the argument is relative to
 /// the current directory (`root`) like any other CLI path — so it is resolved
-/// against `root`, normalized, and made relative to `graph_root` before lookup.
-/// This makes the command cwd-agnostic: the same file resolves whether given
+/// against `root`, normalized, and made relative to `graph_root` first. This
+/// makes lookup cwd-agnostic: the same file resolves whether given
 /// project-relative from a subdirectory or root-relative from the top. A `.md`
-/// suffix is tried as a fallback, and the raw argument is tried last for back
-/// compatibility. On a miss, a node whose key ends with the argument is
-/// suggested — but only when the suffix match is unambiguous (otherwise the
-/// candidates are listed, so an arbitrary pick is never presented as "the" one).
-fn resolve_node(
-    composed: &drft::model::Graph,
-    root: &Path,
-    graph_root: &Path,
-    path: &str,
-) -> Result<String> {
+/// suffix is offered as a fallback, and the raw argument is tried last for back
+/// compatibility.
+fn node_candidates(root: &Path, graph_root: &Path, path: &str) -> Vec<String> {
     let mut candidates = Vec::new();
     if let Some(key) = graph_key(root, graph_root, path) {
         candidates.push(format!("{key}.md"));
@@ -170,27 +197,75 @@ fn resolve_node(
     }
     candidates.push(format!("{path}.md"));
     candidates.push(path.to_string());
+    candidates
+}
 
-    for candidate in &candidates {
-        if composed.nodes.contains_key(candidate) {
-            return Ok(candidate.clone());
+/// Resolve a user-supplied path to a node key in the composed graph. On a miss,
+/// a node whose key ends with the argument is suggested — but only when the
+/// suffix match is unambiguous (otherwise the candidates are listed, so an
+/// arbitrary pick is never presented as "the" one).
+fn resolve_node(
+    composed: &drft::model::Graph,
+    root: &Path,
+    graph_root: &Path,
+    path: &str,
+) -> Result<String> {
+    for candidate in node_candidates(root, graph_root, path) {
+        if composed.nodes.contains_key(&candidate) {
+            return Ok(candidate);
         }
     }
+    anyhow::bail!("{}", not_found_message(composed, None, path))
+}
 
-    // Suggest nodes whose key ends with the given path (e.g. a bare filename or
-    // a project-relative suffix) — the common "right file, wrong prefix" miss.
-    // Normalize the needle so it matches the graph's forward-slash keys, and only
-    // present a single suggestion when it's unambiguous.
+/// Resolve a lock path to a live node or a removed one. A live node (still in the
+/// graph) wins over a lockfile entry, so re-locking a tracked file updates it
+/// rather than dropping it; a path present only in the lockfile resolves to
+/// `Removed`. `None` means the path matched neither.
+fn resolve_lock_target(
+    composed: &drft::model::Graph,
+    existing: &lock::Lock,
+    root: &Path,
+    graph_root: &Path,
+    path: &str,
+) -> Option<LockTarget> {
+    let candidates = node_candidates(root, graph_root, path);
+    for candidate in &candidates {
+        if composed.nodes.contains_key(candidate) {
+            return Some(LockTarget::Live(candidate.clone()));
+        }
+    }
+    for candidate in &candidates {
+        if existing.nodes.contains_key(candidate) {
+            return Some(LockTarget::Removed(candidate.clone()));
+        }
+    }
+    None
+}
+
+/// Build the "node not found" message. Suggests nodes whose key ends with the
+/// given path (the common "right file, wrong prefix" miss), searching the graph
+/// and — when provided — the lockfile, so a mistyped removed node still gets a
+/// suggestion. Normalizes the needle to match the graph's forward-slash keys and
+/// only presents a single suggestion when it's unambiguous.
+fn not_found_message(
+    composed: &drft::model::Graph,
+    lock: Option<&lock::Lock>,
+    path: &str,
+) -> String {
     let needle = drft::util::normalize_relative_path(path);
     let suffix = format!("/{needle}");
-    let matches: Vec<&String> = composed
+    let mut matches: Vec<&String> = composed
         .nodes
         .keys()
+        .chain(lock.into_iter().flat_map(|l| l.nodes.keys()))
         .filter(|k| k.as_str() == needle || k.ends_with(&suffix))
         .collect();
+    matches.sort();
+    matches.dedup();
     match matches.as_slice() {
-        [] => anyhow::bail!("node not found: \"{path}\""),
-        [hit] => anyhow::bail!("node not found: \"{path}\" — did you mean \"{hit}\"?"),
+        [] => format!("node not found: \"{path}\""),
+        [hit] => format!("node not found: \"{path}\" — did you mean \"{hit}\"?"),
         many => {
             let shown = many
                 .iter()
@@ -202,7 +277,7 @@ fn resolve_node(
             } else {
                 String::new()
             };
-            anyhow::bail!(
+            format!(
                 "node not found: \"{path}\" — multiple matches: {}{more}",
                 shown.join(", ")
             )

--- a/tests/lock.rs
+++ b/tests/lock.rs
@@ -20,6 +20,19 @@ fn lock(dir: &std::path::Path) {
     assert!(output.status.success(), "lock should exit 0");
 }
 
+/// Run `drft lock <paths>` and return (exit code, stderr).
+fn lock_paths(dir: &std::path::Path, paths: &[&str]) -> (i32, String) {
+    let output = drft_bin()
+        .args(["-C", dir.to_str().unwrap(), "lock"])
+        .args(paths)
+        .output()
+        .unwrap();
+    (
+        output.status.code().unwrap(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
 /// First lock writes drft.lock in the path-keyed format (node hashes + nested
 /// edge target hashes), with no version field. A subsequent check is clean.
 #[test]
@@ -116,5 +129,95 @@ fn deleted_file_reports_unresolved_and_removed_node() {
     assert!(
         stdout.contains("removed-node"),
         "expected removed-node, got: {stdout}"
+    );
+}
+
+/// Scope-locking a path that is in the lockfile but gone from disk drops its
+/// entry, clearing `removed-node` — the reviewed-deletion case. This is the
+/// finding whose only other remedy was the whole-graph `drft lock`.
+#[test]
+fn scope_lock_drops_removed_node() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("index.md"), "[doomed](doomed.md)").unwrap();
+    fs::write(dir.path().join("doomed.md"), "# Doomed").unwrap();
+
+    lock(dir.path());
+    fs::remove_file(dir.path().join("doomed.md")).unwrap();
+    assert!(check(dir.path()).contains("removed-node"));
+
+    let (code, stderr) = lock_paths(dir.path(), &["doomed.md"]);
+    assert_eq!(
+        code, 0,
+        "locking a removed path should succeed, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("unlocked removed node: doomed.md"),
+        "expected an unlock notice, got: {stderr}"
+    );
+    assert!(
+        !check(dir.path()).contains("removed-node"),
+        "removed-node should be cleared after scope-locking the deleted path"
+    );
+}
+
+/// The issue's headline case: a batch of a live (repaired) path and a deleted one
+/// in a single call. The live path re-locks and the deleted one drops, atomically
+/// — no all-or-nothing abort. After it, the deletion leaves no findings.
+#[test]
+fn batch_lock_updates_live_and_drops_removed() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(
+        dir.path().join("index.md"),
+        "[guide](guide.md) [doomed](doomed.md)",
+    )
+    .unwrap();
+    fs::write(dir.path().join("guide.md"), "# Guide").unwrap();
+    fs::write(dir.path().join("doomed.md"), "# Doomed").unwrap();
+
+    lock(dir.path());
+    // Delete one target and repair the citing document in the same breath.
+    fs::remove_file(dir.path().join("doomed.md")).unwrap();
+    fs::write(dir.path().join("index.md"), "[guide](guide.md)").unwrap();
+
+    let (code, _) = lock_paths(dir.path(), &["index.md", "doomed.md"]);
+    assert_eq!(code, 0, "a batch of live + removed paths should succeed");
+
+    let stdout = check(dir.path());
+    for finding in ["removed-node", "removed-edge", "stale"] {
+        assert!(
+            !stdout.contains(finding),
+            "expected no {finding} after the batch lock, got: {stdout}"
+        );
+    }
+}
+
+/// An unresolved path does not abort the call: paths that resolve are written,
+/// the miss is reported, and the exit code is non-zero. The batch is tolerant,
+/// not all-or-nothing.
+#[test]
+fn lock_reports_misses_but_writes_resolved() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("index.md"), "[setup](setup.md)").unwrap();
+    fs::write(dir.path().join("setup.md"), "# Setup").unwrap();
+    lock(dir.path());
+
+    // Edit a file, then lock it alongside a nonexistent path.
+    fs::write(dir.path().join("setup.md"), "# Setup (edited)").unwrap();
+    let (code, stderr) = lock_paths(dir.path(), &["setup.md", "nope.md"]);
+
+    assert_eq!(code, 2, "a miss should make the call exit non-zero");
+    assert!(
+        stderr.contains("node not found: \"nope.md\""),
+        "expected the miss to be reported, got: {stderr}"
+    );
+    // setup.md was written despite the miss, so its own stale-node clears. (The
+    // dependent index.md keeps a stale-edge until it too is locked — ordinary
+    // scoped-lock behavior, not a property of the miss.)
+    assert!(
+        !check(dir.path()).contains("stale-node]: setup.md"),
+        "the resolved path should still have been locked despite the miss"
     );
 }


### PR DESCRIPTION
Fixes #89.

## Problem

`drft lock` accepted a single path and resolved it only against the composed
graph. A path whose file was deleted failed with `node not found` (exit 2), so
the only way to clear a `removed-node` finding was the bare `drft lock` — the
whole-graph call the workflow singles out as the one never to make. Assembling a
lock list from `drft check` output (the natural workflow) had no path that worked.

## Change

`lock` is now variadic over **exact node paths**, and tolerant:

| you lock… | result |
| --- | --- |
| a path still in the graph | re-snapshots as before |
| a path only in the lockfile (file deleted) | its entry is dropped — the reviewed-deletion case that clears `removed-node` |
| a live path + a deleted path together | live one updates, deleted one drops, in one atomic write |
| a path that resolves + one that doesn't | the resolver is written; the miss is reported; exit 2 |

Live nodes win over lockfile entries, so re-locking a tracked file updates it
rather than dropping it. A directory (hash-less) path now skips gracefully
instead of panicking on an `.expect`.

## Tests

Three integration tests in `tests/lock.rs`: the drop, the batch (live + removed),
and tolerant misses. Full suite, clippy `-D warnings`, and `fmt --check` pass.

## Notes

- The CLI positional stays **exact paths** (no prefix/glob expansion); shell globs
  cover live-file convenience. This follows the writer-vs-readers taxonomy the team
  settled on — `lock` is the sole writer; `check` stays a no-positional gate.
- README gains a short scoped-lock note.