### PR TITLE
Release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to drft are documented here.
 
+## 0.15.0 (2026-08-19)
+
+Finishes the read verbs of the #90 query surface. `drft edges` projects the graph's edges, and `drft graph` gains a text rendering of the whole composed graph — so an agent can read nodes, edges, or the entire graph without parsing JSON.
+
+### Breaking changes
+
+- **`drft graph` defaults to text output** (#90). `drft graph` now honors the global `--format`, whose default is `text`, and renders the composed graph as `# nodes` / `# edges` sections. It previously always emitted the composed JGF as pretty JSON. **This breaks pipelines**: `drft graph | jq …` now feeds text to `jq`, which errors — pass `--format json` to restore the JGF document. `--raw` is unaffected — it stays JSON-only and ignores `--format`, so `drft graph --raw` is unchanged.
+
+### New
+
+- **`drft edges` projects the graph's edges** (#90). `drft edges <selector…> [--namespace <g>…] [--field <k>…] [--format text|json]` reads the composed graph's edge half, matched on source: the selector resolves to source nodes — the same vocabulary as `drft nodes` (exact path, bare directory standing for its recursive subtree, or a globset over node keys) — and the projection is every edge leaving them, the outbound one-hop view. With no selector, every edge. It stays distinct from `drft impact` (a transitive traversal from a seed set) and `drft check` (a whole-graph gate). `--namespace` and `--field` narrow the edge set and its metadata as they do for `nodes`; a mistyped source errors while an empty glob is exit 0. Text is one block per edge — `source → target` then its metadata; JSON carries `{ total, edges: [{ source, target, metadata }] }`. An edge with no per-graph metadata still projects. The metadata narrowing and text rendering shared with `nodes` moved into a new `projection` module.
+- **`drft graph` renders the composed graph as text** (#90). Under the default `--format text`, `drft graph` prints every node's metadata under a `# nodes` header, then every edge under `# edges`, reusing the `nodes` and `edges` renderings — so a model reads the whole graph in one call without parsing JSON. `--format json` still yields the composed JGF (see the breaking-changes note on the default). Scoped selectors on `graph` are out of scope — `drft nodes` and `drft edges` cover scoped projection.
+
+### Fixed
+
+- **`@frontmatter` metadata keeps code spans** (#95). The frontmatter parser masks backtick code spans before scanning for link targets, so a `path.md` written in prose can't be mistaken for an edge. That masked buffer was also captured as node metadata, so an `@frontmatter` value like `purpose` came back with its code spans blanked — surfaced once `drft nodes` and `drft graph --format json` read frontmatter metadata as prose. Metadata is now captured from the raw frontmatter while edge extraction still runs on the masked copy, so code spans survive as authored and edges are byte-identical to before. A value that is invalid YAML on its own — one beginning with a backtick, or hiding a `:` in an unquoted span — still falls back to the masked parse; quoting it or using a `|` block scalar captures it verbatim.
+
 ## 0.14.0 (2026-08-18)
 
 Adds the first read verb of the #90 query surface. `drft nodes` reads what the graph knows about a set of paths, so an agent can ground itself on a file's metadata without exporting and parsing the whole composed graph.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "drft-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drft-cli"
-version = "0.14.0"
+version = "0.15.0"
 categories = ["command-line-utilities", "development-tools"]
 edition = "2024"
 homepage = "https://github.com/johnmdonahue/drft-cli"

--- a/drft.lock
+++ b/drft.lock
@@ -22,7 +22,7 @@ hash = "b3:2a96e992de334b67fe25ad9bfd611a83ee491da2a51160d1ed6344a02b764042"
 
 [[node]]
 path = "CHANGELOG.md"
-hash = "b3:ab3a9ddb1742000bfd71328380ef590d8604c2b40cdb17cbb88a178d03515185"
+hash = "b3:cf23c9d6fc2d8d849114f11cdb8ab84c4461cc99fa92ffd559c463f0ccefd211"
 
 [[node]]
 path = "CLAUDE.md"
@@ -90,7 +90,7 @@ target_hash = "b3:6ce4d5c42026071af2b68201e9debff0112ad9d9d8d8fc75d16d562d5fc1a7
 
 [[node]]
 path = "Cargo.toml"
-hash = "b3:f7fd681ddd5591bc914d91f9c5113857242288413c0449933f39ff0066085c26"
+hash = "b3:380393d708f2c4cd480503d35c394b42c7c59fb608321fdfb17252d88223b8bd"
 
 [[node]]
 path = "LICENSE"


### PR DESCRIPTION
Release v0.15.0 — finishes the read verbs of the #90 query surface.

Bundles the changes merged since v0.14.0:

- **`drft edges`** (#99) — projects the graph's edges, matched on source.
- **`drft graph` text rendering** (#100) — `graph` respects `--format` (text default), rendering the composed graph as `# nodes` / `# edges` sections. **Breaking:** bare `drft graph` now emits text; pass `--format json` for the JGF. `--raw` is unchanged (JSON-only).
- **frontmatter code-span fix** (#97) — `@frontmatter` metadata keeps backtick code spans instead of blanking them.

See CHANGELOG.md for the full v0.15.0 section. Version bumped in Cargo.toml; both tracked files re-locked so `drft check` passes on the release commit.