### PR TITLE
fix: frontmatter metadata carries the edge-scan mask (#95)

### DIFF
--- a/drft.lock
+++ b/drft.lock
@@ -189,7 +189,7 @@ target_hash = "b3:8b71e3f3697412fa4f88a0e9dbd52a66c7f68549cf1869b5da1b5c2c76b712
 
 [[node.edge]]
 target = "src/parsers/frontmatter.rs"
-target_hash = "b3:5170b0ce6856f4583e22ca7cbdaf32520426f321305a0c3f63cc4e20e35ecbe2"
+target_hash = "b3:6640fe4094f0be266b563aa689139d448700c4fd2d602339bc8c5ddb39379f86"
 
 [[node]]
 path = "docs/parsers/markdown.md"
@@ -312,7 +312,7 @@ hash = "b3:1c02814ec3c3cd546ce6245bad395daae5bea765ef857784b76fe6c630793344"
 
 [[node]]
 path = "src/parsers/frontmatter.rs"
-hash = "b3:5170b0ce6856f4583e22ca7cbdaf32520426f321305a0c3f63cc4e20e35ecbe2"
+hash = "b3:6640fe4094f0be266b563aa689139d448700c4fd2d602339bc8c5ddb39379f86"
 
 [[node]]
 path = "src/parsers/markdown.rs"

--- a/drft.lock
+++ b/drft.lock
@@ -189,7 +189,7 @@ target_hash = "b3:8b71e3f3697412fa4f88a0e9dbd52a66c7f68549cf1869b5da1b5c2c76b712
 
 [[node.edge]]
 target = "src/parsers/frontmatter.rs"
-target_hash = "b3:1015955f3d9f463269bf20afbc80451a83a1366ba886d0e1c1733ff586d7f2c6"
+target_hash = "b3:3141acca048acfba229b56cd48b537988a2e5d8091fd0eb01e7e47c9926c345f"
 
 [[node]]
 path = "docs/parsers/markdown.md"
@@ -312,7 +312,7 @@ hash = "b3:1c02814ec3c3cd546ce6245bad395daae5bea765ef857784b76fe6c630793344"
 
 [[node]]
 path = "src/parsers/frontmatter.rs"
-hash = "b3:1015955f3d9f463269bf20afbc80451a83a1366ba886d0e1c1733ff586d7f2c6"
+hash = "b3:3141acca048acfba229b56cd48b537988a2e5d8091fd0eb01e7e47c9926c345f"
 
 [[node]]
 path = "src/parsers/markdown.rs"

--- a/drft.lock
+++ b/drft.lock
@@ -189,7 +189,7 @@ target_hash = "b3:8b71e3f3697412fa4f88a0e9dbd52a66c7f68549cf1869b5da1b5c2c76b712
 
 [[node.edge]]
 target = "src/parsers/frontmatter.rs"
-target_hash = "b3:6640fe4094f0be266b563aa689139d448700c4fd2d602339bc8c5ddb39379f86"
+target_hash = "b3:1015955f3d9f463269bf20afbc80451a83a1366ba886d0e1c1733ff586d7f2c6"
 
 [[node]]
 path = "docs/parsers/markdown.md"
@@ -312,7 +312,7 @@ hash = "b3:1c02814ec3c3cd546ce6245bad395daae5bea765ef857784b76fe6c630793344"
 
 [[node]]
 path = "src/parsers/frontmatter.rs"
-hash = "b3:6640fe4094f0be266b563aa689139d448700c4fd2d602339bc8c5ddb39379f86"
+hash = "b3:1015955f3d9f463269bf20afbc80451a83a1366ba886d0e1c1733ff586d7f2c6"
 
 [[node]]
 path = "src/parsers/markdown.rs"

--- a/src/parsers/frontmatter.rs
+++ b/src/parsers/frontmatter.rs
@@ -179,10 +179,15 @@ impl FrontmatterParser {
 
 /// Capture the frontmatter block as node metadata. Prefers the *raw* block so a
 /// code span in a value — the service name or path an author put in backticks —
-/// survives as the prose it is, instead of coming back blanked. Falls back to the
-/// masked block only when the raw block is not valid YAML on its own (a code span
-/// can hide a `:` that would otherwise break the mapping), and returns `None` when
-/// there is no frontmatter block at all.
+/// survives as the prose it is, instead of coming back blanked.
+///
+/// Falls back to the masked block only when the raw block is not valid YAML on its
+/// own: an unquoted value that *begins* with a backtick, or hides a `:` inside a
+/// span, is rejected by every YAML parser (backtick is a reserved indicator), so
+/// drft — not a YAML linter — cannot recover it. The fallback keeps the sibling
+/// fields structured at the cost of blanking that one span; the author's fix is to
+/// quote the value or use a `|` block scalar, both of which the raw path captures
+/// verbatim. Returns `None` when there is no frontmatter block at all.
 fn extract_metadata(content: &str) -> Option<serde_json::Value> {
     // Prefer the raw block so code spans survive as prose.
     if let Some(block) = frontmatter_block(content)
@@ -199,12 +204,15 @@ fn extract_metadata(content: &str) -> Option<serde_json::Value> {
     docs.first().map(to_json)
 }
 
-/// Extract the YAML frontmatter block — the text between the opening `---` and
-/// the next `\n---`, or `None` when there is no well-formed block. Works on either
-/// the masked copy (for the edge scan) or the raw content (for metadata): masking
-/// preserves offsets and newlines, so both agree on the block's boundaries. The
-/// slice keeps the newline that follows the opening fence, so a node's line within
-/// the block equals its line within the file.
+/// Extract the YAML frontmatter block — the text between the opening `---` and the
+/// next `\n---`, or `None` when there is no well-formed block. Callable on the raw
+/// content (for metadata) or the masked copy (for the edge scan). The two usually
+/// agree on the block, but need not: `strip_code` blanks a whole span, newlines
+/// included, so a `\n---` hidden inside a code span survives in the raw content but
+/// not the masked copy, and the two then find different boundaries — one reason
+/// metadata and the edge scan run as independent buffers. The slice keeps the
+/// newline after the opening fence, so a node's line within the block equals its
+/// line within the file.
 fn frontmatter_block(stripped: &str) -> Option<&str> {
     let rest = stripped.strip_prefix("---")?;
     let end = rest.find("\n---")?;
@@ -517,14 +525,33 @@ mod tests {
 
     #[test]
     fn metadata_falls_back_to_masked_when_raw_is_not_valid_yaml() {
-        // A code span hiding a `:` makes the raw block ambiguous YAML; the masked
-        // parse stands in so the block still yields structured metadata (the span
-        // blanks in the fallback) rather than being dropped whole.
+        // A code span hiding a `:` makes the raw block invalid YAML; the masked
+        // parse stands in so the block still yields structured metadata rather than
+        // being dropped whole. `title` blanks to null — the tell that the *masked*
+        // path ran, not raw (raw would keep the backticks or fail outright) — while
+        // the sibling `status` comes through.
         let content = "---\ntitle: `key: value`\nstatus: draft\n---\n";
         let meta = parse(content)
             .metadata
-            .expect("masked fallback keeps metadata when raw YAML is ambiguous");
+            .expect("masked fallback keeps metadata when raw YAML is invalid");
+        assert!(
+            meta["title"].is_null(),
+            "masked span blanks to null: {meta}"
+        );
         assert_eq!(meta["status"], "draft");
+    }
+
+    #[test]
+    fn unquoted_leading_backtick_is_invalid_yaml_and_blanks_via_fallback() {
+        // Known limitation: a value that *starts* with a code span is invalid YAML
+        // (backtick is a reserved indicator — Psych, saphyr, and js-yaml all reject
+        // it), so the raw parse fails and the masked fallback blanks the leading
+        // span. Sibling fields are unharmed. The author's fix is to quote the value
+        // or use a `|` block scalar, both captured verbatim (see the tests above).
+        let content = "---\npurpose: `widget-loader` is the entry point\nstatus: ok\n---\n";
+        let meta = parse(content).metadata.unwrap();
+        assert_eq!(meta["purpose"], "is the entry point");
+        assert_eq!(meta["status"], "ok");
     }
 
     #[test]

--- a/src/parsers/frontmatter.rs
+++ b/src/parsers/frontmatter.rs
@@ -126,7 +126,10 @@ impl Parser for FrontmatterParser {
     }
 
     fn parse(&self, _path: &str, content: &str) -> ParseResult {
-        // `stripped` is owned and outlives the borrowed marked AST below.
+        // The edge scan runs on a *masked* copy: `strip_code` blanks code spans so
+        // a `path.md` written in prose can't be mistaken for a link target. Metadata
+        // capture (below) runs on the raw frontmatter instead, so the two no longer
+        // share a buffer. `stripped` is owned and outlives the borrowed AST.
         let stripped = strip_code(content);
         let Some(yaml_str) = frontmatter_block(&stripped) else {
             return ParseResult::default();
@@ -157,17 +160,32 @@ impl Parser for FrontmatterParser {
             })
             .collect();
 
-        ParseResult {
-            links,
-            metadata: Some(to_json(root)),
-        }
+        // Metadata captures the *raw* frontmatter so a code span in a value — the
+        // service name or path an author put in backticks — survives as the prose it
+        // is, instead of coming back blanked. The masked parse only stands in when
+        // the raw block is not valid YAML on its own (a code span can hide a `:` that
+        // would otherwise break the mapping), preserving the previous behavior there.
+        let metadata = raw_metadata(content).or_else(|| Some(to_json(root)));
+
+        ParseResult { links, metadata }
     }
 }
 
-/// Extract the YAML frontmatter block from code-stripped content — the text
-/// between the opening `---` and the next `\n---`, or `None` when there is no
-/// well-formed block. The slice keeps the newline that follows the opening
-/// fence, so a node's line within the block equals its line within the file.
+/// Parse the raw (unmasked) frontmatter block into metadata JSON. Returns `None`
+/// when there is no block or it is not valid YAML on its own — the caller falls
+/// back to the masked parse in that case.
+fn raw_metadata(content: &str) -> Option<serde_json::Value> {
+    let yaml_str = frontmatter_block(content)?;
+    let docs = MarkedYaml::load_from_str(yaml_str).ok()?;
+    docs.first().map(to_json)
+}
+
+/// Extract the YAML frontmatter block — the text between the opening `---` and
+/// the next `\n---`, or `None` when there is no well-formed block. Works on either
+/// the masked copy (for the edge scan) or the raw content (for metadata): masking
+/// preserves offsets and newlines, so both agree on the block's boundaries. The
+/// slice keeps the newline that follows the opening fence, so a node's line within
+/// the block equals its line within the file.
 fn frontmatter_block(stripped: &str) -> Option<&str> {
     let rest = stripped.strip_prefix("---")?;
     let end = rest.find("\n---")?;
@@ -443,6 +461,47 @@ mod tests {
     fn no_metadata_without_frontmatter() {
         let result = parse("# Just a heading\n");
         assert!(result.metadata.is_none());
+    }
+
+    #[test]
+    fn metadata_keeps_code_spans_in_values() {
+        // The edge-scan mask blanked code spans in captured metadata; metadata now
+        // carries the raw value, so `widget-loader` survives as the prose it is.
+        let content =
+            "---\npurpose: A code span like `widget-loader` and a path `claims.md`.\n---\n";
+        let meta = parse(content).metadata.unwrap();
+        assert_eq!(
+            meta["purpose"],
+            "A code span like `widget-loader` and a path `claims.md`."
+        );
+    }
+
+    #[test]
+    fn code_span_in_metadata_does_not_become_an_edge() {
+        // Scope guard: capturing the raw value must not make a code-span path an
+        // edge. The mask still governs edge extraction, so nothing links here.
+        let content = "---\npurpose: see `config.rs` for details\n---\n";
+        let result = parse(content);
+        assert!(result.links.is_empty(), "code spans are not edges");
+        assert_eq!(
+            result.metadata.unwrap()["purpose"],
+            "see `config.rs` for details"
+        );
+    }
+
+    #[test]
+    fn block_scalar_with_code_span_survives_whole() {
+        // The reported case: a multi-line `purpose` block scalar whose spans were
+        // blanked. Every character now comes back, newline included.
+        let content = "---\npurpose: |\n  Plain words. A span like `widget-loader` stays.\nsources:\n  - b.md\n---\n";
+        let result = parse(content);
+        assert_eq!(
+            result.metadata.unwrap()["purpose"],
+            "Plain words. A span like `widget-loader` stays.\n"
+        );
+        // The real derivation is still an edge.
+        assert_eq!(result.links.len(), 1);
+        assert_eq!(result.links[0].target, "b.md");
     }
 
     #[test]

--- a/src/parsers/frontmatter.rs
+++ b/src/parsers/frontmatter.rs
@@ -126,20 +126,35 @@ impl Parser for FrontmatterParser {
     }
 
     fn parse(&self, _path: &str, content: &str) -> ParseResult {
-        // The edge scan runs on a *masked* copy: `strip_code` blanks code spans so
-        // a `path.md` written in prose can't be mistaken for a link target. Metadata
-        // capture (below) runs on the raw frontmatter instead, so the two no longer
-        // share a buffer. `stripped` is owned and outlives the borrowed AST.
+        // Two independent buffers, one per job. The edge scan runs on a *masked*
+        // copy — `strip_code` blanks code spans so a `path.md` written in prose
+        // can't be mistaken for a link target. Metadata runs on the *raw*
+        // frontmatter, so a code span in a value survives as the prose it is.
+        // Neither gates the other: a stray backtick that blanks the closing `---`
+        // in the masked copy must not also erase the metadata, and vice versa.
+        ParseResult {
+            links: self.extract_links(content),
+            metadata: extract_metadata(content),
+        }
+    }
+}
+
+impl FrontmatterParser {
+    /// Extract frontmatter link edges from the *masked* frontmatter block, where
+    /// code spans are blanked so a `path.md` written in prose is never a link
+    /// target. An absent or malformed masked block yields no links.
+    fn extract_links(&self, content: &str) -> Vec<Link> {
+        // `stripped` is owned and outlives the borrowed marked AST below.
         let stripped = strip_code(content);
         let Some(yaml_str) = frontmatter_block(&stripped) else {
-            return ParseResult::default();
+            return Vec::new();
         };
         // Malformed YAML contributes nothing — drft is not a YAML linter.
         let Ok(docs) = MarkedYaml::load_from_str(yaml_str) else {
-            return ParseResult::default();
+            return Vec::new();
         };
         let Some(root) = docs.first() else {
-            return ParseResult::default();
+            return Vec::new();
         };
 
         let mut candidates = Vec::new();
@@ -151,32 +166,36 @@ impl Parser for FrontmatterParser {
             }
             None => collect_links(root, &mut candidates),
         }
-        let links = candidates
+        candidates
             .into_iter()
             .filter(|(value, _)| is_link_candidate(value))
             .map(|(target, line)| Link {
                 target,
                 line: Some(line),
             })
-            .collect();
-
-        // Metadata captures the *raw* frontmatter so a code span in a value — the
-        // service name or path an author put in backticks — survives as the prose it
-        // is, instead of coming back blanked. The masked parse only stands in when
-        // the raw block is not valid YAML on its own (a code span can hide a `:` that
-        // would otherwise break the mapping), preserving the previous behavior there.
-        let metadata = raw_metadata(content).or_else(|| Some(to_json(root)));
-
-        ParseResult { links, metadata }
+            .collect()
     }
 }
 
-/// Parse the raw (unmasked) frontmatter block into metadata JSON. Returns `None`
-/// when there is no block or it is not valid YAML on its own — the caller falls
-/// back to the masked parse in that case.
-fn raw_metadata(content: &str) -> Option<serde_json::Value> {
-    let yaml_str = frontmatter_block(content)?;
-    let docs = MarkedYaml::load_from_str(yaml_str).ok()?;
+/// Capture the frontmatter block as node metadata. Prefers the *raw* block so a
+/// code span in a value — the service name or path an author put in backticks —
+/// survives as the prose it is, instead of coming back blanked. Falls back to the
+/// masked block only when the raw block is not valid YAML on its own (a code span
+/// can hide a `:` that would otherwise break the mapping), and returns `None` when
+/// there is no frontmatter block at all.
+fn extract_metadata(content: &str) -> Option<serde_json::Value> {
+    // Prefer the raw block so code spans survive as prose.
+    if let Some(block) = frontmatter_block(content)
+        && let Ok(docs) = MarkedYaml::load_from_str(block)
+        && let Some(root) = docs.first()
+    {
+        return Some(to_json(root));
+    }
+    // Fall back to the masked block only when the raw block is not valid YAML on its
+    // own — a code span can hide a `:` that would otherwise break the mapping.
+    let stripped = strip_code(content);
+    let block = frontmatter_block(&stripped)?;
+    let docs = MarkedYaml::load_from_str(block).ok()?;
     docs.first().map(to_json)
 }
 
@@ -466,14 +485,46 @@ mod tests {
     #[test]
     fn metadata_keeps_code_spans_in_values() {
         // The edge-scan mask blanked code spans in captured metadata; metadata now
-        // carries the raw value, so `widget-loader` survives as the prose it is.
-        let content =
-            "---\npurpose: A code span like `widget-loader` and a path `claims.md`.\n---\n";
+        // carries the raw value across every field, not just one — the issue flagged
+        // `title`/`description` too, so assert a second field, not only `purpose`.
+        let content = "---\npurpose: A code span like `widget-loader` and a path `claims.md`.\ntitle: the `Foo` service\n---\n";
         let meta = parse(content).metadata.unwrap();
         assert_eq!(
             meta["purpose"],
             "A code span like `widget-loader` and a path `claims.md`."
         );
+        assert_eq!(meta["title"], "the `Foo` service");
+    }
+
+    #[test]
+    fn metadata_survives_when_a_stray_backtick_breaks_the_masked_block() {
+        // An unclosed backtick in a value pairs with one in the body, so the mask
+        // blanks everything between — including the closing `---` — and the edge
+        // scan finds no block. Metadata reads the raw frontmatter on its own buffer,
+        // so it is still captured. (The masked edge scan finds nothing, unchanged.)
+        let content =
+            "---\npurpose: a `widget\nsources:\n  - b.md\n---\n\n# Body with a `code span`\n";
+        let result = parse(content);
+        let meta = result
+            .metadata
+            .expect("metadata comes from the raw block, not the masked one");
+        assert_eq!(meta["purpose"], "a `widget");
+        assert!(
+            result.links.is_empty(),
+            "the masked edge scan finds no block"
+        );
+    }
+
+    #[test]
+    fn metadata_falls_back_to_masked_when_raw_is_not_valid_yaml() {
+        // A code span hiding a `:` makes the raw block ambiguous YAML; the masked
+        // parse stands in so the block still yields structured metadata (the span
+        // blanks in the fallback) rather than being dropped whole.
+        let content = "---\ntitle: `key: value`\nstatus: draft\n---\n";
+        let meta = parse(content)
+            .metadata
+            .expect("masked fallback keeps metadata when raw YAML is ambiguous");
+        assert_eq!(meta["status"], "draft");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #95.

## Problem

The frontmatter parser masks code spans (backtick spans → equal-length spaces) as
a pre-pass so a `path.md` written in prose can't be mistaken for a link target
during edge extraction. That masked buffer was **also** captured as node metadata,
so an `@frontmatter` value like `purpose` came back with its code spans blanked.
`drft nodes` surfaced a pre-existing bug (`drft graph --format json` blanked it
too); nobody was reading `@frontmatter` metadata as prose before.

## Fix

`parse` is split into two independent buffers, neither gating the other:

- **`extract_links`** runs on the masked copy — edge extraction is byte-identical
  to before, so a code span still never becomes an edge.
- **`extract_metadata`** runs on the **raw** frontmatter, so code spans survive as
  the prose an author wrote. A stray backtick that blanks the closing `---` in the
  masked copy no longer erases the metadata.

## Known limitation (documented, not a regression)

The raw capture is faithful for valid YAML. A value that is invalid YAML *on its
own* — one that **begins** with a backtick (`purpose: \`x\` ...`) or hides a `:`
inside an unquoted span — is rejected by every YAML parser (backtick is a reserved
indicator; Psych, saphyr, and js-yaml all refuse it), so drft (not a YAML linter)
can't recover it. Those fall back to the masked parse, which blanks that one span
while keeping sibling fields structured. The author's fix is to quote the value or
use a `|` block scalar — both captured verbatim. This is strictly better than
`main`, which blanked every span in every field.

## Scope

Metadata capture only. Edge extraction, line numbers, `keys` scoping, and the
`metadata.is_some()` contract are unchanged.

## Tests

- reported block-scalar repro returns full prose, with the `sources` edge intact
- code spans preserved across multiple fields (`purpose` **and** `title`)
- a code span is still never an edge (scope guard)
- stray-backtick case the masked scan can't see but metadata captures (decouple)
- invalid-YAML value exercises the masked fallback (asserts the masked-only tell)
- leading-backtick limitation pinned, with sibling fields unharmed

## Review

Reviewed by two independent in-session blind subagents; both findings rounds
addressed (decouple completeness, fallback test strength, invalid-YAML honesty,
doc-comment correctness).