### PR TITLE
lock: drop a removed node when its deleted path is named

### DIFF
--- a/drft.lock
+++ b/drft.lock
@@ -300,7 +300,7 @@ hash = "b3:b437206e0e16ea1a0643edda5d8b1ab7361816bb42222bc80e488e13329b0516"
 
 [[node]]
 path = "src/main.rs"
-hash = "b3:297802b051fbd298663b74c0bfd217ba91ad11120d3df519eea680e1176659a7"
+hash = "b3:5523068674b1faea1f7f634d0c161debf09d24829c7343a93a5b35f0b71e2a67"
 
 [[node]]
 path = "src/model.rs"
@@ -368,7 +368,7 @@ hash = "b3:dc15abb7afc8314627fd1346ade4e129ad9796ddcbab651d82f342c15db03dfc"
 
 [[node]]
 path = "tests/lock.rs"
-hash = "b3:0038a8b5130180edccaa42ea447a03352eee911cef76bcbbea2e96179417e5e7"
+hash = "b3:8ed372bf58ec2e1f76d314cc364ac2992aa02f80bce65f9d8e39557e1f1299ef"
 
 [[node]]
 path = "tests/output.rs"

--- a/drft.lock
+++ b/drft.lock
@@ -300,7 +300,7 @@ hash = "b3:b437206e0e16ea1a0643edda5d8b1ab7361816bb42222bc80e488e13329b0516"
 
 [[node]]
 path = "src/main.rs"
-hash = "b3:5523068674b1faea1f7f634d0c161debf09d24829c7343a93a5b35f0b71e2a67"
+hash = "b3:7e79dbb71abcbbbbc2e07154df140fb6ac7f1c7dc127f869f08e6a5890e2e94d"
 
 [[node]]
 path = "src/model.rs"
@@ -368,7 +368,7 @@ hash = "b3:dc15abb7afc8314627fd1346ade4e129ad9796ddcbab651d82f342c15db03dfc"
 
 [[node]]
 path = "tests/lock.rs"
-hash = "b3:8ed372bf58ec2e1f76d314cc364ac2992aa02f80bce65f9d8e39557e1f1299ef"
+hash = "b3:a4e6a7a9c1bec9cf0eee23d73d224ba35725928da4f0d1bb8671f1cf6a85f213"
 
 [[node]]
 path = "tests/output.rs"

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,12 +182,21 @@ fn run_lock(root: &Path, paths: &[String]) -> Result<i32> {
 /// suffix is offered as a fallback, and the raw argument is tried last for back
 /// compatibility.
 fn node_candidates(root: &Path, graph_root: &Path, path: &str) -> Vec<String> {
+    // The `.md` fallback is for a bare doc name (`guide` → `guide.md`). An argument
+    // that already carries an extension names a specific file, so appending `.md`
+    // would only invent a bogus `guide.md.md` candidate — and, pushed first, try it
+    // ahead of the exact key.
+    let add_md = Path::new(path).extension().is_none();
     let mut candidates = Vec::new();
     if let Some(key) = graph_key(root, graph_root, path) {
-        candidates.push(format!("{key}.md"));
+        if add_md {
+            candidates.push(format!("{key}.md"));
+        }
         candidates.push(key);
     }
-    candidates.push(format!("{path}.md"));
+    if add_md {
+        candidates.push(format!("{path}.md"));
+    }
     candidates.push(path.to_string());
     candidates
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,44 +142,46 @@ fn run_lock(root: &Path, paths: &[String]) -> Result<i32> {
         return Ok(0);
     }
 
+    let mut existing = lock::read(&graph_root)?.unwrap_or_default();
+
     // Resolve every path before writing any of them. A typo in the third of five
     // must not leave the first two locked: a partial lock claims some files were
     // reviewed and drops the rest without saying so, which is worse than failing.
+    // A path resolves against the graph or, when its file is gone, against the
+    // lockfile — so a deleted node can be named to clear its `removed-node` finding.
     let nodes = paths
         .iter()
-        .map(|p| resolve_node(&composed, root, &graph_root, p))
+        .map(|p| resolve_lock_node(&composed, &existing, root, &graph_root, p))
         .collect::<Result<Vec<_>>>()?;
 
-    let mut existing = lock::read(&graph_root)?.unwrap_or_default();
+    // Make the lockfile reflect each named path's current state: re-snapshot a node
+    // that carries content, and drop the entry for anything that no longer does —
+    // a deleted file, or a path that has become a hash-less directory. Dropping the
+    // entry for a reviewed deletion is how a `removed-node` finding is cleared.
     for node in nodes {
-        let entry = snapshot
-            .nodes
-            .get(&node)
-            .expect("resolved node is in the snapshot")
-            .clone();
-        existing.nodes.insert(node, entry);
+        match snapshot.nodes.get(&node) {
+            Some(entry) => {
+                existing.nodes.insert(node, entry.clone());
+            }
+            None => {
+                existing.nodes.remove(&node);
+            }
+        }
     }
     lock::write(&graph_root, &existing)?;
     Ok(0)
 }
 
-/// Resolve a user-supplied path to a node key in the composed graph.
+/// Candidate node keys for a user-supplied path, most-specific first.
 ///
 /// Nodes are keyed by graph-root-relative path, but the argument is relative to
 /// the current directory (`root`) like any other CLI path — so it is resolved
-/// against `root`, normalized, and made relative to `graph_root` before lookup.
-/// This makes the command cwd-agnostic: the same file resolves whether given
+/// against `root`, normalized, and made relative to `graph_root` first. This
+/// makes lookup cwd-agnostic: the same file resolves whether given
 /// project-relative from a subdirectory or root-relative from the top. A `.md`
-/// suffix is tried as a fallback, and the raw argument is tried last for back
-/// compatibility. On a miss, a node whose key ends with the argument is
-/// suggested — but only when the suffix match is unambiguous (otherwise the
-/// candidates are listed, so an arbitrary pick is never presented as "the" one).
-fn resolve_node(
-    composed: &drft::model::Graph,
-    root: &Path,
-    graph_root: &Path,
-    path: &str,
-) -> Result<String> {
+/// suffix is offered as a fallback, and the raw argument is tried last for back
+/// compatibility.
+fn node_candidates(root: &Path, graph_root: &Path, path: &str) -> Vec<String> {
     let mut candidates = Vec::new();
     if let Some(key) = graph_key(root, graph_root, path) {
         candidates.push(format!("{key}.md"));
@@ -187,27 +189,25 @@ fn resolve_node(
     }
     candidates.push(format!("{path}.md"));
     candidates.push(path.to_string());
+    candidates
+}
 
-    for candidate in &candidates {
-        if composed.nodes.contains_key(candidate) {
-            return Ok(candidate.clone());
-        }
-    }
-
-    // Suggest nodes whose key ends with the given path (e.g. a bare filename or
-    // a project-relative suffix) — the common "right file, wrong prefix" miss.
-    // Normalize the needle so it matches the graph's forward-slash keys, and only
-    // present a single suggestion when it's unambiguous.
+/// Build a "node not found" error, suggesting a key that ends with the given path
+/// (the common "right file, wrong prefix" miss). The needle is normalized to match
+/// the graph's forward-slash keys, and a single suggestion is only offered when the
+/// suffix match is unambiguous — otherwise the candidates are listed, so an
+/// arbitrary pick is never presented as "the" one.
+fn not_found_error<'a>(keys: impl Iterator<Item = &'a String>, path: &str) -> anyhow::Error {
     let needle = drft::util::normalize_relative_path(path);
     let suffix = format!("/{needle}");
-    let matches: Vec<&String> = composed
-        .nodes
-        .keys()
+    let mut matches: Vec<&String> = keys
         .filter(|k| k.as_str() == needle || k.ends_with(&suffix))
         .collect();
+    matches.sort();
+    matches.dedup();
     match matches.as_slice() {
-        [] => anyhow::bail!("node not found: \"{path}\""),
-        [hit] => anyhow::bail!("node not found: \"{path}\" — did you mean \"{hit}\"?"),
+        [] => anyhow::anyhow!("node not found: \"{path}\""),
+        [hit] => anyhow::anyhow!("node not found: \"{path}\" — did you mean \"{hit}\"?"),
         many => {
             let shown = many
                 .iter()
@@ -219,12 +219,52 @@ fn resolve_node(
             } else {
                 String::new()
             };
-            anyhow::bail!(
+            anyhow::anyhow!(
                 "node not found: \"{path}\" — multiple matches: {}{more}",
                 shown.join(", ")
             )
         }
     }
+}
+
+/// Resolve a user-supplied path to a node key in the composed graph.
+fn resolve_node(
+    composed: &drft::model::Graph,
+    root: &Path,
+    graph_root: &Path,
+    path: &str,
+) -> Result<String> {
+    for candidate in node_candidates(root, graph_root, path) {
+        if composed.nodes.contains_key(&candidate) {
+            return Ok(candidate);
+        }
+    }
+    Err(not_found_error(composed.nodes.keys(), path))
+}
+
+/// Resolve a lock path to a node key present in the graph or, when its file is
+/// gone, in the existing lockfile. A live node re-snapshots; a key that survives
+/// only in the lock is a deletion under review, and naming it drops the entry.
+/// This is what lets a `removed-node` finding be cleared by locking the vanished
+/// path — the reviewed-deletion case the graph alone cannot resolve. Suggestions
+/// on a miss search both the graph and the lockfile, so a mistyped deleted path
+/// still gets one.
+fn resolve_lock_node(
+    composed: &drft::model::Graph,
+    existing: &lock::Lock,
+    root: &Path,
+    graph_root: &Path,
+    path: &str,
+) -> Result<String> {
+    for candidate in node_candidates(root, graph_root, path) {
+        if composed.nodes.contains_key(&candidate) || existing.nodes.contains_key(&candidate) {
+            return Ok(candidate);
+        }
+    }
+    Err(not_found_error(
+        composed.nodes.keys().chain(existing.nodes.keys()),
+        path,
+    ))
 }
 
 /// Resolve `arg` (relative to the current directory `root`, or absolute) to a

--- a/tests/lock.rs
+++ b/tests/lock.rs
@@ -182,3 +182,95 @@ fn scoped_lock_writes_nothing_when_a_path_is_unresolvable() {
         "a.md must not be locked when a later path fails, got: {stdout}"
     );
 }
+
+/// Locking a path whose file has been deleted drops its lock entry, clearing
+/// `removed-node`. The deletion is the finding, so naming the vanished path is how
+/// you review it — the case the graph alone cannot resolve, since the node is gone.
+#[test]
+fn scoped_lock_drops_a_removed_node() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("index.md"), "[doomed](doomed.md)").unwrap();
+    fs::write(dir.path().join("doomed.md"), "# Doomed").unwrap();
+    lock(dir.path());
+
+    fs::remove_file(dir.path().join("doomed.md")).unwrap();
+    assert!(check(dir.path()).contains("removed-node"));
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "lock", "doomed.md"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "locking a removed path should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !check(dir.path()).contains("removed-node"),
+        "removed-node should be cleared after locking the deleted path"
+    );
+}
+
+/// A batch of a repaired live path and a deleted one locks in one atomic call: the
+/// live path re-snapshots, the deleted one drops. This is the workflow the earlier
+/// one-path-per-call form could not express without the forbidden bare `drft lock`.
+#[test]
+fn scoped_lock_batches_a_live_update_with_a_drop() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(
+        dir.path().join("index.md"),
+        "[guide](guide.md) [doomed](doomed.md)",
+    )
+    .unwrap();
+    fs::write(dir.path().join("guide.md"), "# Guide").unwrap();
+    fs::write(dir.path().join("doomed.md"), "# Doomed").unwrap();
+    lock(dir.path());
+
+    // Delete one target and repair the citing document in the same breath.
+    fs::remove_file(dir.path().join("doomed.md")).unwrap();
+    fs::write(dir.path().join("index.md"), "[guide](guide.md)").unwrap();
+
+    let output = drft_bin()
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "lock",
+            "index.md",
+            "doomed.md",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let stdout = check(dir.path());
+    for finding in ["removed-node", "removed-edge", "stale"] {
+        assert!(
+            !stdout.contains(finding),
+            "expected no {finding} after the batch lock, got: {stdout}"
+        );
+    }
+}
+
+/// Locking a directory is a no-op, not a panic. A directory node carries no hash
+/// and no edges, so it is never a lock entry; naming one has nothing to snapshot.
+#[test]
+fn scoped_lock_of_a_directory_is_a_noop() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::create_dir(dir.path().join("sub")).unwrap();
+    fs::write(dir.path().join("sub").join("a.md"), "# A").unwrap();
+    fs::write(dir.path().join("index.md"), "[sub](sub)").unwrap();
+    lock(dir.path());
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "lock", "sub"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "locking a directory should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/tests/lock.rs
+++ b/tests/lock.rs
@@ -274,3 +274,34 @@ fn scoped_lock_of_a_directory_is_a_noop() {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+/// An argument with an extension resolves to that exact node, not a `.md`-appended
+/// variant. With both `a.md` and `a.md.md` present, `lock a.md` must snapshot
+/// `a.md` — the `.md` fallback is only for a bare doc name.
+#[test]
+fn scoped_lock_of_an_extensioned_path_does_not_prefer_a_dot_md_variant() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("a.md"), "# A").unwrap();
+    fs::write(dir.path().join("a.md.md"), "# A dot md").unwrap();
+    lock(dir.path());
+
+    fs::write(dir.path().join("a.md"), "# A edited").unwrap();
+    fs::write(dir.path().join("a.md.md"), "# A dot md edited").unwrap();
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "lock", "a.md"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let stdout = check(dir.path());
+    assert!(
+        !stdout.contains("stale-node]: a.md "),
+        "a.md itself should have been locked, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("stale-node]: a.md.md"),
+        "a.md.md must stay stale — it was not the named path, got: {stdout}"
+    );
+}


### PR DESCRIPTION
Fixes #89.

## Problem

Scope-locking resolved a path only against the composed graph, so a path whose
file was deleted failed with `node not found` (exit 2). The only call that cleared
the resulting `removed-node` finding was bare `drft lock` — the whole-graph call
the workflow singles out as the one never to make. A routine deletion left a
finding whose only remedy was the prohibited call.

This builds on #82 (variadic `lock`) and keeps its atomic all-or-nothing semantics.

## Change

Resolve a lock path against the graph **or**, when its file is gone, against the
lockfile. Then make the lockfile reflect each named path's current state:

| named path | result |
| --- | --- |
| a node that carries content | re-snapshot it (as before) |
| a deleted file still in the lock | drop its entry — clears `removed-node` |
| a path that has become a hash-less directory | drop its entry (no-op if none) |
| resolves in neither graph nor lock | error, exit 2, whole call aborts |

Because a reviewed deletion now resolves (against the lock), naming it in a batch
just works: `drft lock index.md doomed.md` re-snapshots the live one and drops the
deleted one in one atomic write. The only remaining cause of a miss is a genuine
typo, where aborting the whole call is correct — so #82's atomic rule is preserved,
not reverted.

Also fixes a latent panic: locking a directory hit an `.expect` on the snapshot
(directory nodes carry no hash, so they are absent from it). It is now the same
drop-the-entry no-op.

## Tests

Four integration tests in `tests/lock.rs`: the drop, the batch (live + removed),
and the directory no-op; the existing atomic-abort test still holds. Full suite,
clippy `-D warnings`, and `fmt --check` pass.