### PR TITLE
docs: make drft's AI-native purpose legible (read verbs, dogfooding, positioning)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # drft
 
-A structural integrity checker for linked file systems. Treats a directory of files as a dependency graph — files are nodes, links are edges — and validates the graph against configurable rules.
+A drift checker for linked files, built for LLMs and humans working in the same repo. It treats a directory of files as a dependency graph — files are nodes, links are edges — and flags what drifts when a dependency changes.
 
 ## Dogfooding
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["graph", "linter", "dependency-graph", "structural-integrity"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/johnmdonahue/drft-cli"
-description = "A structural integrity checker for linked file systems"
+description = "A drift checker for linked files, built for LLMs and humans working in the same repo"
 
 [lib]
 name = "drft"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # drft
 
-A structural integrity checker for linked file systems.
+A drift checker for linked files, built for LLMs and humans working in the same repo.
 
-Files link to other files. When a target changes, the files that depend on it may no longer be accurate. drft tracks these dependencies and flags what needs review.
+When one file derives from another — a doc from code, a summary from its source, a plan from the research behind it — a change to the source can leave the dependent out of date. drft records these derivations as links in a graph, snapshots a reviewed baseline with `drft lock`, and reports which files a change has left stale or otherwise drifted. Staleness is one kind of drift; the graph's shape drifts too — a broken link, a removed file, a new edge — and drft reports those as well.
 
-It treats your directory as a graph — files are nodes, links are edges — and checks the structure for drift. `drft check` catches broken links and staleness. `drft lock` snapshots hashes so it can detect when a dependency changes and flag everything downstream. `drft impact <file>` tells you what to review when you touch a file.
+Whether a flagged derivation still holds is a reading, not something a linter can settle, so drft surfaces it for review rather than asserting it's broken. `drft impact <file>` lists what to review before an edit. `drft nodes <path>` reads a file's declared metadata so an agent can orient without opening it. `drft check` reports drift; `drft lock` records that a change was reviewed.
 
-Each `drft.toml` declares exactly one graph. Run drft from anywhere inside the directory tree and it walks up to the nearest config. That's the model — everything else is configuration.
+Each `drft.toml` declares one graph; run drft from anywhere inside the tree and it walks up to the nearest config.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,13 @@ See the [configuration reference](docs/config.md) for all options.
 
 ## LLM integration
 
-All commands support `--format json` with actionable `fix` fields in every diagnostic. `drft impact` is designed for agent workflows — it shows which files to review after an edit, sorted by priority.
+drft grounds an agent in a codebase's structure without making it open every file. The read verbs project what the graph already knows:
+
+- `drft nodes <path>` returns a file's metadata — its frontmatter fields (say, `purpose` or `sources`) plus its `fs` type and hash — so an agent learns what a file is _for_ without reading it.
+- `drft edges <path>` returns what a file links to; `drft impact <path>` returns what depends on it, sorted by review priority.
+- `drft graph` renders the whole composed graph as compact text, so a model reads the structure in one call without parsing JSON.
+
+Every command also emits `--format json` with actionable `fix` fields in each diagnostic. See [Reading the graph](docs/reading.md) for the selector grammar and the `--namespace` / `--field` filters.
 
 This repo dogfoods the pattern with Claude Code hooks. See [CLAUDE.md](CLAUDE.md) for the agent instructions and `.claude/settings.json` for the hook configuration.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,11 +4,12 @@ purpose: map of drft's reference documentation
 
 # Documentation
 
-drft builds a dependency graph from your files and checks it for drift. The
-substrate is a **set of independent graphs** — `fs` (a node per file, typed and
-hashed), `markdown` (link edges), and `frontmatter` (edges plus metadata). A
-composition step merges them by path into one graph, and rules read the composed
-graph to emit findings.
+drft is a drift checker for linked files, built for LLMs and humans working in
+the same repo. It builds a dependency graph from your files and checks it for
+drift. The substrate is a **set of independent graphs** — `fs` (a node per file,
+typed and hashed), `markdown` (link edges), and `frontmatter` (edges plus
+metadata). A composition step merges them by path into one graph, and rules read
+the composed graph to emit findings.
 
 ## Reference
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,7 @@
+---
+purpose: map of drft's reference documentation
+---
+
 # Documentation
 
 drft builds a dependency graph from your files and checks it for drift. The

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,3 +11,4 @@ graph to emit findings.
 - [Configuration](config.md) — `drft.toml`: `ignore`, `[graphs.*]`, `[rules.*]`
 - [Parsers](parsers/README.md) — how parsers extract links and metadata
 - [Rules](rules/README.md) — the drift and structural findings `drft check` emits
+- [Reading the graph](reading.md) — the `nodes`, `edges`, and `graph` read verbs, and grounding an agent on graph metadata

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,4 +1,5 @@
 ---
+purpose: configure the walk, graphs, and rules through drft.toml
 sources:
   - ../src/config.rs
   - ../src/cli.rs

--- a/docs/parsers/README.md
+++ b/docs/parsers/README.md
@@ -1,4 +1,5 @@
 ---
+purpose: how parsers extract links and metadata from a graph's files
 sources:
   - ../../src/parsers/mod.rs
 ---

--- a/docs/parsers/frontmatter.md
+++ b/docs/parsers/frontmatter.md
@@ -1,4 +1,5 @@
 ---
+purpose: the frontmatter parser — edges from link values plus node metadata
 sources:
   - ../../src/parsers/frontmatter.rs
 ---

--- a/docs/parsers/markdown.md
+++ b/docs/parsers/markdown.md
@@ -1,4 +1,5 @@
 ---
+purpose: the markdown parser — link edges from body link syntax
 sources:
   - ../../src/parsers/markdown.rs
 ---

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -1,7 +1,9 @@
 ---
+purpose: read the graph with nodes, edges, and graph to ground an agent
 sources:
   - ../src/nodes.rs
   - ../src/edges.rs
+  - ../src/impact.rs
   - ../src/projection.rs
   - ../src/main.rs
   - ../src/cli.rs

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -1,0 +1,128 @@
+---
+sources:
+  - ../src/nodes.rs
+  - ../src/edges.rs
+  - ../src/projection.rs
+  - ../src/main.rs
+  - ../src/cli.rs
+---
+
+# Reading the graph
+
+The read verbs project what the graph already knows about your files, so a reader
+— often an LLM agent — can ground itself on a file's role and connections without
+opening every file. `drft nodes` answers "what is this file?", `drft edges`
+answers "what does it link to?", and `drft graph` hands back the whole composed
+graph at once.
+
+| Verb                | Projects                                                                          |
+| ------------------- | --------------------------------------------------------------------------------- |
+| `drft nodes <sel…>` | Node metadata: the `@fs` type and hash plus any parser blocks (`@frontmatter`, …) |
+| `drft edges <sel…>` | Edges leaving the selected nodes, matched on source                               |
+| `drft graph`        | The whole composed graph — every node, then every edge                            |
+
+These are projections, not traversals. `drft impact` walks the graph transitively
+to answer "what depends on this?"; `drft check` gates the whole graph for drift.
+The read verbs just show a scoped slice of what is already there.
+
+## Selectors
+
+Every read verb takes the same positional selector, matched against node keys —
+the same vocabulary as `drft.toml`'s `files` and `ignore`. A selector is one of:
+
+- An **exact path** — `docs/config.md` — resolving to that node.
+- A **bare directory** — `docs/` — standing for its recursive subtree.
+- A **globset pattern** — `'**/*.md'` — matched against node keys.
+
+`docs`, `docs/`, and `docs/**` all name the same set, so there is no wrong
+spelling. Quote globs so the shell passes them through rather than expanding them
+itself. `drft edges` matches the selector against edge **sources**, so a directory
+selector projects every edge leaving that subtree.
+
+Selector expansion is a reader affordance only. Writers like `drft lock` stay
+exact-path-only, so a subtree or glob never fans out into a write.
+
+An exact path that matches nothing is a likely typo: the command errors (exit 2)
+with a suggestion. A glob that matches nothing is a legitimate empty result
+(exit 0) — it answers which files match, and none do.
+
+## Narrowing with `--namespace` and `--field`
+
+Two repeatable flags narrow what comes back, shared by `nodes` and `edges`:
+
+- `--namespace <name>` restricts to one graph's lens — `fs`, `markdown`,
+  `frontmatter`, or any `[graphs.*]` you declare. It accepts the bare name or its
+  `@`-prefixed key (`frontmatter` or `@frontmatter`) and filters the **set** as
+  well as the metadata: a node with no `@frontmatter` block drops out rather than
+  appearing empty. An unknown namespace is a typo — it errors, listing the
+  declared graphs.
+- `--field <name>` restricts the returned metadata to named keys and lists only
+  the nodes that declare them. Frontmatter is open-ended and drft does not own its
+  schema, so a wholly unmatched field is a legitimate empty result, not an error —
+  it answers which files declare that field.
+
+```
+$ drft nodes docs/guide.md --namespace frontmatter --field purpose
+docs/guide.md
+  @frontmatter
+    purpose: how to configure the walk
+```
+
+## Output: text or JSON
+
+`--format text` (the default) is a compact block per node or edge, built for
+reading without parsing JSON. A node block is its id, then each namespace, then
+each field:
+
+```
+$ drft nodes docs/guide.md
+docs/guide.md
+  @frontmatter
+    purpose: how to configure the walk
+    sources: ["config.rs"]
+  @fs
+    hash: b3:…
+    type: file
+```
+
+An edge block is `source → target`, then the same indented metadata:
+
+```
+$ drft edges docs/guide.md
+docs/guide.md → docs/config.md
+  @markdown
+    lines: [12]
+    raw: config.md
+```
+
+`drft graph --format text` renders the whole graph as a `# nodes` section
+followed by a `# edges` section — the node and edge blocks above, under headers.
+
+`--format json` returns a structured document instead: `{ total, nodes: [...] }`
+for `nodes`, `{ total, edges: [...] }` for `edges`, and the composed JGF for
+`graph`. `drft graph` honors `--format` like the others (text by default); pass
+`--format json` for the JGF, or `--raw` for the unmerged set of per-graph
+fragments, which is JSON only.
+
+For the full flag list, run `drft nodes --help`, `drft edges --help`, or
+`drft graph --help`.
+
+## Grounding an agent
+
+The read verbs let an agent learn a file's role and connections from the graph
+rather than from its bytes:
+
+- **What is this file?** `drft nodes path/to/file.md` returns its metadata — the
+  authored frontmatter (its purpose, its declared sources) and its `fs` type and
+  hash — so the agent knows what the file is for without reading it.
+- **What does it depend on, and what depends on it?** `drft edges path/to/file.md`
+  is the outbound one-hop view; `drft impact path/to/file.md` is the inbound one,
+  sorted by review priority.
+- **What is the whole structure?** `drft graph` renders every node and edge as
+  text in a single call, so a model reads the shape of the project at once.
+
+Because a selector expands to many nodes, one call can ground a whole subtree:
+`drft nodes docs/ --namespace frontmatter --field purpose` returns every doc's
+stated purpose, and `drft nodes $(drft impact observations.md --format json | jq
+-r '.impacted[].path')` reads the metadata of exactly the files an edit puts in
+review.

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -7,6 +7,7 @@ sources:
   - ../src/projection.rs
   - ../src/main.rs
   - ../src/cli.rs
+  - ../src/config.rs
 ---
 
 # Reading the graph
@@ -126,5 +127,6 @@ rather than from its bytes:
 Because a selector expands to many nodes, one call can ground a whole subtree:
 `drft nodes docs/ --namespace frontmatter --field purpose` returns every doc's
 stated purpose, and `drft nodes $(drft impact observations.md --format json | jq
--r '.impacted[].path')` reads the metadata of exactly the files an edit puts in
-review.
+-r '.impacted[].node')` reads the metadata of exactly the files an edit puts in
+review. (The key is `.node`; `impact` reports no `.path`, and an empty expansion
+would collapse to a bare `drft nodes` that projects every node.)

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,4 +1,5 @@
 ---
+purpose: the drift and structural findings drft check emits
 sources:
   - ../../src/rules/staleness.rs
   - ../../src/rules/structural.rs

--- a/drft.lock
+++ b/drft.lock
@@ -26,7 +26,7 @@ hash = "b3:cf23c9d6fc2d8d849114f11cdb8ab84c4461cc99fa92ffd559c463f0ccefd211"
 
 [[node]]
 path = "CLAUDE.md"
-hash = "b3:0608a5e5ab70aa73b528d4a3402b712df92ca9913231a76046aa2e815474e8b7"
+hash = "b3:0257778ef9a19e27c49c766f0e59b9d696e238758b2dcb60cebaf95b34cca2a4"
 
 [[node.edge]]
 target = "RELEASING.md"
@@ -90,7 +90,7 @@ target_hash = "b3:6ce4d5c42026071af2b68201e9debff0112ad9d9d8d8fc75d16d562d5fc1a7
 
 [[node]]
 path = "Cargo.toml"
-hash = "b3:380393d708f2c4cd480503d35c394b42c7c59fb608321fdfb17252d88223b8bd"
+hash = "b3:dad801e584c3606d1102e7f5d21c40426743d14a037d743afedb2f91d53a18a2"
 
 [[node]]
 path = "LICENSE"
@@ -98,15 +98,15 @@ hash = "b3:871c2fd5cdfe89fa6ff01664a1420bf40d0ab18c0e250e59a3ab27225f31bb0e"
 
 [[node]]
 path = "README.md"
-hash = "b3:ad52d251fb0442eac3f97e52cd31612e970bbf0236d655faaa5c20921c344212"
+hash = "b3:376b83692dd7ef2d17c78b01ae9b0158a5ac9c9939d7dcda22089d497368f420"
 
 [[node.edge]]
 target = "CLAUDE.md"
-target_hash = "b3:0608a5e5ab70aa73b528d4a3402b712df92ca9913231a76046aa2e815474e8b7"
+target_hash = "b3:0257778ef9a19e27c49c766f0e59b9d696e238758b2dcb60cebaf95b34cca2a4"
 
 [[node.edge]]
 target = "docs/README.md"
-target_hash = "b3:02385b2bdd49988b5b4e18df9bc326328e4629806923ad3f4855560193c8b356"
+target_hash = "b3:5d7c551d580837a78023fee615d11b96bedeb22ac00a7b28f0c71d724f2c08d6"
 
 [[node.edge]]
 target = "docs/config.md"
@@ -129,7 +129,7 @@ hash = "b3:70c1b3ef7b655bf68cbb1a35b6d9683924c97b34b9f6647f9aef507ef116cebf"
 
 [[node]]
 path = "docs/README.md"
-hash = "b3:02385b2bdd49988b5b4e18df9bc326328e4629806923ad3f4855560193c8b356"
+hash = "b3:5d7c551d580837a78023fee615d11b96bedeb22ac00a7b28f0c71d724f2c08d6"
 
 [[node.edge]]
 target = "docs/config.md"

--- a/drft.lock
+++ b/drft.lock
@@ -42,11 +42,11 @@ hash = "b3:ec7e9d0d826d0d8500ae1bdf96760b702c07f62ac1bd81a796d54fe123fcc94e"
 
 [[node.edge]]
 target = "docs/parsers/README.md"
-target_hash = "b3:9907cb7e84e573adeefca75129e6a7f8514e3d28ca101cbb19fb55265083f011"
+target_hash = "b3:48af6aaf933bc63dc2f2c1ef5fb4ac77dbf9dddb695779a751d8a77f10e203ab"
 
 [[node.edge]]
 target = "docs/rules/README.md"
-target_hash = "b3:001783ea083536a80cc88600bce3816cc6c90106685e825fe3e23e29936d8232"
+target_hash = "b3:e4e6c40e2a07fd773c48102664c26af665fa45a4502523d9e1df97d52c97268c"
 
 [[node.edge]]
 target = "src/builders/mod.rs"
@@ -106,15 +106,15 @@ target_hash = "b3:0608a5e5ab70aa73b528d4a3402b712df92ca9913231a76046aa2e815474e8
 
 [[node.edge]]
 target = "docs/README.md"
-target_hash = "b3:2a1a8d8111f2c056343531d5a55651f2713aee9320a7d97b4aef702ac717d97e"
+target_hash = "b3:02385b2bdd49988b5b4e18df9bc326328e4629806923ad3f4855560193c8b356"
 
 [[node.edge]]
 target = "docs/config.md"
-target_hash = "b3:8b71e3f3697412fa4f88a0e9dbd52a66c7f68549cf1869b5da1b5c2c76b7125e"
+target_hash = "b3:a782543cd5ba74b04fd8583049352836636b4c3b05f429877235ca9ef963ddcc"
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:1078da2341994ee7572d6c75133d1cb4eaecc427c4555f5ea451d643f6274adf"
+target_hash = "b3:90b0460f916bcd13e76f7ed82c49f16e13bcb3fd8f63c1251c1f085fe5a26258"
 
 [[node.edge]]
 target = "https://github.com/johnmdonahue/drft-cli/releases"
@@ -129,39 +129,39 @@ hash = "b3:70c1b3ef7b655bf68cbb1a35b6d9683924c97b34b9f6647f9aef507ef116cebf"
 
 [[node]]
 path = "docs/README.md"
-hash = "b3:2a1a8d8111f2c056343531d5a55651f2713aee9320a7d97b4aef702ac717d97e"
+hash = "b3:02385b2bdd49988b5b4e18df9bc326328e4629806923ad3f4855560193c8b356"
 
 [[node.edge]]
 target = "docs/config.md"
-target_hash = "b3:8b71e3f3697412fa4f88a0e9dbd52a66c7f68549cf1869b5da1b5c2c76b7125e"
+target_hash = "b3:a782543cd5ba74b04fd8583049352836636b4c3b05f429877235ca9ef963ddcc"
 
 [[node.edge]]
 target = "docs/parsers/README.md"
-target_hash = "b3:9907cb7e84e573adeefca75129e6a7f8514e3d28ca101cbb19fb55265083f011"
+target_hash = "b3:48af6aaf933bc63dc2f2c1ef5fb4ac77dbf9dddb695779a751d8a77f10e203ab"
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:1078da2341994ee7572d6c75133d1cb4eaecc427c4555f5ea451d643f6274adf"
+target_hash = "b3:90b0460f916bcd13e76f7ed82c49f16e13bcb3fd8f63c1251c1f085fe5a26258"
 
 [[node.edge]]
 target = "docs/rules/README.md"
-target_hash = "b3:001783ea083536a80cc88600bce3816cc6c90106685e825fe3e23e29936d8232"
+target_hash = "b3:e4e6c40e2a07fd773c48102664c26af665fa45a4502523d9e1df97d52c97268c"
 
 [[node]]
 path = "docs/config.md"
-hash = "b3:8b71e3f3697412fa4f88a0e9dbd52a66c7f68549cf1869b5da1b5c2c76b7125e"
+hash = "b3:a782543cd5ba74b04fd8583049352836636b4c3b05f429877235ca9ef963ddcc"
 
 [[node.edge]]
 target = "docs/parsers/README.md"
-target_hash = "b3:9907cb7e84e573adeefca75129e6a7f8514e3d28ca101cbb19fb55265083f011"
+target_hash = "b3:48af6aaf933bc63dc2f2c1ef5fb4ac77dbf9dddb695779a751d8a77f10e203ab"
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
-target_hash = "b3:ef2ebd19dbc6c8b7d88f9561c2afceed6c8db753fcd8f2c49e20194150986dee"
+target_hash = "b3:27431bd9affeb853dfd9f4472484c3debbacd0f18e1335c1abf2f0f601cc0460"
 
 [[node.edge]]
 target = "docs/rules/README.md"
-target_hash = "b3:001783ea083536a80cc88600bce3816cc6c90106685e825fe3e23e29936d8232"
+target_hash = "b3:e4e6c40e2a07fd773c48102664c26af665fa45a4502523d9e1df97d52c97268c"
 
 [[node.edge]]
 target = "src/cli.rs"
@@ -173,15 +173,15 @@ target_hash = "b3:b0e7369b409c17d0bafc0284666b68a138a06abc23ff7b3905b95f37ae70f9
 
 [[node]]
 path = "docs/parsers/README.md"
-hash = "b3:9907cb7e84e573adeefca75129e6a7f8514e3d28ca101cbb19fb55265083f011"
+hash = "b3:48af6aaf933bc63dc2f2c1ef5fb4ac77dbf9dddb695779a751d8a77f10e203ab"
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
-target_hash = "b3:ef2ebd19dbc6c8b7d88f9561c2afceed6c8db753fcd8f2c49e20194150986dee"
+target_hash = "b3:27431bd9affeb853dfd9f4472484c3debbacd0f18e1335c1abf2f0f601cc0460"
 
 [[node.edge]]
 target = "docs/parsers/markdown.md"
-target_hash = "b3:71f1ce453d7db6746e4a8b9cc1e2bedd608589beb0340e697bc0ce931b9a7d1f"
+target_hash = "b3:a44c5da7480f407327ee9ea2684212f90c4c49743296a98352764a90a2d58885"
 
 [[node.edge]]
 target = "src/parsers/mod.rs"
@@ -189,11 +189,11 @@ target_hash = "b3:d17d93b9838e4703720bafd4150e1dee5653416cb080218716ae21a5c615c3
 
 [[node]]
 path = "docs/parsers/frontmatter.md"
-hash = "b3:ef2ebd19dbc6c8b7d88f9561c2afceed6c8db753fcd8f2c49e20194150986dee"
+hash = "b3:27431bd9affeb853dfd9f4472484c3debbacd0f18e1335c1abf2f0f601cc0460"
 
 [[node.edge]]
 target = "docs/config.md"
-target_hash = "b3:8b71e3f3697412fa4f88a0e9dbd52a66c7f68549cf1869b5da1b5c2c76b7125e"
+target_hash = "b3:a782543cd5ba74b04fd8583049352836636b4c3b05f429877235ca9ef963ddcc"
 
 [[node.edge]]
 target = "src/parsers/frontmatter.rs"
@@ -201,15 +201,15 @@ target_hash = "b3:3141acca048acfba229b56cd48b537988a2e5d8091fd0eb01e7e47c9926c34
 
 [[node]]
 path = "docs/parsers/markdown.md"
-hash = "b3:71f1ce453d7db6746e4a8b9cc1e2bedd608589beb0340e697bc0ce931b9a7d1f"
+hash = "b3:a44c5da7480f407327ee9ea2684212f90c4c49743296a98352764a90a2d58885"
 
 [[node.edge]]
 target = "docs/config.md"
-target_hash = "b3:8b71e3f3697412fa4f88a0e9dbd52a66c7f68549cf1869b5da1b5c2c76b7125e"
+target_hash = "b3:a782543cd5ba74b04fd8583049352836636b4c3b05f429877235ca9ef963ddcc"
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
-target_hash = "b3:ef2ebd19dbc6c8b7d88f9561c2afceed6c8db753fcd8f2c49e20194150986dee"
+target_hash = "b3:27431bd9affeb853dfd9f4472484c3debbacd0f18e1335c1abf2f0f601cc0460"
 
 [[node.edge]]
 target = "src/parsers/markdown.rs"
@@ -217,7 +217,7 @@ target_hash = "b3:952fafe8eb3a776168da8ec935438fbd39de4599375f1c0e82334d3dd8d361
 
 [[node]]
 path = "docs/reading.md"
-hash = "b3:1078da2341994ee7572d6c75133d1cb4eaecc427c4555f5ea451d643f6274adf"
+hash = "b3:90b0460f916bcd13e76f7ed82c49f16e13bcb3fd8f63c1251c1f085fe5a26258"
 
 [[node.edge]]
 target = "src/cli.rs"
@@ -226,6 +226,10 @@ target_hash = "b3:55a73406640ceb7106cd6a8ac8a16b0c9bf0dbdbad59b714a5dda20bff6bc3
 [[node.edge]]
 target = "src/edges.rs"
 target_hash = "b3:be1dec67033a9c7cc489da7609beafedb6ce6ff043178ae908e6ceb8e9ac599b"
+
+[[node.edge]]
+target = "src/impact.rs"
+target_hash = "b3:297723111a36e1bf06d13b460e12175d1093505ec7df97149b52e6aa67921a55"
 
 [[node.edge]]
 target = "src/main.rs"
@@ -241,7 +245,7 @@ target_hash = "b3:c45f328c6d4cc3cb58e4d764ac360bde82d4ee17e411dbcb786fa7019a76c6
 
 [[node]]
 path = "docs/rules/README.md"
-hash = "b3:001783ea083536a80cc88600bce3816cc6c90106685e825fe3e23e29936d8232"
+hash = "b3:e4e6c40e2a07fd773c48102664c26af665fa45a4502523d9e1df97d52c97268c"
 
 [[node.edge]]
 target = "src/config.rs"
@@ -261,7 +265,7 @@ hash = "b3:d5d34129a3b5777158c5e4241ecb5d7a829df2e94a967f6b586dfbb5ab9e94a7"
 
 [[node]]
 path = "drft.toml"
-hash = "b3:a7ccd291217b49db38491769dde12f20363991b5ee780c515b5ed9b9952bcc1a"
+hash = "b3:a6e8628d7cdc6398e145216b9b4c9c7ec99253f42b672cfdb0f45ce0257bad55"
 
 [[node]]
 path = "npm/README.md"

--- a/drft.lock
+++ b/drft.lock
@@ -114,7 +114,7 @@ target_hash = "b3:a782543cd5ba74b04fd8583049352836636b4c3b05f429877235ca9ef963dd
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:90b0460f916bcd13e76f7ed82c49f16e13bcb3fd8f63c1251c1f085fe5a26258"
+target_hash = "b3:8a1deddf23a2b49ac31705f188c439575579d34052e318a07b5bbad7a37b6e27"
 
 [[node.edge]]
 target = "https://github.com/johnmdonahue/drft-cli/releases"
@@ -141,7 +141,7 @@ target_hash = "b3:48af6aaf933bc63dc2f2c1ef5fb4ac77dbf9dddb695779a751d8a77f10e203
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:90b0460f916bcd13e76f7ed82c49f16e13bcb3fd8f63c1251c1f085fe5a26258"
+target_hash = "b3:8a1deddf23a2b49ac31705f188c439575579d34052e318a07b5bbad7a37b6e27"
 
 [[node.edge]]
 target = "docs/rules/README.md"
@@ -165,7 +165,7 @@ target_hash = "b3:e4e6c40e2a07fd773c48102664c26af665fa45a4502523d9e1df97d52c9726
 
 [[node.edge]]
 target = "src/cli.rs"
-target_hash = "b3:55a73406640ceb7106cd6a8ac8a16b0c9bf0dbdbad59b714a5dda20bff6bc3ff"
+target_hash = "b3:ae162d118f40d11d1f5df0dd021808af110232cc813d30a1a78e15bc14265bb5"
 
 [[node.edge]]
 target = "src/config.rs"
@@ -217,11 +217,15 @@ target_hash = "b3:952fafe8eb3a776168da8ec935438fbd39de4599375f1c0e82334d3dd8d361
 
 [[node]]
 path = "docs/reading.md"
-hash = "b3:90b0460f916bcd13e76f7ed82c49f16e13bcb3fd8f63c1251c1f085fe5a26258"
+hash = "b3:8a1deddf23a2b49ac31705f188c439575579d34052e318a07b5bbad7a37b6e27"
 
 [[node.edge]]
 target = "src/cli.rs"
-target_hash = "b3:55a73406640ceb7106cd6a8ac8a16b0c9bf0dbdbad59b714a5dda20bff6bc3ff"
+target_hash = "b3:ae162d118f40d11d1f5df0dd021808af110232cc813d30a1a78e15bc14265bb5"
+
+[[node.edge]]
+target = "src/config.rs"
+target_hash = "b3:b0e7369b409c17d0bafc0284666b68a138a06abc23ff7b3905b95f37ae70f906"
 
 [[node.edge]]
 target = "src/edges.rs"
@@ -304,7 +308,7 @@ hash = "b3:f56fdcddee36a2cc7c9c55b619b80c0571ca85e89334e06741b157d4315d84d4"
 
 [[node]]
 path = "src/cli.rs"
-hash = "b3:55a73406640ceb7106cd6a8ac8a16b0c9bf0dbdbad59b714a5dda20bff6bc3ff"
+hash = "b3:ae162d118f40d11d1f5df0dd021808af110232cc813d30a1a78e15bc14265bb5"
 
 [[node]]
 path = "src/compose.rs"

--- a/drft.lock
+++ b/drft.lock
@@ -237,7 +237,7 @@ target_hash = "b3:4b25105ac3ffc8b8136b8e4ba36092644f2cdd6774204f36252170d9241348
 
 [[node.edge]]
 target = "src/nodes.rs"
-target_hash = "b3:89a1a9a83bac02b9bdac38f1c0b4f3a86de8a7d07bfa246c5e5762fff44c8922"
+target_hash = "b3:bd63f170e88bb37482e7384aa3becb20cea1d7dfcf2be4b4ab79a8e636329920"
 
 [[node.edge]]
 target = "src/projection.rs"
@@ -348,7 +348,7 @@ hash = "b3:8c1fefc41499866612547a86607ed805cb3ad04adceaafbafaba59aa495a1c4e"
 
 [[node]]
 path = "src/nodes.rs"
-hash = "b3:89a1a9a83bac02b9bdac38f1c0b4f3a86de8a7d07bfa246c5e5762fff44c8922"
+hash = "b3:bd63f170e88bb37482e7384aa3becb20cea1d7dfcf2be4b4ab79a8e636329920"
 
 [[node]]
 path = "src/parsers/frontmatter.rs"

--- a/drft.lock
+++ b/drft.lock
@@ -98,7 +98,7 @@ hash = "b3:871c2fd5cdfe89fa6ff01664a1420bf40d0ab18c0e250e59a3ab27225f31bb0e"
 
 [[node]]
 path = "README.md"
-hash = "b3:d83c14f6950c702404e883b7cab6d40bea9b6c3ca5635a8b9af196684846a4ff"
+hash = "b3:ad52d251fb0442eac3f97e52cd31612e970bbf0236d655faaa5c20921c344212"
 
 [[node.edge]]
 target = "CLAUDE.md"
@@ -106,11 +106,15 @@ target_hash = "b3:0608a5e5ab70aa73b528d4a3402b712df92ca9913231a76046aa2e815474e8
 
 [[node.edge]]
 target = "docs/README.md"
-target_hash = "b3:8d7418c6e44101f556bd8bb0852965e24ba8259cbd21a29d1f48c080f069d2e1"
+target_hash = "b3:2a1a8d8111f2c056343531d5a55651f2713aee9320a7d97b4aef702ac717d97e"
 
 [[node.edge]]
 target = "docs/config.md"
 target_hash = "b3:8b71e3f3697412fa4f88a0e9dbd52a66c7f68549cf1869b5da1b5c2c76b7125e"
+
+[[node.edge]]
+target = "docs/reading.md"
+target_hash = "b3:1078da2341994ee7572d6c75133d1cb4eaecc427c4555f5ea451d643f6274adf"
 
 [[node.edge]]
 target = "https://github.com/johnmdonahue/drft-cli/releases"
@@ -125,7 +129,7 @@ hash = "b3:70c1b3ef7b655bf68cbb1a35b6d9683924c97b34b9f6647f9aef507ef116cebf"
 
 [[node]]
 path = "docs/README.md"
-hash = "b3:8d7418c6e44101f556bd8bb0852965e24ba8259cbd21a29d1f48c080f069d2e1"
+hash = "b3:2a1a8d8111f2c056343531d5a55651f2713aee9320a7d97b4aef702ac717d97e"
 
 [[node.edge]]
 target = "docs/config.md"
@@ -134,6 +138,10 @@ target_hash = "b3:8b71e3f3697412fa4f88a0e9dbd52a66c7f68549cf1869b5da1b5c2c76b712
 [[node.edge]]
 target = "docs/parsers/README.md"
 target_hash = "b3:9907cb7e84e573adeefca75129e6a7f8514e3d28ca101cbb19fb55265083f011"
+
+[[node.edge]]
+target = "docs/reading.md"
+target_hash = "b3:1078da2341994ee7572d6c75133d1cb4eaecc427c4555f5ea451d643f6274adf"
 
 [[node.edge]]
 target = "docs/rules/README.md"
@@ -206,6 +214,30 @@ target_hash = "b3:ef2ebd19dbc6c8b7d88f9561c2afceed6c8db753fcd8f2c49e20194150986d
 [[node.edge]]
 target = "src/parsers/markdown.rs"
 target_hash = "b3:952fafe8eb3a776168da8ec935438fbd39de4599375f1c0e82334d3dd8d36183"
+
+[[node]]
+path = "docs/reading.md"
+hash = "b3:1078da2341994ee7572d6c75133d1cb4eaecc427c4555f5ea451d643f6274adf"
+
+[[node.edge]]
+target = "src/cli.rs"
+target_hash = "b3:55a73406640ceb7106cd6a8ac8a16b0c9bf0dbdbad59b714a5dda20bff6bc3ff"
+
+[[node.edge]]
+target = "src/edges.rs"
+target_hash = "b3:be1dec67033a9c7cc489da7609beafedb6ce6ff043178ae908e6ceb8e9ac599b"
+
+[[node.edge]]
+target = "src/main.rs"
+target_hash = "b3:4b25105ac3ffc8b8136b8e4ba36092644f2cdd6774204f36252170d92413480d"
+
+[[node.edge]]
+target = "src/nodes.rs"
+target_hash = "b3:89a1a9a83bac02b9bdac38f1c0b4f3a86de8a7d07bfa246c5e5762fff44c8922"
+
+[[node.edge]]
+target = "src/projection.rs"
+target_hash = "b3:c45f328c6d4cc3cb58e4d764ac360bde82d4ee17e411dbcb786fa7019a76c63b"
 
 [[node]]
 path = "docs/rules/README.md"

--- a/drft.toml
+++ b/drft.toml
@@ -16,6 +16,9 @@ files = ["**/*.md"]
 [graphs.frontmatter]
 parser = "frontmatter"
 files = ["**/*.md"]
+# Edges come only from `sources`; every other frontmatter field (purpose, …) is
+# pure node metadata, read with `drft nodes --field`.
+keys = ["sources"]
 
 # Drift is the value prop — promote staleness to error for CI.
 [rules.stale-node]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 #[command(
     name = "drft",
     version,
-    about = "Structural integrity checker for linked file systems"
+    about = "A drift checker for linked files, built for LLMs and humans working in the same repo"
 )]
 pub struct Cli {
     #[command(subcommand)]

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -1,5 +1,5 @@
 //! `drft nodes`: project node metadata for a set of paths — the read verb that
-//! grounds an LLM (or a human) on what the graph knows about each node.
+//! grounds the reader on what the graph knows about each node.
 //!
 //! `nodes` is a *reader*: its selectors expand (an exact path, a subtree, or a
 //! glob), which is safe because a read has no side effect. This module owns the


### PR DESCRIPTION
Makes drft's AI-native purpose legible in the docs, dogfoods the new read verbs on this repo, and closes a tracking gap. No runtime behavior change; no release needed.

Scope note: this is docs-heavy, plus two non-doc changes that carry no runtime behavior — a `drft.toml` change that scopes the dogfood graph's frontmatter edges to `keys = ["sources"]`, and a `cli.rs` clap `about` string so `drft --help` matches the new positioning. Both ride the next release; neither needs an urgent ship.

## What's in it

**1. Explain the read verbs for LLM collaboration.** The README "LLM integration" section predated `nodes`/`edges`/`graph --format text` and described only `--format json` and `drft impact`. It now leads with the grounding pattern (`drft nodes <path>` reads a file's metadata instead of opening it), and a new `docs/reading.md` reference page covers the read-verb family: selector grammar, `--namespace`/`--field`, text vs JSON, grounding examples.

**2. Dogfood the read verbs across the docs.**
- A one-line `purpose:` on every `docs/` page, so `drft nodes docs/ --field purpose` returns a live map of what each doc is for — the grounding use case `reading.md` documents, now real on this repo.
- `[graphs.frontmatter]` scoped to `keys = ["sources"]`, so `sources` is the only edge-producing field and `purpose` (and future fields) are pure metadata. Preserves every current edge.
- `docs/reading.md` sources `src/impact.rs` and `src/config.rs` — the modules behind the commands and behavior it describes, which no doc tracked.

**3. Anchor drft's positioning as AI-native.** New tagline across README, the crate description, CLAUDE.md, `docs/README.md`, and `drft --help`: *"A drift checker for linked files, built for LLMs and humans working in the same repo."* Plain Unix-utility register, not a pitch. The README body frames the problem as derivation drift (staleness is one kind; structural drift is another) and states that whether a flagged derivation still holds is a reading a linter can't settle, so drft surfaces it for review — who reviews is left unstated.

**4. Audience-neutral wording.** `nodes.rs`'s module comment now grounds "the reader," not "an LLM (or a human)."

## Notes
- Dogfooded throughout: `drft check` clean and `dprint check` clean after each step; impacted dependents reviewed before every lock. `cargo test` + `clippy -D warnings` green after the `cli.rs` change.
- A blind review caught a wrong `jq` key in `reading.md` (`.impacted[].path` → `.node`) and the missed `cli.rs` help string; both fixed here.
