### PR TITLE
feat: require --all for a whole-graph lock (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to drft are documented here.
 
+## Unreleased
+
+### Breaking changes
+
+- **The whole-graph lock is `drft lock --all`** (#104). `drft lock` with no paths is a usage error (exit 2) naming both remedies, where it previously snapshotted every node. Zero paths is what a shell hands over when a command substitution matches nothing, so `drft lock $(cmd)` on an empty `cmd` turned a scoped invocation into a whole-graph one — silently, at exit 0, writing a claim that every node had been reviewed into a file that outlives the session. **This breaks any script, hook, or habit that relied on the bare form**: pass `--all` to snapshot the whole graph, which is the right call when regenerating a baseline and the wrong one otherwise. `--all` combined with paths is also an error, since the two state different scopes. There is no short form — spelling out the call that asserts whole-graph review is the point, and a long flag is greppable, so a hook or CI check can forbid `--all` while leaving scoped locks alone. `drft nodes` and `drft edges` keep their zero-selector default: for a reader the cost is a large read, not a durable claim.
+
 ## 0.15.0 (2026-08-19)
 
 Finishes the read verbs of the #90 query surface. `drft edges` projects the graph's edges, and `drft graph` gains a text rendering of the whole composed graph — so an agent can read nodes, edges, or the entire graph without parsing JSON.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,10 +23,10 @@ Do not suppress warnings by removing links, ignoring paths, or disabling rules �
 **Lock only what you reviewed, by name.** A lock asserts the locked state was read and is correct, so the assertion has to stay narrow enough to be true:
 
 - **You may** run `drft lock <path>...` for paths you edited this session, once you have reviewed their impacted dependents. Name every path.
-- **Never run bare `drft lock`.** It clears staleness across the whole graph, including files you never opened and work someone else has in flight. That launders an unreviewed state into a reviewed one, and the record that it was never read is gone.
+- **Never run `drft lock --all`.** It clears staleness across the whole graph, including files you never opened and work someone else has in flight. That launders an unreviewed state into a reviewed one, and the record that it was never read is gone. Bare `drft lock` is a usage error (exit 2), so an empty shell expansion can no longer widen a scoped lock by accident — but `--all` typed deliberately still does everything this rule forbids.
 - **Never lock staleness you did not cause.** If `drft check` reports findings you cannot account for, stop and say so — those are the user's to inspect.
 
-The one bare lock that is correct is **regenerating a baseline**: no `drft.lock` exists, or a release requires every lockfile to be rewritten (0.8.0, 0.9.0, and 0.10.0 each did). There is no prior baseline to preserve, so nothing is being laundered. Ask first, and say that is what you are doing — it is the call the rule otherwise forbids.
+The one `--all` lock that is correct is **regenerating a baseline**: no `drft.lock` exists, or a release requires every lockfile to be rewritten (0.8.0, 0.9.0, and 0.10.0 each did). There is no prior baseline to preserve, so nothing is being laundered. Ask first, and say that is what you are doing — it is the call the rule otherwise forbids.
 
 **A `stale-edge` clears from the declaring side.** An edge's recorded target hash lives on the file that wrote the link, so locking a changed source clears its own `stale-node` and leaves every inbound `stale-edge` standing. Those clear when you lock the dependent — the file whose promise you actually checked. Scoped locking therefore cannot wave off the review it exists to record.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Do not suppress warnings by removing links, ignoring paths, or disabling rules �
 **Lock only what you reviewed, by name.** A lock asserts the locked state was read and is correct, so the assertion has to stay narrow enough to be true:
 
 - **You may** run `drft lock <path>...` for paths you edited this session, once you have reviewed their impacted dependents. Name every path.
-- **Never run `drft lock --all`.** It clears staleness across the whole graph, including files you never opened and work someone else has in flight. That launders an unreviewed state into a reviewed one, and the record that it was never read is gone. Bare `drft lock` is a usage error (exit 2), so an empty shell expansion can no longer widen a scoped lock by accident — but `--all` typed deliberately still does everything this rule forbids.
+- **Never run `drft lock --all`.** It clears staleness across the whole graph, including files you never opened and work someone else has in flight. That launders an unreviewed state into a reviewed one, and the record that it was never read is gone.
 - **Never lock staleness you did not cause.** If `drft check` reports findings you cannot account for, stop and say so — those are the user's to inspect.
 
 The one `--all` lock that is correct is **regenerating a baseline**: no `drft.lock` exists, or a release requires every lockfile to be rewritten (0.8.0, 0.9.0, and 0.10.0 each did). There is no prior baseline to preserve, so nothing is being laundered. Ask first, and say that is what you are doing — it is the call the rule otherwise forbids.

--- a/README.md
+++ b/README.md
@@ -56,13 +56,18 @@ All rules default to `warn`. Override to `error` for CI enforcement or `off` to 
 | `drft check`  | Compare the graph against the lockfile for drift               |
 | `drft lock`   | Snapshot hashes to `drft.lock` for staleness tracking          |
 
-`drft lock` with no argument snapshots the whole graph. Given paths — `drft lock
-src/lib.rs docs/guide.md` — it locks only those nodes and their outbound edges,
+`drft lock src/lib.rs docs/guide.md` locks those nodes and their outbound edges,
 merging into the existing lockfile. A lock asserts the locked state was reviewed,
 so scope it to what you actually read: a bulk lock also clears staleness you
 never looked at, including someone else's unfinished work. Paths all resolve
 before anything is written, so a typo fails the command rather than leaving a
 partial lock behind.
+
+The whole-graph lock is `drft lock --all`, and it has to be named: `drft lock`
+with no paths errors (exit 2). Zero paths is also what a shell hands over when a
+command substitution matches nothing, so without the flag a scoped invocation
+whose expansion came back empty would snapshot the whole graph at exit 0, with
+nothing in the output to say it had.
 
 All commands support `--format json`. Run `drft --help` for the full flag reference.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The binary is called `drft`.
 ```bash
 drft init                 # create a drft.toml
 drft check                # validate the graph
-drft lock                 # snapshot file hashes
+drft lock --all           # snapshot every file's hash as the baseline
 drft check                # now detects staleness too
 ```
 
@@ -63,11 +63,9 @@ never looked at, including someone else's unfinished work. Paths all resolve
 before anything is written, so a typo fails the command rather than leaving a
 partial lock behind.
 
-The whole-graph lock is `drft lock --all`, and it has to be named: `drft lock`
-with no paths errors (exit 2). Zero paths is also what a shell hands over when a
-command substitution matches nothing, so without the flag a scoped invocation
-whose expansion came back empty would snapshot the whole graph at exit 0, with
-nothing in the output to say it had.
+The whole-graph lock is `drft lock --all`. `drft lock` with no paths errors
+(exit 2), so a scoped invocation whose shell expansion came back empty fails
+instead of widening to every node.
 
 All commands support `--format json`. Run `drft --help` for the full flag reference.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@
 
 1. **Bump version** in `Cargo.toml`
 2. **Update CHANGELOG.md** with the new version and date
-3. **Run `drft lock`** — see [the release commit is drift](#the-release-commit-is-drift) below
+3. **Run `drft lock Cargo.toml CHANGELOG.md`** — see [the release commit is drift](#the-release-commit-is-drift) below
 4. **Open a PR** from a release branch (e.g., `release/v0.x.x`) — main is protected
 5. **Merge** after CI passes
 6. **Tag on main**: `git checkout main && git pull && git tag v0.x.x`
@@ -16,12 +16,14 @@ That's it. Everything else is automated.
 
 `check` is a required status check on `main`, and it runs `cargo run -- check`.
 Both `Cargo.toml` and `CHANGELOG.md` are nodes in drft's own graph, so steps 1
-and 2 make them stale and CI fails on the release commit itself. Run `drft lock`
-before committing.
+and 2 make them stale and CI fails on the release commit itself. Run `drft lock
+Cargo.toml CHANGELOG.md` before committing — those two are the only nodes the
+release touches, so the lock stays scoped to what the release actually changed.
 
 `main` also requires branches to be up to date before merging, so a release
-branch that falls behind needs `git merge origin/main` (and another `drft lock`
-if that pulls in tracked changes) before it can land.
+branch that falls behind needs `git merge origin/main` (and another lock, named
+to the files the merge left stale, if it pulls in tracked changes) before it can
+land.
 
 ## What happens automatically
 
@@ -51,7 +53,7 @@ npm uses **trusted publishing** (OIDC) — no token needed. Configure at https:/
 # Edit Cargo.toml: version = "0.3.0"
 # Edit CHANGELOG.md: add ## 0.3.0 section
 git checkout -b release/v0.3.0
-drft lock # both edits above are tracked nodes; CI runs drft check
+drft lock Cargo.toml CHANGELOG.md # both are tracked nodes; CI runs drft check
 git commit -am "Release v0.3.0"
 git push -u origin release/v0.3.0
 gh pr create --title "Release v0.3.0"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,9 +21,9 @@ Cargo.toml CHANGELOG.md` before committing — those two are the only nodes the
 release touches, so the lock stays scoped to what the release actually changed.
 
 `main` also requires branches to be up to date before merging, so a release
-branch that falls behind needs `git merge origin/main` (and another lock, named
-to the files the merge left stale, if it pulls in tracked changes) before it can
-land.
+branch that falls behind needs `git merge origin/main` before it can land. If
+that merge pulls in tracked changes, run `drft check` and lock the files it
+reports.
 
 ## What happens automatically
 

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -43,11 +43,12 @@ itself. `drft edges` matches the selector against edge **sources**, so a directo
 selector projects every edge leaving that subtree.
 
 Selector expansion is a reader affordance only. Writers like `drft lock` stay
-exact-path-only, so a subtree or glob never fans out into a write. The empty
-selector splits the same way: a reader with none returns everything, while `drft
-lock` with no paths errors and requires `--all` to name the whole graph — for a
-reader the cost is a large read, for a writer it is a durable claim that the
-whole graph was reviewed.
+exact-path-only, so a subtree or glob never fans out into a write.
+
+The empty selector divides on the same line. A reader with no selector returns
+everything, because the cost is a large read. `drft lock` with no paths errors
+instead, and names the whole graph as `--all`, because the cost there is a
+durable claim that every node was reviewed.
 
 An exact path that matches nothing is a likely typo: the command errors (exit 2)
 with a suggestion. A glob that matches nothing is a legitimate empty result

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -43,7 +43,11 @@ itself. `drft edges` matches the selector against edge **sources**, so a directo
 selector projects every edge leaving that subtree.
 
 Selector expansion is a reader affordance only. Writers like `drft lock` stay
-exact-path-only, so a subtree or glob never fans out into a write.
+exact-path-only, so a subtree or glob never fans out into a write. The empty
+selector splits the same way: a reader with none returns everything, while `drft
+lock` with no paths errors and requires `--all` to name the whole graph — for a
+reader the cost is a large read, for a writer it is a durable claim that the
+whole graph was reviewed.
 
 An exact path that matches nothing is a likely typo: the command errors (exit 2)
 with a suggestion. A glob that matches nothing is a legitimate empty result

--- a/drft.lock
+++ b/drft.lock
@@ -22,15 +22,15 @@ hash = "b3:fdfab84f5fb35961e9a6a9b20c82f2c9f60ca9c9ab801eaa055e286d46ceb5bd"
 
 [[node]]
 path = "CHANGELOG.md"
-hash = "b3:cf23c9d6fc2d8d849114f11cdb8ab84c4461cc99fa92ffd559c463f0ccefd211"
+hash = "b3:a96743604eb591f92143d410f76e4ae8fbac5333a75be58c6cd36f83131e425a"
 
 [[node]]
 path = "CLAUDE.md"
-hash = "b3:fa9f4b6bd2407a7a087664fbfd09415f23a06e79159650ba993edffcb9648393"
+hash = "b3:f0ef1960837ebcd537416d01eb040e1c6ef97510319887bcd9f183efc10ee637"
 
 [[node.edge]]
 target = "RELEASING.md"
-target_hash = "b3:ff69195206927d63233f36612d1bf90716f4d1df34ff36173e4914da53b5b662"
+target_hash = "b3:487a739269373875e508ecc49686d1ae580cdc8b770da7ac70f47b48f6ecb964"
 
 [[node.edge]]
 target = "src/compose.rs"
@@ -66,7 +66,7 @@ target_hash = "b3:ee0a6eff00d1b7c73ae7a7613422501c3290ec758e9e8eb147b220b89c234b
 
 [[node.edge]]
 target = "src/lock.rs"
-target_hash = "b3:b437206e0e16ea1a0643edda5d8b1ab7361816bb42222bc80e488e13329b0516"
+target_hash = "b3:332514bd6a0fbdddea391f8979e33857d66524e0a226b2b39d7c9f6f424404a9"
 
 [[node.edge]]
 target = "src/model.rs"
@@ -98,11 +98,11 @@ hash = "b3:871c2fd5cdfe89fa6ff01664a1420bf40d0ab18c0e250e59a3ab27225f31bb0e"
 
 [[node]]
 path = "README.md"
-hash = "b3:71a93f831a36e95bf0bb5da4dd77d6b962aff837cfaf618d0e282cc3203b8c87"
+hash = "b3:9e4b535ec9d61d9892423c8902fd3750aa2510d885ae201fbc136b0c44b82103"
 
 [[node.edge]]
 target = "CLAUDE.md"
-target_hash = "b3:fa9f4b6bd2407a7a087664fbfd09415f23a06e79159650ba993edffcb9648393"
+target_hash = "b3:f0ef1960837ebcd537416d01eb040e1c6ef97510319887bcd9f183efc10ee637"
 
 [[node.edge]]
 target = "docs/README.md"
@@ -114,14 +114,14 @@ target_hash = "b3:a782543cd5ba74b04fd8583049352836636b4c3b05f429877235ca9ef963dd
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:97b210abac9fe973928d0f27befb26c17399ad61218750c6b7672c3e14863988"
+target_hash = "b3:fc188b108b2219feb7de9139ad2225d43933c664d40cbf22b203241fc4bd0a50"
 
 [[node.edge]]
 target = "https://github.com/johnmdonahue/drft-cli/releases"
 
 [[node]]
 path = "RELEASING.md"
-hash = "b3:ff69195206927d63233f36612d1bf90716f4d1df34ff36173e4914da53b5b662"
+hash = "b3:487a739269373875e508ecc49686d1ae580cdc8b770da7ac70f47b48f6ecb964"
 
 [[node]]
 path = "dist-workspace.toml"
@@ -141,7 +141,7 @@ target_hash = "b3:48af6aaf933bc63dc2f2c1ef5fb4ac77dbf9dddb695779a751d8a77f10e203
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:97b210abac9fe973928d0f27befb26c17399ad61218750c6b7672c3e14863988"
+target_hash = "b3:fc188b108b2219feb7de9139ad2225d43933c664d40cbf22b203241fc4bd0a50"
 
 [[node.edge]]
 target = "docs/rules/README.md"
@@ -165,7 +165,7 @@ target_hash = "b3:e4e6c40e2a07fd773c48102664c26af665fa45a4502523d9e1df97d52c9726
 
 [[node.edge]]
 target = "src/cli.rs"
-target_hash = "b3:49073b7d6227ecd81d1d09e072cc40ff966ef549ddbfd6a97cb97c15e3151a7f"
+target_hash = "b3:5f396f41a7ac62dc62594654290ade1d0ea53491a526ffcc8b5b856e5158f724"
 
 [[node.edge]]
 target = "src/config.rs"
@@ -217,11 +217,11 @@ target_hash = "b3:952fafe8eb3a776168da8ec935438fbd39de4599375f1c0e82334d3dd8d361
 
 [[node]]
 path = "docs/reading.md"
-hash = "b3:97b210abac9fe973928d0f27befb26c17399ad61218750c6b7672c3e14863988"
+hash = "b3:fc188b108b2219feb7de9139ad2225d43933c664d40cbf22b203241fc4bd0a50"
 
 [[node.edge]]
 target = "src/cli.rs"
-target_hash = "b3:49073b7d6227ecd81d1d09e072cc40ff966ef549ddbfd6a97cb97c15e3151a7f"
+target_hash = "b3:5f396f41a7ac62dc62594654290ade1d0ea53491a526ffcc8b5b856e5158f724"
 
 [[node.edge]]
 target = "src/config.rs"
@@ -273,7 +273,7 @@ hash = "b3:a6e8628d7cdc6398e145216b9b4c9c7ec99253f42b672cfdb0f45ce0257bad55"
 
 [[node]]
 path = "npm/README.md"
-hash = "b3:f9b05887e9a822bc7070280ba542359b56d89e6f2a17ccb52355808a02f99a16"
+hash = "b3:d01d34d3dc92a081460aa815cfcadb73a1293177e1f7f160b721a1e514ec4456"
 
 [[node.edge]]
 target = "https://github.com/johnmdonahue/drft-cli"
@@ -308,7 +308,7 @@ hash = "b3:f56fdcddee36a2cc7c9c55b619b80c0571ca85e89334e06741b157d4315d84d4"
 
 [[node]]
 path = "src/cli.rs"
-hash = "b3:49073b7d6227ecd81d1d09e072cc40ff966ef549ddbfd6a97cb97c15e3151a7f"
+hash = "b3:5f396f41a7ac62dc62594654290ade1d0ea53491a526ffcc8b5b856e5158f724"
 
 [[node]]
 path = "src/compose.rs"
@@ -340,7 +340,7 @@ hash = "b3:1965b48add43e7ec39afd9e15946f004a6410eaa9a46083df196bfdd1b84dfb9"
 
 [[node]]
 path = "src/lock.rs"
-hash = "b3:b437206e0e16ea1a0643edda5d8b1ab7361816bb42222bc80e488e13329b0516"
+hash = "b3:332514bd6a0fbdddea391f8979e33857d66524e0a226b2b39d7c9f6f424404a9"
 
 [[node]]
 path = "src/main.rs"
@@ -424,7 +424,7 @@ hash = "b3:dc15abb7afc8314627fd1346ade4e129ad9796ddcbab651d82f342c15db03dfc"
 
 [[node]]
 path = "tests/lock.rs"
-hash = "b3:40db042dfdfe7f6018124bf044531044c12620f7ed4dcde28685bb4441aeef72"
+hash = "b3:c28ef1f7e3b6f5212e31bb0af838004a1a8920b5b4b04a8b969d4c00f34fc316"
 
 [[node]]
 path = "tests/nodes.rs"

--- a/drft.lock
+++ b/drft.lock
@@ -26,11 +26,11 @@ hash = "b3:cf23c9d6fc2d8d849114f11cdb8ab84c4461cc99fa92ffd559c463f0ccefd211"
 
 [[node]]
 path = "CLAUDE.md"
-hash = "b3:0257778ef9a19e27c49c766f0e59b9d696e238758b2dcb60cebaf95b34cca2a4"
+hash = "b3:fa9f4b6bd2407a7a087664fbfd09415f23a06e79159650ba993edffcb9648393"
 
 [[node.edge]]
 target = "RELEASING.md"
-target_hash = "b3:1fb80017545dabbf628f79a97b646c05b3f5cec1b1062ad0f75c598b736f6dab"
+target_hash = "b3:ff69195206927d63233f36612d1bf90716f4d1df34ff36173e4914da53b5b662"
 
 [[node.edge]]
 target = "src/compose.rs"
@@ -98,11 +98,11 @@ hash = "b3:871c2fd5cdfe89fa6ff01664a1420bf40d0ab18c0e250e59a3ab27225f31bb0e"
 
 [[node]]
 path = "README.md"
-hash = "b3:376b83692dd7ef2d17c78b01ae9b0158a5ac9c9939d7dcda22089d497368f420"
+hash = "b3:71a93f831a36e95bf0bb5da4dd77d6b962aff837cfaf618d0e282cc3203b8c87"
 
 [[node.edge]]
 target = "CLAUDE.md"
-target_hash = "b3:0257778ef9a19e27c49c766f0e59b9d696e238758b2dcb60cebaf95b34cca2a4"
+target_hash = "b3:fa9f4b6bd2407a7a087664fbfd09415f23a06e79159650ba993edffcb9648393"
 
 [[node.edge]]
 target = "docs/README.md"
@@ -114,14 +114,14 @@ target_hash = "b3:a782543cd5ba74b04fd8583049352836636b4c3b05f429877235ca9ef963dd
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:8a1deddf23a2b49ac31705f188c439575579d34052e318a07b5bbad7a37b6e27"
+target_hash = "b3:97b210abac9fe973928d0f27befb26c17399ad61218750c6b7672c3e14863988"
 
 [[node.edge]]
 target = "https://github.com/johnmdonahue/drft-cli/releases"
 
 [[node]]
 path = "RELEASING.md"
-hash = "b3:1fb80017545dabbf628f79a97b646c05b3f5cec1b1062ad0f75c598b736f6dab"
+hash = "b3:ff69195206927d63233f36612d1bf90716f4d1df34ff36173e4914da53b5b662"
 
 [[node]]
 path = "dist-workspace.toml"
@@ -141,7 +141,7 @@ target_hash = "b3:48af6aaf933bc63dc2f2c1ef5fb4ac77dbf9dddb695779a751d8a77f10e203
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:8a1deddf23a2b49ac31705f188c439575579d34052e318a07b5bbad7a37b6e27"
+target_hash = "b3:97b210abac9fe973928d0f27befb26c17399ad61218750c6b7672c3e14863988"
 
 [[node.edge]]
 target = "docs/rules/README.md"
@@ -165,7 +165,7 @@ target_hash = "b3:e4e6c40e2a07fd773c48102664c26af665fa45a4502523d9e1df97d52c9726
 
 [[node.edge]]
 target = "src/cli.rs"
-target_hash = "b3:ae162d118f40d11d1f5df0dd021808af110232cc813d30a1a78e15bc14265bb5"
+target_hash = "b3:49073b7d6227ecd81d1d09e072cc40ff966ef549ddbfd6a97cb97c15e3151a7f"
 
 [[node.edge]]
 target = "src/config.rs"
@@ -217,11 +217,11 @@ target_hash = "b3:952fafe8eb3a776168da8ec935438fbd39de4599375f1c0e82334d3dd8d361
 
 [[node]]
 path = "docs/reading.md"
-hash = "b3:8a1deddf23a2b49ac31705f188c439575579d34052e318a07b5bbad7a37b6e27"
+hash = "b3:97b210abac9fe973928d0f27befb26c17399ad61218750c6b7672c3e14863988"
 
 [[node.edge]]
 target = "src/cli.rs"
-target_hash = "b3:ae162d118f40d11d1f5df0dd021808af110232cc813d30a1a78e15bc14265bb5"
+target_hash = "b3:49073b7d6227ecd81d1d09e072cc40ff966ef549ddbfd6a97cb97c15e3151a7f"
 
 [[node.edge]]
 target = "src/config.rs"
@@ -237,7 +237,7 @@ target_hash = "b3:297723111a36e1bf06d13b460e12175d1093505ec7df97149b52e6aa67921a
 
 [[node.edge]]
 target = "src/main.rs"
-target_hash = "b3:4b25105ac3ffc8b8136b8e4ba36092644f2cdd6774204f36252170d92413480d"
+target_hash = "b3:f5f53361e0274157bbd2d1aab9f2fc2f8f34d9ba85cfc7d1d46ce72896c411f0"
 
 [[node.edge]]
 target = "src/nodes.rs"
@@ -308,7 +308,7 @@ hash = "b3:f56fdcddee36a2cc7c9c55b619b80c0571ca85e89334e06741b157d4315d84d4"
 
 [[node]]
 path = "src/cli.rs"
-hash = "b3:ae162d118f40d11d1f5df0dd021808af110232cc813d30a1a78e15bc14265bb5"
+hash = "b3:49073b7d6227ecd81d1d09e072cc40ff966ef549ddbfd6a97cb97c15e3151a7f"
 
 [[node]]
 path = "src/compose.rs"
@@ -344,7 +344,7 @@ hash = "b3:b437206e0e16ea1a0643edda5d8b1ab7361816bb42222bc80e488e13329b0516"
 
 [[node]]
 path = "src/main.rs"
-hash = "b3:4b25105ac3ffc8b8136b8e4ba36092644f2cdd6774204f36252170d92413480d"
+hash = "b3:f5f53361e0274157bbd2d1aab9f2fc2f8f34d9ba85cfc7d1d46ce72896c411f0"
 
 [[node]]
 path = "src/model.rs"
@@ -416,7 +416,7 @@ hash = "b3:d9ea0b837a0b894e3d5123a036e89ce832aa69b78044c17bb8134d3fd904c3b3"
 
 [[node]]
 path = "tests/impact.rs"
-hash = "b3:243dec1ecf1ac18d8ae70c074dc272fbc9ad2b60714807a0c7bd0f8dc2801e2d"
+hash = "b3:7ef3fcf111c31dc264387d849c7cbdf2e76a2ca1662dabb6d82b1572a21d134e"
 
 [[node]]
 path = "tests/init.rs"
@@ -424,7 +424,7 @@ hash = "b3:dc15abb7afc8314627fd1346ade4e129ad9796ddcbab651d82f342c15db03dfc"
 
 [[node]]
 path = "tests/lock.rs"
-hash = "b3:a4e6a7a9c1bec9cf0eee23d73d224ba35725928da4f0d1bb8671f1cf6a85f213"
+hash = "b3:40db042dfdfe7f6018124bf044531044c12620f7ed4dcde28685bb4441aeef72"
 
 [[node]]
 path = "tests/nodes.rs"
@@ -436,7 +436,7 @@ hash = "b3:d7ef6af77459cc2bd4582565b3162d730995820c54120aeecca361c093f7214d"
 
 [[node]]
 path = "tests/parsers.rs"
-hash = "b3:d4e29aced89c5b175f4fa01b926171d95a36d295c6f79843f0dbd923e8c0f47f"
+hash = "b3:e4c83976b9be3fd4906a951c899db03296c99e19b239d667a57c1d48361f4b61"
 
 [[node]]
 path = "tests/rules.rs"

--- a/npm/README.md
+++ b/npm/README.md
@@ -14,7 +14,7 @@ npm install drft-cli
 
 ```bash
 npx drft check
-npx drft lock
+npx drft lock --all
 npx drft graph
 npx drft impact setup.md
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,9 +34,7 @@ pub enum Commands {
         /// Lock these paths and their outbound edges (at least one required, or --all)
         paths: Vec<String>,
 
-        /// Lock every node in the graph. Required to be explicit: a lock asserts
-        /// the locked state was reviewed, and zero paths is also what a shell
-        /// hands over when a command substitution matches nothing.
+        /// Lock every node in the graph
         #[arg(long)]
         all: bool,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,8 +31,14 @@ pub enum Commands {
 
     /// Snapshot the current state to drft.lock
     Lock {
-        /// Lock only these paths and their outbound edges (default: lock the whole graph)
+        /// Lock these paths and their outbound edges (at least one required, or --all)
         paths: Vec<String>,
+
+        /// Lock every node in the graph. Required to be explicit: a lock asserts
+        /// the locked state was reviewed, and zero paths is also what a shell
+        /// hands over when a command substitution matches nothing.
+        #[arg(long)]
+        all: bool,
     },
 
     /// Render the composed graph as text or JGF

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -4,8 +4,9 @@
 //! staleness.
 //!
 //! The on-disk form (`drft.lock`) is deterministic TOML with no timestamps and
-//! no version field. A parse failure warns and points at `drft lock` rather than
-//! failing the command.
+//! no version field. A parse failure warns and points at `drft lock --all` rather
+//! than failing the command — an unparseable lockfile has no baseline to preserve,
+//! which is the one case the whole-graph lock is the right call.
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -116,7 +117,7 @@ impl Lock {
 }
 
 // `deny_unknown_fields` rejects foreign shapes (e.g. an older lockfile format)
-// so they surface as a parse failure that points at `drft lock`, rather than
+// so they surface as a parse failure that points at `drft lock --all`, rather than
 // silently deserializing into an empty lock.
 #[derive(Debug, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
@@ -144,7 +145,7 @@ struct EdgeToml {
 }
 
 /// Read `drft.lock` from `root`. Returns `Ok(None)` when the file is absent or
-/// cannot be parsed (a parse failure warns and points at `drft lock`).
+/// cannot be parsed (a parse failure warns and points at `drft lock --all`).
 pub fn read(root: &Path) -> Result<Option<Lock>> {
     let path = root.join(LOCK_FILE);
     if !path.exists() {
@@ -155,7 +156,9 @@ pub fn read(root: &Path) -> Result<Option<Lock>> {
     match Lock::from_toml(&content) {
         Ok(lock) => Ok(Some(lock)),
         Err(e) => {
-            eprintln!("warn: could not parse {LOCK_FILE} ({e}) — run `drft lock` to regenerate");
+            eprintln!(
+                "warn: could not parse {LOCK_FILE} ({e}) — run `drft lock --all` to regenerate"
+            );
             Ok(None)
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ fn try_main() -> Result<i32> {
 
     match &cli.command {
         Commands::Init => run_init(&root),
-        Commands::Lock { paths } => run_lock(&root, paths),
+        Commands::Lock { paths, all } => run_lock(&root, paths, *all),
         Commands::Impact {
             paths,
             depth,
@@ -138,19 +138,42 @@ files = ["**/*.md"]
 
 /// Snapshot the composed graph into `drft.lock`: node content hashes and each
 /// node's outbound edge target hashes. With paths, lock only those nodes (their
-/// bytes and their outbound edge targets), merging into the existing lockfile.
+/// bytes and their outbound edge targets), merging into the existing lockfile;
+/// with `--all`, lock every node.
 ///
 /// A lock is an assertion that the locked state was reviewed, so the scoped form
 /// exists to make that assertion narrow enough to be true — lock what you read,
 /// not whatever happens to be stale.
-fn run_lock(root: &Path, paths: &[String]) -> Result<i32> {
+///
+/// The whole-graph lock has to be named. Zero paths is also what the shell hands
+/// over when a command substitution matches nothing, so inferring "every node"
+/// from an empty argument list would turn a scoped invocation into a whole-graph
+/// assertion silently, in a file that outlives the session.
+fn run_lock(root: &Path, paths: &[String], all: bool) -> Result<i32> {
+    // Both guards are pure argv, so they answer before any graph work.
+    if paths.is_empty() && !all {
+        anyhow::bail!(
+            "no paths given — name the paths you reviewed (`drft lock <path>...`), \
+             or pass `--all` to lock every node. An empty argument list is also \
+             what a shell substitution that matched nothing produces, so it is \
+             not read as the whole graph."
+        );
+    }
+    if !paths.is_empty() && all {
+        anyhow::bail!(
+            "`--all` locks every node, so it cannot be combined with paths — \
+             drop `--all` to lock only the paths you named, or drop the paths \
+             to lock the whole graph."
+        );
+    }
+
     let graph_root = find_graph_root(root);
     let config = Config::load(&graph_root)?;
     let set = graphs::build_set(&graph_root, &config)?;
     let composed = compose::compose(&set);
     let snapshot = lock::Lock::from_composed(&composed);
 
-    if paths.is_empty() {
+    if all {
         lock::write(&graph_root, &snapshot)?;
         return Ok(0);
     }

--- a/tests/impact.rs
+++ b/tests/impact.rs
@@ -137,7 +137,7 @@ fn scoped_lock_refreshes_only_one_node() {
     fs::write(dir.path().join("setup.md"), "# Setup").unwrap();
 
     drft_bin()
-        .args(["-C", dir.path().to_str().unwrap(), "lock"])
+        .args(["-C", dir.path().to_str().unwrap(), "lock", "--all"])
         .output()
         .unwrap();
 

--- a/tests/lock.rs
+++ b/tests/lock.rs
@@ -12,9 +12,9 @@ fn check(dir: &std::path::Path) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned()
 }
 
-fn lock(dir: &std::path::Path) {
+fn lock_all(dir: &std::path::Path) {
     let output = drft_bin()
-        .args(["-C", dir.to_str().unwrap(), "lock"])
+        .args(["-C", dir.to_str().unwrap(), "lock", "--all"])
         .output()
         .unwrap();
     assert!(output.status.success(), "lock should exit 0");
@@ -29,7 +29,7 @@ fn first_lock_then_clean_check() {
     fs::write(dir.path().join("index.md"), "[setup](setup.md)").unwrap();
     fs::write(dir.path().join("setup.md"), "# Setup").unwrap();
 
-    lock(dir.path());
+    lock_all(dir.path());
 
     let lockfile = fs::read_to_string(dir.path().join("drft.lock")).unwrap();
     assert!(lockfile.contains("[[node]]"));
@@ -63,7 +63,7 @@ fn edit_dependency_reports_stale_node_and_stale_edge() {
     fs::write(dir.path().join("index.md"), "[setup](setup.md)").unwrap();
     fs::write(dir.path().join("setup.md"), "# Setup").unwrap();
 
-    lock(dir.path());
+    lock_all(dir.path());
     fs::write(dir.path().join("setup.md"), "# Setup (edited)").unwrap();
 
     let stdout = check(dir.path());
@@ -85,11 +85,11 @@ fn relock_clears_staleness() {
     fs::write(dir.path().join("index.md"), "[setup](setup.md)").unwrap();
     fs::write(dir.path().join("setup.md"), "# Setup").unwrap();
 
-    lock(dir.path());
+    lock_all(dir.path());
     fs::write(dir.path().join("setup.md"), "# Setup (edited)").unwrap();
     assert!(check(dir.path()).contains("stale"));
 
-    lock(dir.path());
+    lock_all(dir.path());
     assert!(
         !check(dir.path()).contains("stale"),
         "re-locking should clear staleness"
@@ -105,7 +105,7 @@ fn deleted_file_reports_unresolved_and_removed_node() {
     fs::write(dir.path().join("index.md"), "[setup](setup.md)").unwrap();
     fs::write(dir.path().join("setup.md"), "# Setup").unwrap();
 
-    lock(dir.path());
+    lock_all(dir.path());
     fs::remove_file(dir.path().join("setup.md")).unwrap();
 
     let stdout = check(dir.path());
@@ -129,7 +129,7 @@ fn scoped_lock_accepts_several_paths() {
     for name in ["a", "b", "c"] {
         fs::write(dir.path().join(format!("{name}.md")), format!("# {name}")).unwrap();
     }
-    lock(dir.path());
+    lock_all(dir.path());
 
     for name in ["a", "b", "c"] {
         fs::write(
@@ -161,7 +161,7 @@ fn scoped_lock_writes_nothing_when_a_path_is_unresolvable() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
     fs::write(dir.path().join("a.md"), "# a").unwrap();
-    lock(dir.path());
+    lock_all(dir.path());
     fs::write(dir.path().join("a.md"), "# a edited").unwrap();
 
     let output = drft_bin()
@@ -192,7 +192,7 @@ fn scoped_lock_drops_a_removed_node() {
     fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
     fs::write(dir.path().join("index.md"), "[doomed](doomed.md)").unwrap();
     fs::write(dir.path().join("doomed.md"), "# Doomed").unwrap();
-    lock(dir.path());
+    lock_all(dir.path());
 
     fs::remove_file(dir.path().join("doomed.md")).unwrap();
     assert!(check(dir.path()).contains("removed-node"));
@@ -226,7 +226,7 @@ fn scoped_lock_batches_a_live_update_with_a_drop() {
     .unwrap();
     fs::write(dir.path().join("guide.md"), "# Guide").unwrap();
     fs::write(dir.path().join("doomed.md"), "# Doomed").unwrap();
-    lock(dir.path());
+    lock_all(dir.path());
 
     // Delete one target and repair the citing document in the same breath.
     fs::remove_file(dir.path().join("doomed.md")).unwrap();
@@ -262,7 +262,7 @@ fn scoped_lock_of_a_directory_is_a_noop() {
     fs::create_dir(dir.path().join("sub")).unwrap();
     fs::write(dir.path().join("sub").join("a.md"), "# A").unwrap();
     fs::write(dir.path().join("index.md"), "[sub](sub)").unwrap();
-    lock(dir.path());
+    lock_all(dir.path());
 
     let output = drft_bin()
         .args(["-C", dir.path().to_str().unwrap(), "lock", "sub"])
@@ -284,7 +284,7 @@ fn scoped_lock_of_an_extensioned_path_does_not_prefer_a_dot_md_variant() {
     fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
     fs::write(dir.path().join("a.md"), "# A").unwrap();
     fs::write(dir.path().join("a.md.md"), "# A dot md").unwrap();
-    lock(dir.path());
+    lock_all(dir.path());
 
     fs::write(dir.path().join("a.md"), "# A edited").unwrap();
     fs::write(dir.path().join("a.md.md"), "# A dot md edited").unwrap();
@@ -303,5 +303,118 @@ fn scoped_lock_of_an_extensioned_path_does_not_prefer_a_dot_md_variant() {
     assert!(
         stdout.contains("stale-node]: a.md.md"),
         "a.md.md must stay stale — it was not the named path, got: {stdout}"
+    );
+}
+
+/// Zero paths is a usage error, not the whole graph. `drft lock $(cmd)` where
+/// `cmd` printed nothing hands drft exactly this argv, so inferring "every node"
+/// from it would turn a scoped invocation into a whole-graph review assertion
+/// with nothing in the output saying so.
+#[test]
+fn lock_with_no_paths_errors_and_writes_nothing() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("a.md"), "# a").unwrap();
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "lock"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2), "usage error exits 2");
+    assert!(
+        !dir.path().join("drft.lock").exists(),
+        "a refused lock must not write a lockfile"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("drft lock <path>...") && stderr.contains("--all"),
+        "the error should name both remedies, got: {stderr}"
+    );
+}
+
+/// The refusal leaves an existing lockfile untouched, so a mis-expanded command
+/// cannot re-snapshot the baseline on its way to failing.
+#[test]
+fn lock_with_no_paths_leaves_an_existing_lockfile_alone() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("a.md"), "# a").unwrap();
+    lock_all(dir.path());
+    let before = fs::read_to_string(dir.path().join("drft.lock")).unwrap();
+
+    fs::write(dir.path().join("a.md"), "# a edited").unwrap();
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "lock"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+
+    assert_eq!(
+        fs::read_to_string(dir.path().join("drft.lock")).unwrap(),
+        before,
+        "the lockfile should be byte-identical after a refused lock"
+    );
+    let stdout = check(dir.path());
+    assert!(
+        stdout.contains("stale-node]: a.md"),
+        "the staleness the refused lock would have cleared must still be reported, got: {stdout}"
+    );
+}
+
+/// `--all` names the whole-graph lock the bare form used to be: every node,
+/// including ones never passed on the command line.
+#[test]
+fn lock_all_locks_every_node() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    for name in ["a", "b", "c"] {
+        fs::write(dir.path().join(format!("{name}.md")), format!("# {name}")).unwrap();
+    }
+    lock_all(dir.path());
+
+    for name in ["a", "b", "c"] {
+        fs::write(
+            dir.path().join(format!("{name}.md")),
+            format!("# {name} edited"),
+        )
+        .unwrap();
+    }
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "lock", "--all"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let stdout = check(dir.path());
+    assert!(
+        !stdout.contains("stale"),
+        "--all should clear every node, got: {stdout}"
+    );
+}
+
+/// `--all` and paths state two different scopes. Honoring either one silently
+/// would be the same mis-scoped write the flag exists to prevent, so it errors.
+#[test]
+fn lock_all_with_paths_is_a_usage_error() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("a.md"), "# a").unwrap();
+    fs::write(dir.path().join("b.md"), "# b").unwrap();
+    lock_all(dir.path());
+    fs::write(dir.path().join("a.md"), "# a edited").unwrap();
+    fs::write(dir.path().join("b.md"), "# b edited").unwrap();
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "lock", "--all", "a.md"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stdout = check(dir.path());
+    assert!(
+        stdout.contains("stale-node]: a.md") && stdout.contains("stale-node]: b.md"),
+        "neither scope should have been written, got: {stdout}"
     );
 }

--- a/tests/lock.rs
+++ b/tests/lock.rs
@@ -418,3 +418,60 @@ fn lock_all_with_paths_is_a_usage_error() {
         "neither scope should have been written, got: {stdout}"
     );
 }
+
+/// The refusal reaches a JSON consumer as an envelope, not as bare stderr prose.
+/// The `--format` scan that produces it runs before clap parses, so it is easy to
+/// break without noticing from the text path alone.
+#[test]
+fn lock_with_no_paths_errors_as_a_json_envelope() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("a.md"), "# a").unwrap();
+
+    let output = drft_bin()
+        .args([
+            "-C",
+            dir.path().to_str().unwrap(),
+            "lock",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let parsed: serde_json::Value =
+        serde_json::from_str(stderr.trim()).unwrap_or_else(|e| panic!("not JSON ({e}): {stderr}"));
+    assert_eq!(parsed["exit_code"], 2);
+    assert!(
+        parsed["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("--all")),
+        "the envelope should name the remedy, got: {parsed}"
+    );
+}
+
+/// `--all` has no short form. Spelling out the call that asserts whole-graph
+/// review is the point, and a long flag is greppable — so a hook or CI check can
+/// forbid `--all` while leaving scoped locks alone.
+#[test]
+fn lock_all_has_no_short_form() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), common::DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("a.md"), "# a").unwrap();
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "lock", "-a"])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "-a must not be an alias for --all"
+    );
+    assert!(
+        !dir.path().join("drft.lock").exists(),
+        "-a must not have locked anything"
+    );
+}

--- a/tests/parsers.rs
+++ b/tests/parsers.rs
@@ -20,7 +20,7 @@ fn frontmatter_sources_create_edges() {
     fs::write(data.join("notes.md"), "# Notes").unwrap();
 
     drft_bin()
-        .args(["-C", dir.path().to_str().unwrap(), "lock"])
+        .args(["-C", dir.path().to_str().unwrap(), "lock", "--all"])
         .output()
         .unwrap();
 


### PR DESCRIPTION
Closes #104.

## Behavior

- **`drft lock` with no paths errors (exit 2).** The message names both remedies — `drft lock <path>...` and `--all`. Nothing is written; an existing `drft.lock` is byte-identical afterward, so a mis-expanded command can't re-snapshot the baseline on its way to failing.
- **`drft lock --all` locks every node** — the capability the bare form used to be, now with a name. No short form: typing out the call that asserts whole-graph review is the point, and a long flag is greppable, so a hook or CI check can forbid `--all` while allowing scoped locks.
- **`--all` with paths errors (exit 2).** Not in the issue; the two state different scopes, and silently honoring one is the mis-scoped write the flag exists to prevent.
- Both guards run before config load and graph build, so a usage error doesn't depend on a valid config.
- The JSON error envelope already covers this — `--format json` emits `{"error": …, "exit_code": 2}` via the existing pre-clap path.

## Scope

`nodes` and `edges` keep their zero-selector default, per the issue: there the cost is a large read, not a durable false claim, and the default is genuinely useful interactively. `docs/reading.md` now states that split where it draws the reader/writer line.

## Docs

- `README.md` — leads with the scoped form; the whole-graph paragraph explains why the flag is required.
- `RELEASING.md` — release lock scoped to `Cargo.toml CHANGELOG.md`, the only nodes a release touches.
- `CLAUDE.md` — the "never bare lock" rule becomes "never `--all`", noting the accident is now closed but the deliberate call still isn't allowed.

## Tests

`tests/lock.rs`: `lock_with_no_paths_errors_and_writes_nothing`, `lock_with_no_paths_leaves_an_existing_lockfile_alone` (asserts the staleness it would have cleared is still reported), `lock_all_locks_every_node`, `lock_all_with_paths_is_a_usage_error`. Whole-graph helpers in `tests/lock.rs`, `tests/parsers.rs`, `tests/impact.rs` now pass `--all`.

Full suite green, clippy clean, `drft check` exit 0.

CHANGELOG left for the release PR, per RELEASING.md.
