### PR TITLE
Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to drft are documented here.
 
+## 0.14.0 (2026-08-18)
+
+Adds the first read verb of the #90 query surface. `drft nodes` reads what the graph knows about a set of paths, so an agent can ground itself on a file's metadata without exporting and parsing the whole composed graph.
+
+### New
+
+- **`drft nodes` projects node metadata** (#90). `drft nodes <selector…> [--namespace <g>…] [--field <k>…] [--format text|json]` reads the composed graph's node half, scoped by a selector and narrowed by namespace and field. A selector is an exact path (cwd-aware, with the `.md` fallback `impact` and `lock` use), a bare directory standing for its recursive subtree (`docs/` ⇒ `docs/**`), or a globset pattern over node keys — the same vocabulary as `drft.toml`'s `files`/`ignore` — and `docs`, `docs/`, and `docs/**` all name one set. `--namespace` accepts the bare graph name or its `@`-prefixed key, filters the node set as well as the metadata, and errors on an unknown namespace with the declared graphs listed; `--field` narrows to named keys and lists only the nodes that declare them, so a wholly unmatched field is a legitimate empty result rather than an error. Text output is a first-class projection — one compact block per node — for reading without parsing JSON; JSON carries `{ total, nodes: [{ id, metadata }] }`. As a reader it expands selectors freely, so a mistyped path errors while an empty glob is exit 0. First increment of #90; `edges` and `graph --format text` follow.
+
+### Fixed
+
+- **`drft lock` clears a removed node when you name its deleted path** (#89). A file deleted from the graph left a `removed-node` finding that nothing could clear, because the path no longer resolved to a node to re-snapshot. Naming the vanished path now drops its lockfile entry, so a reviewed deletion clears the finding — the case the live graph alone could not resolve. Relatedly, the `.md` fallback is only tried when the named path has no extension, so locking `guide.md` no longer also invents a `guide.md.md` candidate.
+
 ## 0.13.0 (2026-07-30)
 
 Makes the honest form of `drft lock` the convenient one, so agent guidance can scope the lock rather than ban it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "drft-cli"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drft-cli"
-version = "0.13.0"
+version = "0.14.0"
 categories = ["command-line-utilities", "development-tools"]
 edition = "2024"
 homepage = "https://github.com/johnmdonahue/drft-cli"

--- a/drft.lock
+++ b/drft.lock
@@ -22,7 +22,7 @@ hash = "b3:2a96e992de334b67fe25ad9bfd611a83ee491da2a51160d1ed6344a02b764042"
 
 [[node]]
 path = "CHANGELOG.md"
-hash = "b3:e618e0bd862d56006bd5eadd1ee0f7b1d3c91edd70a7e02b3cb6c21f7d2f1cbb"
+hash = "b3:ab3a9ddb1742000bfd71328380ef590d8604c2b40cdb17cbb88a178d03515185"
 
 [[node]]
 path = "CLAUDE.md"
@@ -90,7 +90,7 @@ target_hash = "b3:6ce4d5c42026071af2b68201e9debff0112ad9d9d8d8fc75d16d562d5fc1a7
 
 [[node]]
 path = "Cargo.toml"
-hash = "b3:6999c4af4db67a6f5a4c59cdb90d8d493bb33927ddeb6a5217bcc411d9505f50"
+hash = "b3:f7fd681ddd5591bc914d91f9c5113857242288413c0449933f39ff0066085c26"
 
 [[node]]
 path = "LICENSE"


### PR DESCRIPTION
Release **v0.14.0**.

### New
- **`drft nodes`** — the first read verb of the #90 query surface: project node
  metadata scoped by a selector and narrowed by `--namespace`/`--field`, in
  compact text (for LLM grounding) or JSON. Shipped in #93.

### Fixed
- **`drft lock` clears a removed node when you name its deleted path** (#89) — a
  reviewed deletion can now clear its `removed-node` finding; the `.md` fallback
  only applies to extension-less paths.

Version bumped in `Cargo.toml`, `CHANGELOG.md` updated, and `drft lock` run so
the release commit itself passes `drft check`. Tag `v0.14.0` on `main` after
merge to trigger the release + publish workflows.