### PR TITLE
feat: add graph --format text composed rendering (#90, increment 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ All rules default to `warn`. Override to `error` for CI enforcement or `off` to 
 
 ## Commands
 
-| Command       | What it does                                                |
-| ------------- | ----------------------------------------------------------- |
-| `drft init`   | Create a default `drft.toml`                                |
-| `drft graph`  | Export the composed graph as JGF (`--raw` for the set)      |
-| `drft nodes`  | Project node metadata by path, subtree, or glob             |
-| `drft edges`  | Project edges (matched on source) by path, subtree, or glob |
-| `drft impact` | Show what depends on given files, sorted by review priority |
-| `drft check`  | Compare the graph against the lockfile for drift            |
-| `drft lock`   | Snapshot hashes to `drft.lock` for staleness tracking       |
+| Command       | What it does                                                   |
+| ------------- | -------------------------------------------------------------- |
+| `drft init`   | Create a default `drft.toml`                                   |
+| `drft graph`  | Render the composed graph as text or JGF (`--raw` for the set) |
+| `drft nodes`  | Project node metadata by path, subtree, or glob                |
+| `drft edges`  | Project edges (matched on source) by path, subtree, or glob    |
+| `drft impact` | Show what depends on given files, sorted by review priority    |
+| `drft check`  | Compare the graph against the lockfile for drift               |
+| `drft lock`   | Snapshot hashes to `drft.lock` for staleness tracking          |
 
 `drft lock` with no argument snapshots the whole graph. Given paths — `drft lock
 src/lib.rs docs/guide.md` — it locks only those nodes and their outbound edges,

--- a/drft.lock
+++ b/drft.lock
@@ -157,7 +157,7 @@ target_hash = "b3:001783ea083536a80cc88600bce3816cc6c90106685e825fe3e23e29936d82
 
 [[node.edge]]
 target = "src/cli.rs"
-target_hash = "b3:88f922841a5615f2e4125ef4935a4eeafaa32d95aa07b5ca67f032f699d04159"
+target_hash = "b3:55a73406640ceb7106cd6a8ac8a16b0c9bf0dbdbad59b714a5dda20bff6bc3ff"
 
 [[node.edge]]
 target = "src/config.rs"
@@ -268,7 +268,7 @@ hash = "b3:f56fdcddee36a2cc7c9c55b619b80c0571ca85e89334e06741b157d4315d84d4"
 
 [[node]]
 path = "src/cli.rs"
-hash = "b3:88f922841a5615f2e4125ef4935a4eeafaa32d95aa07b5ca67f032f699d04159"
+hash = "b3:55a73406640ceb7106cd6a8ac8a16b0c9bf0dbdbad59b714a5dda20bff6bc3ff"
 
 [[node]]
 path = "src/compose.rs"
@@ -328,7 +328,7 @@ hash = "b3:d17d93b9838e4703720bafd4150e1dee5653416cb080218716ae21a5c615c3c7"
 
 [[node]]
 path = "src/projection.rs"
-hash = "b3:0059793b372f2f4cafa9c11bf26b9515eb8366c979c87cc7642fab7d25f6d0eb"
+hash = "b3:c45f328c6d4cc3cb58e4d764ac360bde82d4ee17e411dbcb786fa7019a76c63b"
 
 [[node]]
 path = "src/rules/check.rs"
@@ -372,7 +372,7 @@ hash = "b3:7d95c0b90b249a66ced8e39cfc3e3b13023d582019c405457e03eaa89170ffaf"
 
 [[node]]
 path = "tests/graph.rs"
-hash = "b3:d5648fe35d33136e160bec6b010e8073b609a212fa0f7e4ea90c05d1d7467b3c"
+hash = "b3:d9ea0b837a0b894e3d5123a036e89ce832aa69b78044c17bb8134d3fd904c3b3"
 
 [[node]]
 path = "tests/impact.rs"

--- a/drft.lock
+++ b/drft.lock
@@ -98,7 +98,7 @@ hash = "b3:871c2fd5cdfe89fa6ff01664a1420bf40d0ab18c0e250e59a3ab27225f31bb0e"
 
 [[node]]
 path = "README.md"
-hash = "b3:5f00a66af72880151692dbceec10bd210c507c1b8071b3855a3cdd6336580fb4"
+hash = "b3:d83c14f6950c702404e883b7cab6d40bea9b6c3ca5635a8b9af196684846a4ff"
 
 [[node.edge]]
 target = "CLAUDE.md"
@@ -157,7 +157,7 @@ target_hash = "b3:001783ea083536a80cc88600bce3816cc6c90106685e825fe3e23e29936d82
 
 [[node.edge]]
 target = "src/cli.rs"
-target_hash = "b3:51c6ccc63e51eaa3b0d449f3a0ff79c6ef94b06bc2d9a4971ff733c6b043579e"
+target_hash = "b3:88f922841a5615f2e4125ef4935a4eeafaa32d95aa07b5ca67f032f699d04159"
 
 [[node.edge]]
 target = "src/config.rs"
@@ -268,7 +268,7 @@ hash = "b3:f56fdcddee36a2cc7c9c55b619b80c0571ca85e89334e06741b157d4315d84d4"
 
 [[node]]
 path = "src/cli.rs"
-hash = "b3:51c6ccc63e51eaa3b0d449f3a0ff79c6ef94b06bc2d9a4971ff733c6b043579e"
+hash = "b3:88f922841a5615f2e4125ef4935a4eeafaa32d95aa07b5ca67f032f699d04159"
 
 [[node]]
 path = "src/compose.rs"
@@ -304,7 +304,7 @@ hash = "b3:b437206e0e16ea1a0643edda5d8b1ab7361816bb42222bc80e488e13329b0516"
 
 [[node]]
 path = "src/main.rs"
-hash = "b3:88fb03a9337faf60badd04c72ce6e5bb6d2db96113029accf6cee36d1af28e71"
+hash = "b3:4b25105ac3ffc8b8136b8e4ba36092644f2cdd6774204f36252170d92413480d"
 
 [[node]]
 path = "src/model.rs"
@@ -328,7 +328,7 @@ hash = "b3:d17d93b9838e4703720bafd4150e1dee5653416cb080218716ae21a5c615c3c7"
 
 [[node]]
 path = "src/projection.rs"
-hash = "b3:6684649de29b73c2854a0954eef16a12bf2d0451dcf7b99e910129f4b570c906"
+hash = "b3:0059793b372f2f4cafa9c11bf26b9515eb8366c979c87cc7642fab7d25f6d0eb"
 
 [[node]]
 path = "src/rules/check.rs"
@@ -372,7 +372,7 @@ hash = "b3:7d95c0b90b249a66ced8e39cfc3e3b13023d582019c405457e03eaa89170ffaf"
 
 [[node]]
 path = "tests/graph.rs"
-hash = "b3:317ec95915031ee51e9bcd86da06b439d120fd13ef29509e02fe668fd4fbb2f5"
+hash = "b3:d5648fe35d33136e160bec6b010e8073b609a212fa0f7e4ea90c05d1d7467b3c"
 
 [[node]]
 path = "tests/impact.rs"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,7 +35,7 @@ pub enum Commands {
         paths: Vec<String>,
     },
 
-    /// Export the dependency graph as composed JGF
+    /// Render the composed graph as text or JGF
     Graph {
         /// Emit the raw set of per-graph fragments instead of the composed graph
         /// (JSON only; ignores --format)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,6 +38,7 @@ pub enum Commands {
     /// Export the dependency graph as composed JGF
     Graph {
         /// Emit the raw set of per-graph fragments instead of the composed graph
+        /// (JSON only; ignores --format)
         #[arg(long)]
         raw: bool,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use drft::graphs;
 use drft::impact;
 use drft::lock;
 use drft::nodes;
+use drft::projection;
 use drft::rules;
 
 use anyhow::{Context, Result};
@@ -82,7 +83,7 @@ fn try_main() -> Result<i32> {
             depth,
             direction,
         } => run_impact(&root, cli.format, paths, *depth, *direction),
-        Commands::Graph { raw } => run_graph(&root, *raw),
+        Commands::Graph { raw } => run_graph(&root, *raw, cli.format),
         Commands::Nodes {
             selectors,
             namespaces,
@@ -306,17 +307,41 @@ fn graph_key(root: &Path, graph_root: &Path, arg: &str) -> Option<String> {
     (!key.is_empty()).then_some(key)
 }
 
-fn run_graph(root: &Path, raw: bool) -> Result<i32> {
+fn run_graph(root: &Path, raw: bool, format: OutputFormat) -> Result<i32> {
     let graph_root = find_graph_root(root);
     let config = Config::load(&graph_root)?;
     let set = graphs::build_set(&graph_root, &config)?;
 
-    let json = if raw {
-        serde_json::to_string_pretty(&set)?
-    } else {
-        serde_json::to_string_pretty(&compose::compose(&set).into_document())?
-    };
-    println!("{json}");
+    // `--raw` dumps the per-graph fragment set — a JSON structure with no text
+    // projection — so it is JSON-only and ignores `--format`. The composed views
+    // below honor it.
+    if raw {
+        println!("{}", serde_json::to_string_pretty(&set)?);
+        return Ok(0);
+    }
+
+    let composed = compose::compose(&set);
+    match format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&composed.into_document())?
+            );
+        }
+        OutputFormat::Text => {
+            // The whole composed graph as text: every node's metadata, then every
+            // edge. `# nodes` / `# edges` headers keep the two sections legible
+            // for a model reading the graph without parsing JSON. Reuses the same
+            // per-node/per-edge rendering as `drft nodes` and `drft edges`.
+            let keys = resolve_selectors(&composed, root, &graph_root, &[])?;
+            let node_text = nodes::format_text(&nodes::project(&composed, &keys, &[], &[]));
+            let edge_text = edges::format_text(&edges::project(&composed, None, &[], &[]));
+            print!(
+                "{}",
+                projection::join_sections(&[("nodes", &node_text), ("edges", &edge_text)])
+            );
+        }
+    }
     Ok(0)
 }
 

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -85,6 +85,28 @@ pub fn join_blocks(blocks: Vec<String>) -> String {
     format!("{}\n", blocks.join("\n\n"))
 }
 
+/// Join labeled sections for the composed `graph` text view. Each section is a
+/// `# <label>` header followed by its already-rendered body (from `join_blocks`),
+/// with one blank line between the header and a non-empty body and one blank line
+/// between sections. An empty body renders as its header alone — the section is
+/// still named, so a graph with no edges reads as `# edges` with nothing under it
+/// rather than a missing or dangling section. No node id or `source → target`
+/// header begins with `# `, so the section markers never collide with content.
+pub fn join_sections(sections: &[(&str, &str)]) -> String {
+    let mut out = String::new();
+    for (i, (label, body)) in sections.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        out.push_str(&format!("# {label}\n"));
+        if !body.is_empty() {
+            out.push('\n');
+            out.push_str(body);
+        }
+    }
+    out
+}
+
 /// Render a metadata value for text output. An ordinary string prints bare; a
 /// string carrying control characters — a YAML block scalar's newlines, say —
 /// would break the one-line-per-field layout (and an embedded blank line could
@@ -154,5 +176,27 @@ mod tests {
     fn join_blocks_envelope() {
         assert_eq!(join_blocks(vec![]), "");
         assert_eq!(join_blocks(vec!["a".into(), "b".into()]), "a\n\nb\n");
+    }
+
+    #[test]
+    fn join_sections_labels_both_and_separates_with_a_blank_line() {
+        // Each body is what `join_blocks` yields — a trailing newline included.
+        let nodes = join_blocks(vec!["docs/a.md".into()]);
+        let edges = join_blocks(vec!["a.md → b.md".into()]);
+        assert_eq!(
+            join_sections(&[("nodes", &nodes), ("edges", &edges)]),
+            "# nodes\n\ndocs/a.md\n\n# edges\n\na.md → b.md\n"
+        );
+    }
+
+    #[test]
+    fn join_sections_keeps_an_empty_section_as_its_header() {
+        // A graph with no edges: the `# edges` header still names the section, with
+        // nothing under it and no dangling blank line.
+        let nodes = join_blocks(vec!["docs/a.md".into()]);
+        assert_eq!(
+            join_sections(&[("nodes", &nodes), ("edges", "")]),
+            "# nodes\n\ndocs/a.md\n\n# edges\n"
+        );
     }
 }

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -90,8 +90,11 @@ pub fn join_blocks(blocks: Vec<String>) -> String {
 /// with one blank line between the header and a non-empty body and one blank line
 /// between sections. An empty body renders as its header alone — the section is
 /// still named, so a graph with no edges reads as `# edges` with nothing under it
-/// rather than a missing or dangling section. No node id or `source → target`
-/// header begins with `# `, so the section markers never collide with content.
+/// rather than a missing or dangling section. Metadata lines are always indented,
+/// so they never look like a marker; a flush-left content line could in principle
+/// collide (a file literally named `# edges` would render one), but no ordinary
+/// path or `source → target` header begins with `# `, so in practice the markers
+/// stand out.
 pub fn join_sections(sections: &[(&str, &str)]) -> String {
     let mut out = String::new();
     for (i, (label, body)) in sections.iter().enumerate() {
@@ -197,6 +200,25 @@ mod tests {
         assert_eq!(
             join_sections(&[("nodes", &nodes), ("edges", "")]),
             "# nodes\n\ndocs/a.md\n\n# edges\n"
+        );
+    }
+
+    #[test]
+    fn join_sections_empty_graph_is_both_headers() {
+        // A graph with no nodes and no edges: both headers, nothing under either.
+        assert_eq!(
+            join_sections(&[("nodes", ""), ("edges", "")]),
+            "# nodes\n\n# edges\n"
+        );
+    }
+
+    #[test]
+    fn join_sections_empty_nodes_with_edges() {
+        // An empty leading section still gets its header, then the populated one.
+        let edges = join_blocks(vec!["a.md → b.md".into()]);
+        assert_eq!(
+            join_sections(&[("nodes", ""), ("edges", &edges)]),
+            "# nodes\n\n# edges\n\na.md → b.md\n"
         );
     }
 }

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -8,7 +8,9 @@ fn graph_json(dir: &std::path::Path) -> serde_json::Value {
 }
 
 fn graph_json_args(dir: &std::path::Path, extra: &[&str]) -> serde_json::Value {
-    let mut args = vec!["-C", dir.to_str().unwrap(), "graph"];
+    // `graph` respects `--format`, whose default is `text`; JSON assertions ask
+    // for it explicitly.
+    let mut args = vec!["-C", dir.to_str().unwrap(), "graph", "--format", "json"];
     args.extend_from_slice(extra);
     let output = drft_bin().args(&args).output().unwrap();
     assert!(
@@ -67,7 +69,13 @@ fn graph_nodes_are_sorted() {
     fs::write(dir.path().join("a.md"), "a").unwrap();
 
     let output = drft_bin()
-        .args(["-C", dir.path().to_str().unwrap(), "graph"])
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "graph",
+            "--format",
+            "json",
+        ])
         .output()
         .unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -210,4 +218,71 @@ fn graph_raw_emits_the_set() {
     let markdown = graphs.iter().find(|g| g["label"] == "markdown").unwrap();
     assert_eq!(frontmatter["nodes"]["doc.md"]["metadata"]["title"], "Doc");
     assert!(markdown["nodes"].as_object().unwrap().is_empty());
+}
+
+/// `--raw` is JSON-only: it emits the fragment set even under the default text
+/// format, so `drft graph --raw | jq` keeps working without `--format json`.
+#[test]
+fn graph_raw_ignores_text_format() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("index.md"), "# Index").unwrap();
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "graph", "--raw"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("raw is JSON");
+    assert!(v["graphs"].is_array(), "raw emits the fragment set");
+}
+
+/// Bare `drft graph` defaults to the text projection: the composed graph as
+/// `# nodes` / `# edges` sections, so a model reads it without parsing JSON.
+#[test]
+fn graph_defaults_to_text_with_node_and_edge_sections() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("index.md"), "[setup](setup.md)").unwrap();
+    fs::write(dir.path().join("setup.md"), "# Setup").unwrap();
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "graph"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Section headers label the two halves; the boundary is unambiguous.
+    let nodes_hdr = stdout.find("# nodes").expect("nodes section header");
+    let edges_hdr = stdout.find("# edges").expect("edges section header");
+    assert!(nodes_hdr < edges_hdr, "nodes section precedes edges");
+
+    // Nodes render with their `@fs` metadata; the markdown link is an edge.
+    assert!(
+        stdout.contains("index.md\n  @fs\n"),
+        "node block with @fs:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("index.md → setup.md"),
+        "edge block source → target:\n{stdout}"
+    );
+    // The edge belongs under the edges section, not the nodes one.
+    let edge_pos = stdout.find("index.md → setup.md").unwrap();
+    assert!(edge_pos > edges_hdr, "edge sits under the edges header");
+}
+
+/// The text and JSON projections describe the same graph: `--format json` still
+/// yields the composed JGF document.
+#[test]
+fn graph_format_json_still_emits_jgf() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("index.md"), "# Index").unwrap();
+
+    let v = graph_json(dir.path());
+    assert_eq!(
+        v.as_object().unwrap().keys().collect::<Vec<_>>(),
+        vec!["graph"]
+    );
 }

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -272,8 +272,9 @@ fn graph_defaults_to_text_with_node_and_edge_sections() {
     assert!(edge_pos > edges_hdr, "edge sits under the edges header");
 }
 
-/// The text and JSON projections describe the same graph: `--format json` still
-/// yields the composed JGF document.
+/// The text and JSON projections cover the same node/edge set; `--format json`
+/// still yields the composed JGF document. (The views are not information-equal:
+/// text is a projection that drops `_graphs` provenance, JGF keeps it.)
 #[test]
 fn graph_format_json_still_emits_jgf() {
     let dir = TempDir::new().unwrap();
@@ -285,4 +286,25 @@ fn graph_format_json_still_emits_jgf() {
         v.as_object().unwrap().keys().collect::<Vec<_>>(),
         vec!["graph"]
     );
+}
+
+/// The text projection lists nodes in sorted order, like the JSON one — the text
+/// path rides on a different code route (`BTreeMap` iteration via the whole-graph
+/// selector), so it gets its own ordering guard.
+#[test]
+fn graph_text_nodes_are_sorted() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("z.md"), "z").unwrap();
+    fs::write(dir.path().join("a.md"), "a").unwrap();
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "graph"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let a = stdout.find("\na.md\n").expect("a.md node block");
+    let z = stdout.find("\nz.md\n").expect("z.md node block");
+    assert!(a < z, "text node blocks should be sorted");
 }


### PR DESCRIPTION
Third read verb of the #90 query surface. `drft graph` respects `--format` (text default) and renders the composed graph as `# nodes` / `# edges` sections so an agent can read the whole graph without parsing JSON — `--format json` restores the composed JGF.

## Behavior

- **`graph` respects `--format`, text is the default.** Bare `drft graph` now emits text where it used to emit JSON (pre-v1, documented). `--format json` restores the composed JGF document.
- **`--raw` is JSON-only and ignores `--format`.** It dumps the fragment set, which has no text projection, so `drft graph --raw` keeps emitting JSON even under the default text format — no `--format json` needed, no error.
- **Text layout.** `# nodes` section (each node's metadata) then `# edges` section (`source → target` plus metadata), reusing `nodes::format_text` / `edges::format_text` joined by the new `projection::join_sections`. An empty section renders as its header alone (a graph with no edges reads as `# edges` with nothing under it).

## Scope

Minimal: `--format text` over the whole composed graph. No `[SELECTOR…]`/`--namespace`/`--field` on `graph` yet — deferred to #47, where the `--raw` open thread is resolved.

## Tests

- Unit: `join_sections` (labels both sections, keeps an empty section as its header) in `src/projection.rs`.
- Behavior (`tests/graph.rs`): `graph_defaults_to_text_with_node_and_edge_sections`, `graph_raw_ignores_text_format`, `graph_format_json_still_emits_jgf`; existing JSON tests made explicit about `--format json`.

CHANGELOG is left for the release PR, per RELEASING.md.
