### PR TITLE
feat: add drft nodes metadata projection (#90, increment 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ All rules default to `warn`. Override to `error` for CI enforcement or `off` to 
 | ------------- | ----------------------------------------------------------- |
 | `drft init`   | Create a default `drft.toml`                                |
 | `drft graph`  | Export the composed graph as JGF (`--raw` for the set)      |
+| `drft nodes`  | Project node metadata by path, subtree, or glob             |
 | `drft impact` | Show what depends on given files, sorted by review priority |
 | `drft check`  | Compare the graph against the lockfile for drift            |
 | `drft lock`   | Snapshot hashes to `drft.lock` for staleness tracking       |

--- a/drft.lock
+++ b/drft.lock
@@ -300,7 +300,7 @@ hash = "b3:b437206e0e16ea1a0643edda5d8b1ab7361816bb42222bc80e488e13329b0516"
 
 [[node]]
 path = "src/main.rs"
-hash = "b3:f6e7b95ab9eb1bf5f2fc560464220671963773e8e2f5afa9c11937fd842830aa"
+hash = "b3:b23403cf50afbb8fe1b5129b0d19e17021d8019c668589f34a9960c8028d35aa"
 
 [[node]]
 path = "src/model.rs"
@@ -308,7 +308,7 @@ hash = "b3:8c1fefc41499866612547a86607ed805cb3ad04adceaafbafaba59aa495a1c4e"
 
 [[node]]
 path = "src/nodes.rs"
-hash = "b3:5ad688839aca7d13501ab5916f64168e2a797c7ce9df4f18434743a4a032e9d6"
+hash = "b3:1c02814ec3c3cd546ce6245bad395daae5bea765ef857784b76fe6c630793344"
 
 [[node]]
 path = "src/parsers/frontmatter.rs"
@@ -376,7 +376,7 @@ hash = "b3:a4e6a7a9c1bec9cf0eee23d73d224ba35725928da4f0d1bb8671f1cf6a85f213"
 
 [[node]]
 path = "tests/nodes.rs"
-hash = "b3:3c04a48d346712c178ad1c85f0aeacd469b5c2c035d84fe6628af09044dcedb9"
+hash = "b3:5a150c88e48a59c6a010cbf87d0ba753d143494d4f9664610e8ca42acfacb9ae"
 
 [[node]]
 path = "tests/output.rs"

--- a/drft.lock
+++ b/drft.lock
@@ -98,7 +98,7 @@ hash = "b3:871c2fd5cdfe89fa6ff01664a1420bf40d0ab18c0e250e59a3ab27225f31bb0e"
 
 [[node]]
 path = "README.md"
-hash = "b3:ca38d7ba3882ce9e2aee9678932862967cf9a3497b0ee1d79ec0aea6ef3def22"
+hash = "b3:cf2229f3c176501f153d8512a2d24fd5889b72d5203b6880fd1ec5835185fe62"
 
 [[node.edge]]
 target = "CLAUDE.md"
@@ -157,7 +157,7 @@ target_hash = "b3:001783ea083536a80cc88600bce3816cc6c90106685e825fe3e23e29936d82
 
 [[node.edge]]
 target = "src/cli.rs"
-target_hash = "b3:d23b0f8d5686a9f340a4129384bac66abb10a8b5a6a12eabee05a409bf83907b"
+target_hash = "b3:a95863600566534eb07a41be3b45b50e3bae677ad8d177d7931da17c55b70fe1"
 
 [[node.edge]]
 target = "src/config.rs"
@@ -268,7 +268,7 @@ hash = "b3:f56fdcddee36a2cc7c9c55b619b80c0571ca85e89334e06741b157d4315d84d4"
 
 [[node]]
 path = "src/cli.rs"
-hash = "b3:d23b0f8d5686a9f340a4129384bac66abb10a8b5a6a12eabee05a409bf83907b"
+hash = "b3:a95863600566534eb07a41be3b45b50e3bae677ad8d177d7931da17c55b70fe1"
 
 [[node]]
 path = "src/compose.rs"
@@ -292,7 +292,7 @@ hash = "b3:297723111a36e1bf06d13b460e12175d1093505ec7df97149b52e6aa67921a55"
 
 [[node]]
 path = "src/lib.rs"
-hash = "b3:9bd6306f5e3878158b0e19958a2dafd3b1203e61afd544e2204081b212b04fb3"
+hash = "b3:18b71e751e2d963195b28bb7a14c02d8ddd5371b891a31c497c2797b0edf54c3"
 
 [[node]]
 path = "src/lock.rs"
@@ -300,11 +300,15 @@ hash = "b3:b437206e0e16ea1a0643edda5d8b1ab7361816bb42222bc80e488e13329b0516"
 
 [[node]]
 path = "src/main.rs"
-hash = "b3:7e79dbb71abcbbbbc2e07154df140fb6ac7f1c7dc127f869f08e6a5890e2e94d"
+hash = "b3:f6e7b95ab9eb1bf5f2fc560464220671963773e8e2f5afa9c11937fd842830aa"
 
 [[node]]
 path = "src/model.rs"
 hash = "b3:8c1fefc41499866612547a86607ed805cb3ad04adceaafbafaba59aa495a1c4e"
+
+[[node]]
+path = "src/nodes.rs"
+hash = "b3:5ad688839aca7d13501ab5916f64168e2a797c7ce9df4f18434743a4a032e9d6"
 
 [[node]]
 path = "src/parsers/frontmatter.rs"
@@ -369,6 +373,10 @@ hash = "b3:dc15abb7afc8314627fd1346ade4e129ad9796ddcbab651d82f342c15db03dfc"
 [[node]]
 path = "tests/lock.rs"
 hash = "b3:a4e6a7a9c1bec9cf0eee23d73d224ba35725928da4f0d1bb8671f1cf6a85f213"
+
+[[node]]
+path = "tests/nodes.rs"
+hash = "b3:3c04a48d346712c178ad1c85f0aeacd469b5c2c035d84fe6628af09044dcedb9"
 
 [[node]]
 path = "tests/output.rs"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,6 +57,22 @@ pub enum Commands {
         direction: Direction,
     },
 
+    /// Project nodes and their metadata, scoped by selector and narrowed by namespace/field
+    Nodes {
+        /// Globset patterns matched against node keys; a bare directory is its
+        /// recursive subtree. With none, every node is returned.
+        selectors: Vec<String>,
+
+        /// Restrict to a declared graph namespace (repeatable). Accepts the bare
+        /// name (`frontmatter`) or the prefixed key (`@frontmatter`).
+        #[arg(long = "namespace")]
+        namespaces: Vec<String>,
+
+        /// Restrict returned metadata to named fields (repeatable).
+        #[arg(long = "field")]
+        fields: Vec<String>,
+    },
+
     /// Check the composed graph against the lockfile for drift and structural findings
     Check,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod graphs;
 pub mod impact;
 pub mod lock;
 pub mod model;
+pub mod nodes;
 pub mod parsers;
 pub mod rules;
 pub mod sources;

--- a/src/main.rs
+++ b/src/main.rs
@@ -424,27 +424,33 @@ fn resolve_selector(
     }
 
     let mut matched: Vec<String> = Vec::new();
+    let prefix = graph_key(root, graph_root, selector);
 
-    // Exact, cwd-aware resolution (with the `.md` fallback), most-specific first. A
-    // file resolves to itself; a directory is represented by the subtree below, not
-    // the bare directory node — so `docs`, `docs/`, and `docs/**` name one set. A
-    // directory that exists but is empty is a legitimate empty result, not a typo.
-    let mut dir_hit = false;
-    for candidate in node_candidates(root, graph_root, selector) {
-        if let Some(node) = composed.nodes.get(&candidate) {
-            if node.fs_type() == Some("directory") {
-                dir_hit = true;
-            } else {
+    // Does the exact key (no `.md` fallback) name a directory node? Checking this
+    // before the fallback is what keeps a `docs.md` file from shadowing a `docs`
+    // directory when both exist. A trailing slash also declares a directory
+    // outright. Either way, a directory is represented by the subtree below, not the
+    // bare directory node — so `docs`, `docs/`, and `docs/**` name one set.
+    let names_dir = prefix
+        .as_deref()
+        .and_then(|key| composed.nodes.get(key))
+        .is_some_and(|node| node.fs_type() == Some("directory"));
+    let is_dir = names_dir || selector.ends_with('/');
+
+    // A non-directory selector resolves to an exact node, with the `.md` fallback
+    // impact/lock use, most-specific first. A file resolves to itself.
+    if !is_dir {
+        for candidate in node_candidates(root, graph_root, selector) {
+            if composed.nodes.contains_key(&candidate) {
                 matched.push(candidate);
+                break;
             }
-            break;
         }
     }
 
-    // Bare directory ⇒ recursive subtree (`docs/` ⇒ `docs/**`). `graph_key`
-    // normalizes the selector to a graph-root-relative prefix the same way exact
-    // resolution does.
-    if let Some(prefix) = graph_key(root, graph_root, selector) {
+    // Directory ⇒ recursive subtree (`docs/` ⇒ `docs/**`). `graph_key` normalizes
+    // the selector to a graph-root-relative prefix the same way exact resolution does.
+    if let Some(prefix) = &prefix {
         for key in glob_match_keys(composed, &format!("{prefix}/**"))? {
             if !matched.contains(&key) {
                 matched.push(key);
@@ -452,9 +458,10 @@ fn resolve_selector(
         }
     }
 
-    // A non-glob selector that resolves to nothing at all is a likely typo — error
-    // with a suggestion rather than reading as an empty answer.
-    if matched.is_empty() && !dir_hit {
+    // Nothing resolved is a likely typo — error with a suggestion — unless the
+    // selector named a real directory that simply has no descendants, which is a
+    // legitimate empty result.
+    if matched.is_empty() && !names_dir {
         return Err(not_found_error(composed.nodes.keys(), selector));
     }
     Ok(matched)

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use drft::config;
 use drft::graphs;
 use drft::impact;
 use drft::lock;
+use drft::nodes;
 use drft::rules;
 
 use anyhow::{Context, Result};
@@ -81,6 +82,11 @@ fn try_main() -> Result<i32> {
             direction,
         } => run_impact(&root, cli.format, paths, *depth, *direction),
         Commands::Graph { raw } => run_graph(&root, *raw),
+        Commands::Nodes {
+            selectors,
+            namespaces,
+            fields,
+        } => run_nodes(&root, cli.format, selectors, namespaces, fields),
         Commands::Check => run_check(&root, cli.format, cli.color),
     }
 }
@@ -306,6 +312,172 @@ fn run_graph(root: &Path, raw: bool) -> Result<i32> {
     };
     println!("{json}");
     Ok(0)
+}
+
+/// Project the composed graph's nodes and their metadata, scoped by `selectors`
+/// and narrowed by `namespaces`/`fields`. A reader: expanding a selector to many
+/// nodes is expected and has no side effect.
+fn run_nodes(
+    root: &Path,
+    format: OutputFormat,
+    selectors: &[String],
+    namespaces: &[String],
+    fields: &[String],
+) -> Result<i32> {
+    let graph_root = find_graph_root(root);
+    let config = Config::load(&graph_root)?;
+    let composed = compose::compose(&graphs::build_set(&graph_root, &config)?);
+
+    // Validate namespaces up front: a typo must error, not read as an empty
+    // answer. Normalize to the `@<graph>` keys the projection matches on.
+    let requested_ns = resolve_namespaces(&config, namespaces)?;
+
+    let keys = resolve_selectors(&composed, root, &graph_root, selectors)?;
+    let projected = nodes::project(&composed, &keys, &requested_ns, fields);
+
+    match format {
+        OutputFormat::Json => {
+            let output = serde_json::json!({
+                "total": projected.len(),
+                "nodes": projected,
+            });
+            println!("{}", serde_json::to_string_pretty(&output)?);
+        }
+        OutputFormat::Text => {
+            // One compact block per node — id, indented namespaces, fields — so a
+            // model can read it for grounding without parsing JSON.
+            print!("{}", nodes::format_text(&projected));
+        }
+    }
+
+    Ok(0)
+}
+
+/// Validate each requested namespace against the declared graphs (`fs` plus every
+/// `[graphs.*]`) and normalize it to its `@<graph>` metadata key, deduped in the
+/// order given. An unknown namespace is a typo — error, listing the declared
+/// graphs — so it never reads as an empty answer.
+fn resolve_namespaces(config: &Config, namespaces: &[String]) -> Result<Vec<String>> {
+    // `fs` plus every configured graph, sorted for a deterministic error listing.
+    let declared: std::collections::BTreeSet<&str> = config
+        .graphs
+        .keys()
+        .map(String::as_str)
+        .chain(std::iter::once("fs"))
+        .collect();
+
+    let mut normalized: Vec<String> = Vec::new();
+    for name in namespaces {
+        let bare = name.strip_prefix('@').unwrap_or(name);
+        if !declared.contains(bare) {
+            anyhow::bail!(
+                "unknown namespace \"{name}\" — declared graphs: {}",
+                declared.iter().copied().collect::<Vec<_>>().join(", ")
+            );
+        }
+        let key = nodes::normalize_namespace(name);
+        if !normalized.contains(&key) {
+            normalized.push(key);
+        }
+    }
+    Ok(normalized)
+}
+
+/// Resolve the positional selectors to node keys, sorted and deduped. With none,
+/// the whole node set. Each selector is a globset pattern over node keys, a bare
+/// directory (its recursive subtree), or an exact path — reusing `node_candidates`
+/// for the exact, cwd-aware resolution `impact`/`lock` already use.
+fn resolve_selectors(
+    composed: &drft::model::Graph,
+    root: &Path,
+    graph_root: &Path,
+    selectors: &[String],
+) -> Result<Vec<String>> {
+    if selectors.is_empty() {
+        return Ok(composed.nodes.keys().cloned().collect());
+    }
+
+    let mut keys = std::collections::BTreeSet::new();
+    for selector in selectors {
+        keys.extend(resolve_selector(composed, root, graph_root, selector)?);
+    }
+    Ok(keys.into_iter().collect())
+}
+
+/// Resolve one selector to matching node keys.
+///
+/// A glob selector matches its pattern against node keys, graph-root-relative like
+/// `drft.toml`'s `files`/`ignore`; an empty match is a legitimate query result. A
+/// selector with no glob metacharacters is resolved cwd-aware: an exact file
+/// resolves to itself, and a bare directory expands to its recursive subtree
+/// (`docs/` ⇒ `docs/**`) — the same set the glob spelling names, so there is no
+/// wrong spelling. An explicit path that matches nothing is a likely typo and
+/// errors with a suggestion, rather than reading as empty.
+fn resolve_selector(
+    composed: &drft::model::Graph,
+    root: &Path,
+    graph_root: &Path,
+    selector: &str,
+) -> Result<Vec<String>> {
+    if has_glob_meta(selector) {
+        return glob_match_keys(composed, selector);
+    }
+
+    let mut matched: Vec<String> = Vec::new();
+
+    // Exact, cwd-aware resolution (with the `.md` fallback), most-specific first. A
+    // file resolves to itself; a directory is represented by the subtree below, not
+    // the bare directory node — so `docs`, `docs/`, and `docs/**` name one set. A
+    // directory that exists but is empty is a legitimate empty result, not a typo.
+    let mut dir_hit = false;
+    for candidate in node_candidates(root, graph_root, selector) {
+        if let Some(node) = composed.nodes.get(&candidate) {
+            if node.fs_type() == Some("directory") {
+                dir_hit = true;
+            } else {
+                matched.push(candidate);
+            }
+            break;
+        }
+    }
+
+    // Bare directory ⇒ recursive subtree (`docs/` ⇒ `docs/**`). `graph_key`
+    // normalizes the selector to a graph-root-relative prefix the same way exact
+    // resolution does.
+    if let Some(prefix) = graph_key(root, graph_root, selector) {
+        for key in glob_match_keys(composed, &format!("{prefix}/**"))? {
+            if !matched.contains(&key) {
+                matched.push(key);
+            }
+        }
+    }
+
+    // A non-glob selector that resolves to nothing at all is a likely typo — error
+    // with a suggestion rather than reading as an empty answer.
+    if matched.is_empty() && !dir_hit {
+        return Err(not_found_error(composed.nodes.keys(), selector));
+    }
+    Ok(matched)
+}
+
+/// Whether a selector carries glob metacharacters — the signal that switches it
+/// from an exact/subtree path to a pattern matched against node keys.
+fn has_glob_meta(selector: &str) -> bool {
+    selector.contains(['*', '?', '[', ']', '{', '}'])
+}
+
+/// Match one glob pattern against the composed graph's node keys, graph-root-
+/// relative like `drft.toml`'s `files`/`ignore`. Node keys iterate sorted, so the
+/// result is sorted; an empty match is a legitimate reader result.
+fn glob_match_keys(composed: &drft::model::Graph, pattern: &str) -> Result<Vec<String>> {
+    let set = drft::config::compile_globs(std::slice::from_ref(&pattern.to_string()))?
+        .expect("a single non-empty pattern compiles to a set");
+    Ok(composed
+        .nodes
+        .keys()
+        .filter(|k| set.is_match(k.as_str()))
+        .cloned()
+        .collect())
 }
 
 /// List nodes that transitively depend on `paths` (a structural query; `paths`

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -119,15 +119,15 @@ pub fn format_text(nodes: &[NodeProjection]) -> String {
     format!("{}\n", blocks.join("\n\n"))
 }
 
-/// Render a metadata value for text output: a bare string/number/bool prints as
-/// itself; an array or object prints as compact JSON so the block stays scannable.
+/// Render a metadata value for text output. An ordinary string prints bare; a
+/// string carrying control characters — a YAML block scalar's newlines, say —
+/// would break the one-line-per-field layout (and an embedded blank line could
+/// read as a node separator), so it renders as compact JSON like every array,
+/// object, number, or bool: the controls are escaped and the field stays one line.
 fn render_value(value: &Value) -> String {
     match value {
-        Value::String(s) => s.clone(),
-        Value::Bool(b) => b.to_string(),
-        Value::Number(n) => n.to_string(),
-        Value::Null => "null".to_string(),
-        other => other.to_string(),
+        Value::String(s) if !s.chars().any(char::is_control) => s.clone(),
+        _ => value.to_string(),
     }
 }
 
@@ -236,5 +236,29 @@ mod tests {
     #[test]
     fn format_text_empty_is_blank() {
         assert_eq!(format_text(&[]), "");
+    }
+
+    #[test]
+    fn multiline_string_renders_escaped_to_stay_one_line() {
+        // A YAML block scalar's newline must not break the one-line-per-field layout
+        // or read as a node separator: it renders as escaped JSON on a single line.
+        let mut g = Graph::composed();
+        g.set_node(
+            "docs/a.md",
+            Node::new(obj(json!({
+                "@frontmatter": { "purpose": "line one\nline two" },
+                "@fs": { "type": "file", "hash": "b3:1" }
+            }))),
+        );
+        let out = project(
+            &g,
+            &["docs/a.md".into()],
+            &["@frontmatter".into()],
+            &["purpose".into()],
+        );
+        assert_eq!(
+            format_text(&out),
+            "docs/a.md\n  @frontmatter\n    purpose: \"line one\\nline two\"\n"
+        );
     }
 }

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -1,0 +1,240 @@
+//! `drft nodes`: project node metadata for a set of paths — the read verb that
+//! grounds an LLM (or a human) on what the graph knows about each node.
+//!
+//! `nodes` is a *reader*: its selectors expand (an exact path, a subtree, or a
+//! glob), which is safe because a read has no side effect. This module owns the
+//! pure projection and rendering — narrowing each node's composed metadata by
+//! namespace (which lens) and field (which keys), then formatting it as compact
+//! text or JSON. Selector-to-key resolution and namespace validation live in
+//! `main.rs`, next to the shared `node_candidates`/`resolve_node` resolver and
+//! the loaded config they need.
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::model::{Graph, namespace};
+
+/// Normalize a `--namespace` value to its `@`-prefixed metadata key. Accepts the
+/// bare config name (`frontmatter`) or the already-prefixed form (`@frontmatter`),
+/// since the prefixed form appears in JSON output and gets copied from there.
+/// Validation against the declared graphs happens at the call site, where the
+/// config is in hand.
+pub fn normalize_namespace(name: &str) -> String {
+    namespace(name.strip_prefix('@').unwrap_or(name))
+}
+
+/// A projected node: its id and the namespaced metadata that survived the
+/// namespace/field filters. `metadata` holds only `@<graph>` blocks — the
+/// `_graphs` provenance is dropped, since this is a focused projection for
+/// grounding, not the full-fidelity composed node (`drft graph` gives that).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct NodeProjection {
+    pub id: String,
+    pub metadata: Map<String, Value>,
+}
+
+/// Project `keys` out of `graph`, narrowing each node's metadata to `namespaces`
+/// (empty = every `@` namespace) and `fields` (empty = every key).
+///
+/// A node drops out when a namespace filter is set and it carries none of the
+/// requested namespaces, or when a field filter is set and none of the requested
+/// fields appear in any shown namespace. Both are legitimate empties (exit zero),
+/// not errors: a field filter answers *which* nodes declare the field.
+pub fn project(
+    graph: &Graph,
+    keys: &[String],
+    namespaces: &[String],
+    fields: &[String],
+) -> Vec<NodeProjection> {
+    let mut out = Vec::new();
+    for key in keys {
+        let Some(node) = graph.nodes.get(key) else {
+            continue;
+        };
+        let mut metadata = Map::new();
+        for (ns, value) in &node.metadata {
+            // Only `@<graph>` lenses are projected; `_graphs` provenance is not.
+            if !ns.starts_with('@') {
+                continue;
+            }
+            if !namespaces.is_empty() && !namespaces.contains(ns) {
+                continue;
+            }
+            let block = if fields.is_empty() {
+                value.clone()
+            } else {
+                let Some(obj) = value.as_object() else {
+                    continue;
+                };
+                let filtered: Map<String, Value> = obj
+                    .iter()
+                    .filter(|(k, _)| fields.iter().any(|f| f == *k))
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                if filtered.is_empty() {
+                    continue;
+                }
+                Value::Object(filtered)
+            };
+            metadata.insert(ns.clone(), block);
+        }
+        // A namespace or field filter that left nothing means this node does not
+        // carry what was asked for — drop it rather than emit an empty block.
+        if metadata.is_empty() && (!namespaces.is_empty() || !fields.is_empty()) {
+            continue;
+        }
+        out.push(NodeProjection {
+            id: key.clone(),
+            metadata,
+        });
+    }
+    out
+}
+
+/// Render projected nodes as a compact, LLM-legible block per node: the node id
+/// flush-left, each namespace indented under it, each field under that. Blocks
+/// are separated by a blank line and the output ends in a newline. Scalars render
+/// inline; arrays and objects render as compact JSON. An empty projection renders
+/// to the empty string (no trailing newline), so piping stays clean.
+pub fn format_text(nodes: &[NodeProjection]) -> String {
+    if nodes.is_empty() {
+        return String::new();
+    }
+    let mut blocks = Vec::new();
+    for node in nodes {
+        let mut lines = vec![node.id.clone()];
+        for (ns, value) in &node.metadata {
+            lines.push(format!("  {ns}"));
+            match value.as_object() {
+                Some(obj) => {
+                    for (k, v) in obj {
+                        lines.push(format!("    {k}: {}", render_value(v)));
+                    }
+                }
+                None => lines.push(format!("    {}", render_value(value))),
+            }
+        }
+        blocks.push(lines.join("\n"));
+    }
+    format!("{}\n", blocks.join("\n\n"))
+}
+
+/// Render a metadata value for text output: a bare string/number/bool prints as
+/// itself; an array or object prints as compact JSON so the block stays scannable.
+fn render_value(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::Null => "null".to_string(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Node;
+    use serde_json::json;
+
+    fn obj(value: Value) -> Map<String, Value> {
+        value.as_object().unwrap().clone()
+    }
+
+    fn sample_graph() -> Graph {
+        let mut g = Graph::composed();
+        g.set_node(
+            "docs/a.md",
+            Node::new(obj(json!({
+                "@fs": { "type": "file", "hash": "b3:1" },
+                "@frontmatter": { "purpose": "explain a", "status": "draft" },
+                "_graphs": ["@frontmatter", "@fs"]
+            }))),
+        );
+        g.set_node(
+            "docs/b.md",
+            Node::new(obj(json!({
+                "@fs": { "type": "file", "hash": "b3:2" },
+                "@frontmatter": { "status": "final" },
+                "_graphs": ["@frontmatter", "@fs"]
+            }))),
+        );
+        g.set_node(
+            "src/lib.rs",
+            Node::new(obj(json!({
+                "@fs": { "type": "file", "hash": "b3:3" },
+                "_graphs": ["@fs"]
+            }))),
+        );
+        g
+    }
+
+    #[test]
+    fn normalize_namespace_accepts_bare_and_prefixed() {
+        assert_eq!(normalize_namespace("frontmatter"), "@frontmatter");
+        assert_eq!(normalize_namespace("@fs"), "@fs");
+    }
+
+    #[test]
+    fn project_without_filters_keeps_all_namespaces() {
+        let g = sample_graph();
+        let out = project(&g, &["docs/a.md".into()], &[], &[]);
+        assert_eq!(out.len(), 1);
+        // Provenance is dropped; every `@` lens is kept.
+        assert!(out[0].metadata.contains_key("@fs"));
+        assert!(out[0].metadata.contains_key("@frontmatter"));
+        assert!(!out[0].metadata.contains_key("_graphs"));
+    }
+
+    #[test]
+    fn namespace_filter_drops_nodes_without_the_lens() {
+        let g = sample_graph();
+        let keys = vec!["docs/a.md".into(), "src/lib.rs".into()];
+        let out = project(&g, &keys, &["@frontmatter".into()], &[]);
+        // src/lib.rs has no @frontmatter block, so it drops out.
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, "docs/a.md");
+        assert_eq!(
+            out[0].metadata.keys().collect::<Vec<_>>(),
+            vec!["@frontmatter"]
+        );
+    }
+
+    #[test]
+    fn field_filter_lists_only_nodes_that_declare_it() {
+        let g = sample_graph();
+        let keys = vec!["docs/a.md".into(), "docs/b.md".into()];
+        let out = project(&g, &keys, &["@frontmatter".into()], &["purpose".into()]);
+        // Only a.md declares `purpose`; b.md drops out.
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, "docs/a.md");
+        assert_eq!(
+            out[0].metadata["@frontmatter"],
+            json!({ "purpose": "explain a" })
+        );
+    }
+
+    #[test]
+    fn field_filter_with_no_matches_is_empty_not_error() {
+        let g = sample_graph();
+        let keys = vec!["docs/a.md".into(), "docs/b.md".into()];
+        let out = project(&g, &keys, &["@frontmatter".into()], &["nonexistent".into()]);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn format_text_is_one_block_per_node() {
+        let g = sample_graph();
+        let out = project(&g, &["docs/a.md".into()], &["@frontmatter".into()], &[]);
+        let text = format_text(&out);
+        assert_eq!(
+            text,
+            "docs/a.md\n  @frontmatter\n    purpose: explain a\n    status: draft\n"
+        );
+    }
+
+    #[test]
+    fn format_text_empty_is_blank() {
+        assert_eq!(format_text(&[]), "");
+    }
+}

--- a/tests/nodes.rs
+++ b/tests/nodes.rs
@@ -1,0 +1,323 @@
+mod common;
+use common::drft_bin;
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// A graph with a plain root doc and a `docs/` subtree whose files carry
+/// frontmatter, one with a `purpose` key and one without.
+fn fixture() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("index.md"), "# Index, no frontmatter").unwrap();
+
+    let docs = dir.path().join("docs");
+    fs::create_dir_all(docs.join("sub")).unwrap();
+    fs::write(
+        docs.join("a.md"),
+        "---\npurpose: explains a\nstatus: draft\n---\n\n# A",
+    )
+    .unwrap();
+    fs::write(docs.join("b.md"), "---\nstatus: final\n---\n\n# B").unwrap();
+    fs::write(
+        docs.join("sub").join("c.md"),
+        "---\npurpose: explains c\n---\n\n# C",
+    )
+    .unwrap();
+    dir
+}
+
+fn nodes_json(dir: &Path, extra: &[&str]) -> Value {
+    let mut args = vec!["-C", dir.to_str().unwrap(), "--format", "json", "nodes"];
+    args.extend_from_slice(extra);
+    let output = drft_bin().args(&args).output().unwrap();
+    assert!(
+        output.status.success(),
+        "drft nodes failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("valid JSON")
+}
+
+/// The node ids in a projection, in order.
+fn ids(v: &Value) -> Vec<String> {
+    v["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|n| n["id"].as_str().unwrap().to_string())
+        .collect()
+}
+
+/// A node's projected metadata by id.
+fn meta<'a>(v: &'a Value, id: &str) -> &'a Value {
+    v["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|n| n["id"] == id)
+        .unwrap_or_else(|| panic!("node {id} not in projection"))
+        .get("metadata")
+        .unwrap()
+}
+
+/// An exact file path projects that one node with all its namespace blocks.
+#[test]
+fn exact_path_projects_one_node() {
+    let dir = fixture();
+    let v = nodes_json(dir.path(), &["docs/a.md"]);
+    assert_eq!(v["total"], 1);
+    assert_eq!(ids(&v), vec!["docs/a.md"]);
+    // Both the fs facts and the frontmatter block come through; _graphs does not.
+    let m = meta(&v, "docs/a.md");
+    assert_eq!(m["@fs"]["type"], "file");
+    assert_eq!(m["@frontmatter"]["purpose"], "explains a");
+    assert!(m.get("_graphs").is_none());
+}
+
+/// A bare directory is sugar for its recursive subtree: every node under `docs/`,
+/// including nested ones, and nothing above it.
+#[test]
+fn bare_directory_selects_subtree() {
+    let dir = fixture();
+    let v = nodes_json(dir.path(), &["docs/"]);
+    let keys = ids(&v);
+    assert!(keys.iter().any(|k| k == "docs/a.md"));
+    assert!(keys.iter().any(|k| k == "docs/b.md"));
+    assert!(
+        keys.iter().any(|k| k == "docs/sub/c.md"),
+        "subtree recurses, got: {keys:?}"
+    );
+    assert!(
+        !keys.iter().any(|k| k == "index.md"),
+        "nothing above docs/, got: {keys:?}"
+    );
+}
+
+/// A glob pattern matches node keys with the same vocabulary as `drft.toml` —
+/// `*` stays within a path component, so `docs/*.md` excludes the nested file.
+#[test]
+fn glob_pattern_matches_node_keys() {
+    let dir = fixture();
+    let v = nodes_json(dir.path(), &["docs/*.md"]);
+    let keys = ids(&v);
+    assert!(keys.iter().any(|k| k == "docs/a.md"));
+    assert!(keys.iter().any(|k| k == "docs/b.md"));
+    assert!(
+        !keys.iter().any(|k| k == "docs/sub/c.md"),
+        "`*` does not cross a path separator, got: {keys:?}"
+    );
+}
+
+/// With no selector, every node in the graph is returned.
+#[test]
+fn no_selector_returns_all_nodes() {
+    let dir = fixture();
+    let v = nodes_json(dir.path(), &[]);
+    let keys = ids(&v);
+    for path in [
+        "index.md",
+        "docs/a.md",
+        "docs/b.md",
+        "docs/sub/c.md",
+        "drft.toml",
+    ] {
+        assert!(keys.iter().any(|k| k == path), "missing node {path}");
+    }
+}
+
+/// `--namespace` filters the node set as well as the metadata: a node with no
+/// block for the requested namespace drops out rather than appearing empty.
+#[test]
+fn namespace_filters_node_set_and_metadata() {
+    let dir = fixture();
+    let v = nodes_json(dir.path(), &["--namespace", "frontmatter"]);
+    let keys = ids(&v);
+    // index.md and drft.toml have no frontmatter block, so they drop out.
+    assert!(
+        !keys.iter().any(|k| k == "index.md"),
+        "no frontmatter → dropped"
+    );
+    assert!(
+        !keys.iter().any(|k| k == "drft.toml"),
+        "no frontmatter → dropped"
+    );
+    // The docs remain, restricted to their @frontmatter block (no @fs).
+    let a = meta(&v, "docs/a.md");
+    assert!(a.get("@frontmatter").is_some());
+    assert!(
+        a.get("@fs").is_none(),
+        "metadata restricted to the namespace"
+    );
+}
+
+/// The `@`-prefixed namespace form is accepted alongside the bare name.
+#[test]
+fn namespace_accepts_prefixed_form() {
+    let dir = fixture();
+    let v = nodes_json(dir.path(), &["docs/a.md", "--namespace", "@fs"]);
+    let a = meta(&v, "docs/a.md");
+    assert!(a.get("@fs").is_some());
+    assert!(a.get("@frontmatter").is_none());
+}
+
+/// An unknown namespace is a typo, not an empty answer: it errors (exit 2) and
+/// lists the declared graphs.
+#[test]
+fn unknown_namespace_errors_and_lists_declared() {
+    let dir = fixture();
+    let output = drft_bin()
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "nodes",
+            "--namespace",
+            "bogus",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unknown namespace"), "got: {stderr}");
+    assert!(
+        stderr.contains("fs") && stderr.contains("frontmatter") && stderr.contains("markdown"),
+        "declared graphs should be listed, got: {stderr}"
+    );
+}
+
+/// `--field` narrows returned metadata to named keys and drops nodes that do not
+/// declare it — the projection answers which files carry the field.
+#[test]
+fn field_narrows_and_lists_only_declaring_nodes() {
+    let dir = fixture();
+    let v = nodes_json(
+        dir.path(),
+        &["docs/", "--namespace", "frontmatter", "--field", "purpose"],
+    );
+    let keys = ids(&v);
+    // a.md and sub/c.md declare purpose; b.md does not and drops out.
+    assert!(keys.iter().any(|k| k == "docs/a.md"));
+    assert!(keys.iter().any(|k| k == "docs/sub/c.md"));
+    assert!(
+        !keys.iter().any(|k| k == "docs/b.md"),
+        "a node without the field drops out, got: {keys:?}"
+    );
+    assert_eq!(
+        meta(&v, "docs/a.md")["@frontmatter"]["purpose"],
+        "explains a"
+    );
+}
+
+/// An unmatched field is a legitimate empty result, not an error: exit 0 with no
+/// nodes.
+#[test]
+fn unmatched_field_is_empty_not_an_error() {
+    let dir = fixture();
+    let output = drft_bin()
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+            "nodes",
+            "docs/a.md",
+            "--field",
+            "nonexistent",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "unmatched field is not an error");
+    let v: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["total"], 0);
+    assert!(v["nodes"].as_array().unwrap().is_empty());
+}
+
+/// A glob that matches nothing is a valid query with an empty result (exit 0),
+/// distinct from a mistyped exact path.
+#[test]
+fn empty_glob_match_is_exit_zero() {
+    let dir = fixture();
+    let output = drft_bin()
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+            "nodes",
+            "nonesuch/**",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let v: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["total"], 0);
+}
+
+/// A mistyped exact path or directory errors rather than reading as an empty
+/// answer.
+#[test]
+fn missing_exact_path_errors() {
+    let dir = fixture();
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "nodes", "docs/ghost.md"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("node not found"), "got: {stderr}");
+}
+
+/// Text output is a node id followed by its indented namespace/field metadata,
+/// one node per block — legible without parsing JSON.
+#[test]
+fn text_format_is_node_then_indented_metadata() {
+    let dir = fixture();
+    let output = drft_bin()
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "nodes",
+            "docs/a.md",
+            "--namespace",
+            "frontmatter",
+            "--field",
+            "purpose",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        "docs/a.md\n  @frontmatter\n    purpose: explains a\n"
+    );
+}
+
+/// Text output defaults without `--format` and separates node blocks with a blank
+/// line.
+#[test]
+fn text_format_is_the_default_and_separates_nodes() {
+    let dir = fixture();
+    let output = drft_bin()
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "nodes",
+            "docs/",
+            "--namespace",
+            "frontmatter",
+            "--field",
+            "status",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // a.md (status: draft) then a blank line then b.md.
+    assert!(stdout.contains("docs/a.md\n"), "got: {stdout}");
+    assert!(
+        stdout.contains("status: draft\n\ndocs/b.md"),
+        "blank line between node blocks, got: {stdout}"
+    );
+}

--- a/tests/nodes.rs
+++ b/tests/nodes.rs
@@ -321,3 +321,29 @@ fn text_format_is_the_default_and_separates_nodes() {
         "blank line between node blocks, got: {stdout}"
     );
 }
+
+/// When a `docs.md` file and a `docs/` directory both exist, every spelling of the
+/// directory selector still names exactly the subtree — the sibling file must not
+/// leak in, so `docs`, `docs/`, and `docs/**` stay one set.
+#[test]
+fn directory_selector_is_not_shadowed_by_a_sibling_md_file() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("docs.md"), "# Docs, the file").unwrap();
+    let docs = dir.path().join("docs");
+    fs::create_dir_all(&docs).unwrap();
+    fs::write(docs.join("a.md"), "# A").unwrap();
+
+    for sel in ["docs", "docs/", "docs/**"] {
+        let v = nodes_json(dir.path(), &[sel]);
+        let keys = ids(&v);
+        assert!(
+            keys.iter().any(|k| k == "docs/a.md"),
+            "{sel}: names the subtree, got {keys:?}"
+        );
+        assert!(
+            !keys.iter().any(|k| k == "docs.md"),
+            "{sel}: the sibling file must not leak in, got {keys:?}"
+        );
+    }
+}


### PR DESCRIPTION
## drft nodes — a scoped read of the graph's node half

First increment of the #90 query surface: the `nodes` read verb, the
smallest slice that delivers the primary case — grounding an LLM by
reading node metadata at a path.

    drft nodes <SELECTOR…> [--namespace <g>…] [--field <k>…] [--format text|json]

### Selector
- Exact node path — cwd-aware, with the `.md` fallback impact/lock use
- Bare directory ⇒ recursive subtree (`docs/` ⇒ `docs/**`)
- Globset pattern over node keys — same vocabulary as drft.toml files/ignore
- No selector ⇒ every node

`nodes` is a reader, so selector expansion is safe. `docs`, `docs/`, and
`docs/**` all name the identical set (the bare directory node is excluded,
matching the glob). A mistyped exact path errors with a suggestion; an
empty glob match is exit 0.

### Filters
- `--namespace` (bare or `@`-prefixed) filters the node set and the
  metadata; unknown namespace errors listing the declared graphs.
- `--field` narrows to named keys and lists only nodes declaring the
  field; a wholly unmatched field is a legitimate empty result.

### Output
Text is one compact block per node (id, indented namespaces/fields,
containers as compact JSON) for grounding without parsing JSON. JSON is
`{ "total", "nodes": [{ "id", "metadata" }] }`; `_graphs` provenance is
dropped (`drft graph` remains the full-fidelity view).

### Tests
Unit tests in `src/nodes.rs` cover projection and rendering; `tests/nodes.rs`
covers selector resolution, namespace/field filtering, error-vs-empty
behavior, and text/JSON output.

`edges`, `graph --format text`, and opt-in inline evaluations are deferred
to later increments per the design.