### PR TITLE
Release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to drft are documented here.
 
-## Unreleased
+## 0.16.0 (2026-08-20)
+
+Gives every command a run-level layer. A `hints` channel says what happened to _this invocation_ — a selector that matched nothing, a projection large enough to crowd the context it was meant to ground — where findings only ever describe the graph. And `drft lock` stops reading zero paths as every path, so a command substitution that matched nothing can't write a whole-graph review claim.
 
 ### Breaking changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "drft-cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drft-cli"
-version = "0.15.0"
+version = "0.16.0"
 categories = ["command-line-utilities", "development-tools"]
 edition = "2024"
 homepage = "https://github.com/johnmdonahue/drft-cli"

--- a/drft.lock
+++ b/drft.lock
@@ -22,7 +22,7 @@ hash = "b3:fdfab84f5fb35961e9a6a9b20c82f2c9f60ca9c9ab801eaa055e286d46ceb5bd"
 
 [[node]]
 path = "CHANGELOG.md"
-hash = "b3:51da3bd0ae5441cfeb1290ccb19626f9db74be53f1d99fb2ad39ed18d9ef6260"
+hash = "b3:4fa2ecf0dab4fab97431d9a7bac702a46ba9179eaa518b49ab25bf31302c4e55"
 
 [[node]]
 path = "CLAUDE.md"
@@ -90,7 +90,7 @@ target_hash = "b3:6ce4d5c42026071af2b68201e9debff0112ad9d9d8d8fc75d16d562d5fc1a7
 
 [[node]]
 path = "Cargo.toml"
-hash = "b3:dad801e584c3606d1102e7f5d21c40426743d14a037d743afedb2f91d53a18a2"
+hash = "b3:68026886493ded605187c01e6f0089e5a415bceda8c114125e9722d3f94879b5"
 
 [[node]]
 path = "LICENSE"


### PR DESCRIPTION
Release v0.16.0 — gives every command a run-level layer.

Bundles the changes merged since v0.15.0:

- **`hints` advisory channel** (#106) — every command can say something about the
  run rather than about an item in the result: a selector that matched nothing, a
  projection large enough to crowd the context it was meant to ground, a
  misspelled rule name. Each hint is `{name, locus?, message, next?}` — a JSON
  document key where a command prints a document, a stderr envelope where it
  doesn't. Hints never change an exit code and never replace a guard.
- **`drft lock --all` required for a whole-graph lock** (#105) — **Breaking:**
  bare `drft lock` is now a usage error (exit 2) instead of snapshotting every
  node. Zero paths is what a shell hands over when a command substitution matches
  nothing, which silently turned a scoped lock into a whole-graph review claim.
  `drft nodes` and `drft edges` keep their zero-selector default — for a reader
  the cost is a large read, not a durable claim.
- **`Finding.hint` → `Finding.cause`** — **Breaking:** `drft check --format json`
  emits `cause`; text renders `cause:`. The field names the likely reason a
  finding reads as the wrong problem, which is what the rules reference already
  called it, and it frees `hint` for the run-level channel above. No alias.

See CHANGELOG.md for the full v0.16.0 section. Version bumped in Cargo.toml; both
tracked files re-locked so `drft check` passes on the release commit.