### PR TITLE
fix: give each link occurrence its own edge metadata

### DIFF
--- a/docs/parsers/frontmatter.md
+++ b/docs/parsers/frontmatter.md
@@ -12,7 +12,7 @@ The frontmatter parser extracts YAML frontmatter from files. It serves two purpo
 
 ## Link types
 
-The parser extracts one type of link. Each becomes an edge with parser provenance `frontmatter` in the graph. Every edge records the 1-based source line(s) where the value appears as `lines` in its `frontmatter` metadata, exposed in `drft graph` and used by `drft impact` to point a review at the exact reference.
+The parser extracts one type of link. Each becomes an edge with parser provenance `frontmatter` in the graph. Every edge carries an `occurrences` array in its `frontmatter` metadata, one entry per value, each recording the 1-based source `line` where that value appears. `drft graph` exposes the array; `drft impact` reads the lines to point a review at the exact reference.
 
 ### link
 

--- a/docs/parsers/markdown.md
+++ b/docs/parsers/markdown.md
@@ -13,10 +13,12 @@ The markdown parser is drft's built-in parser for standard markdown link syntax.
 ## Link types
 
 Each link type becomes an edge with parser provenance `markdown` in the graph.
-Every edge records the 1-based source line(s) where the link appears as `lines`
-in its `markdown` metadata, exposed in `drft graph` and used by `drft impact` to
-point a review at the exact reference; a target linked from more than one line
-carries each.
+Every edge carries an `occurrences` array in its `markdown` metadata, one entry
+per link the author wrote. Each entry records that link's own 1-based source
+`line`, its fragment-qualified `link`, and its literal `raw` spelling, so a
+target cited from several places keeps each line paired with what that line
+actually said. `drft graph` exposes the array; `drft impact` reads the lines to
+point a review at the exact reference.
 
 ### inline
 
@@ -27,7 +29,7 @@ Standard markdown links where the URL is inline with the text.
 [with fragment](setup.md#installation)
 ```
 
-Fragments (`#heading`) are stripped -- `setup.md#installation` produces an edge to `setup.md`.
+Fragments (`#heading`) are stripped from the target -- `setup.md#installation` produces an edge to `setup.md` -- and kept on the occurrence as `link`.
 
 ### reference
 
@@ -83,4 +85,4 @@ This matters most where it reads like coverage. A layout table citing `` `edge/`
 
 ## External URLs
 
-External links (`http://`, `https://`, `mailto:`, and other URI schemes) are emitted as raw edge targets. A URI target has no defining node, so the `unresolved-edge` rule treats it as an intentional external reference and does not flag it. Anchor-only links (`#heading`) are dropped, and fragments are stripped from targets (`file.md#section` → `file.md`) — both handled when the edge is built, not by the parser.
+External links (`http://`, `https://`, `mailto:`, and other URI schemes) are emitted as raw edge targets. A URI target has no defining node, so the `unresolved-edge` rule treats it as an intentional external reference and does not flag it. Anchor-only links (`#heading`) are dropped, and fragments are stripped from targets (`file.md#section` → `file.md`) and kept on the occurrence — all handled when the edge is built, not by the parser.

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -65,9 +65,14 @@ Two repeatable flags narrow what comes back, shared by `nodes` and `edges`:
   appearing empty. An unknown namespace is a typo — it errors, listing the
   declared graphs.
 - `--field <name>` restricts the returned metadata to named keys and lists only
-  the nodes that declare them. Frontmatter is open-ended and drft does not own its
-  schema, so a wholly unmatched field is a legitimate empty result, not an error —
-  it answers which files declare that field.
+  the entries that declare them. A field names what it is wherever it is
+  declared: the filter also descends into a list of objects, narrowing each entry
+  to the named keys, so `--field role` reaches an authored `authors:` list and
+  `--field line` reaches an edge's link occurrences without naming the array they
+  live in. An entry that keeps nothing drops out, so a node declaring the field
+  only inside a list still survives the filter. Frontmatter is open-ended and drft
+  does not own its schema, so a wholly unmatched field is a legitimate empty
+  result, not an error — it answers which files declare that field.
 
 ```
 $ drft nodes docs/guide.md --namespace frontmatter --field purpose
@@ -108,9 +113,13 @@ docs/guide.md → docs/config.md
 ```
 
 Each entry in `occurrences` is one link the author wrote, so a target cited from
-several places keeps each line paired with the spelling on that line. Narrow to
-one of those facts with `--field line`, which reaches into the entries without
-naming the array.
+several places keeps each line paired with the spelling on that line. `--field
+line` narrows to one of those facts.
+
+Any list of objects renders this way, in `nodes` and `graph` as well as `edges`:
+one `-`-marked sub-block per entry, so an authored `authors:` list reads as
+entries rather than as one line of JSON. An entry with no fields renders as
+`- {}`.
 
 `drft graph --format text` renders the whole graph as a `# nodes` section
 followed by a `# edges` section — the node and edge blocks above, under headers.

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -99,9 +99,18 @@ An edge block is `source → target`, then the same indented metadata:
 $ drft edges docs/guide.md
 docs/guide.md → docs/config.md
   @markdown
-    lines: [12]
-    raw: config.md
+    occurrences
+      - line: 12
+        raw: config.md
+      - line: 40
+        link: docs/config.md#ignore
+        raw: config.md
 ```
+
+Each entry in `occurrences` is one link the author wrote, so a target cited from
+several places keeps each line paired with the spelling on that line. Narrow to
+one of those facts with `--field line`, which reaches into the entries without
+naming the array.
 
 `drft graph --format text` renders the whole graph as a `# nodes` section
 followed by a `# edges` section — the node and edge blocks above, under headers.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -52,9 +52,11 @@ tree and is not one. Link the file that carries what the prose claims —
 graph root but not from the declaring file. Links resolve relative to the file
 that declares them, so a root-relative path fails against a target nobody wrote
 and reads as a typo; the `cause` names the base and suggests the rewrite. It is
-withheld for paths written `./`, `../`, or `/`, which are relative by intent. It
-renders as an indented line under the finding in text output and as a `cause`
-field in JSON.
+withheld for paths written `./`, `../`, or `/`, which are relative by intent. The
+check runs per link occurrence, so a target cited from several places carries the
+cause when any one of those links is bare — the finding names every line, and the
+cause describes the bare one. It renders as an indented line under the finding in
+text output and as a `cause` field in JSON.
 
 A finding is about an item in the graph. A statement about the _run_ that
 produced it — an unknown rule name, a selector that matched nothing — is a

--- a/drft.lock
+++ b/drft.lock
@@ -34,7 +34,7 @@ target_hash = "b3:487a739269373875e508ecc49686d1ae580cdc8b770da7ac70f47b48f6ecb9
 
 [[node.edge]]
 target = "src/compose.rs"
-target_hash = "b3:a17c2ccd39a5ad225be9a761fee623523702f0d3ca50e951d3e27fa30d68ae07"
+target_hash = "b3:b1a7dc9621d4ff6bceb9d4e1b527a7c4abefe22cd7c996397b8f0ad3e6341391"
 
 [[node]]
 path = "CONTRIBUTING.md"
@@ -54,7 +54,7 @@ target_hash = "b3:60c89c7fbb02f44baa56064d7fdfe555badfeeff810ba072f5be97249990f9
 
 [[node.edge]]
 target = "src/compose.rs"
-target_hash = "b3:a17c2ccd39a5ad225be9a761fee623523702f0d3ca50e951d3e27fa30d68ae07"
+target_hash = "b3:b1a7dc9621d4ff6bceb9d4e1b527a7c4abefe22cd7c996397b8f0ad3e6341391"
 
 [[node.edge]]
 target = "src/config.rs"
@@ -114,7 +114,7 @@ target_hash = "b3:ba380aa56e9ff7a5cb6186ac81b46b93c01ca693f72e95e8156f79bc932b4f
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:ffca817d1537b6c36f61d7b3143aae02497fab1545bb91816b9e64d782b9d063"
+target_hash = "b3:bd326b3f2f83e645a0970132aa928069e4188fa820524f8d4bc507dbb71892de"
 
 [[node.edge]]
 target = "https://github.com/johnmdonahue/drft-cli/releases"
@@ -141,7 +141,7 @@ target_hash = "b3:48af6aaf933bc63dc2f2c1ef5fb4ac77dbf9dddb695779a751d8a77f10e203
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:ffca817d1537b6c36f61d7b3143aae02497fab1545bb91816b9e64d782b9d063"
+target_hash = "b3:bd326b3f2f83e645a0970132aa928069e4188fa820524f8d4bc507dbb71892de"
 
 [[node.edge]]
 target = "docs/rules/README.md"
@@ -161,7 +161,7 @@ target_hash = "b3:8afef0115e1a9bcd5d6605be78439fa1d80a72b5bbdd833199a0aa76328a5b
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:ffca817d1537b6c36f61d7b3143aae02497fab1545bb91816b9e64d782b9d063"
+target_hash = "b3:bd326b3f2f83e645a0970132aa928069e4188fa820524f8d4bc507dbb71892de"
 
 [[node.edge]]
 target = "docs/rules/README.md"
@@ -221,7 +221,7 @@ target_hash = "b3:952fafe8eb3a776168da8ec935438fbd39de4599375f1c0e82334d3dd8d361
 
 [[node]]
 path = "docs/reading.md"
-hash = "b3:ffca817d1537b6c36f61d7b3143aae02497fab1545bb91816b9e64d782b9d063"
+hash = "b3:bd326b3f2f83e645a0970132aa928069e4188fa820524f8d4bc507dbb71892de"
 
 [[node.edge]]
 target = "src/cli.rs"
@@ -233,7 +233,7 @@ target_hash = "b3:c104de3d28c807222a580baf8bdca01c09bb8512291b3b7c6e2fd6a55b8b09
 
 [[node.edge]]
 target = "src/edges.rs"
-target_hash = "b3:be1dec67033a9c7cc489da7609beafedb6ce6ff043178ae908e6ceb8e9ac599b"
+target_hash = "b3:0b283749b6c5aa951115cf6e5425511aa9b9c5c913071025575a5c453854a2f4"
 
 [[node.edge]]
 target = "src/impact.rs"
@@ -249,7 +249,7 @@ target_hash = "b3:bd63f170e88bb37482e7384aa3becb20cea1d7dfcf2be4b4ab79a8e6363299
 
 [[node.edge]]
 target = "src/projection.rs"
-target_hash = "b3:9be5c2676ffab19e0333023c9cd931ca6d324903c3b612b342bb1ca53fcec758"
+target_hash = "b3:df91b20142ada7ed0cc6f35da8941cf191a0554aa3eddab0a0d1a16b1572a783"
 
 [[node]]
 path = "docs/rules/README.md"
@@ -257,7 +257,7 @@ hash = "b3:ce65c96837b8767ec1b3996394084f9d9d612a874decccf5aea552e0c3ec9ed1"
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:ffca817d1537b6c36f61d7b3143aae02497fab1545bb91816b9e64d782b9d063"
+target_hash = "b3:bd326b3f2f83e645a0970132aa928069e4188fa820524f8d4bc507dbb71892de"
 
 [[node.edge]]
 target = "src/config.rs"
@@ -269,7 +269,7 @@ target_hash = "b3:f592a8dd3264b1975fbfc2da5958b0a5999efa513b2ca51b2a9df5fa602e38
 
 [[node.edge]]
 target = "src/rules/structural.rs"
-target_hash = "b3:49abe68b2d847cfad0710db875cb14e5dc21c6bf0d8cee248aec6bfdf4203b5a"
+target_hash = "b3:b4f6ef39b51bd3d011595e4515c0d183b56fa3eff1f923a4fe6af1b42c71870e"
 
 [[node]]
 path = "dprint.json"
@@ -320,7 +320,7 @@ hash = "b3:5f396f41a7ac62dc62594654290ade1d0ea53491a526ffcc8b5b856e5158f724"
 
 [[node]]
 path = "src/compose.rs"
-hash = "b3:a17c2ccd39a5ad225be9a761fee623523702f0d3ca50e951d3e27fa30d68ae07"
+hash = "b3:b1a7dc9621d4ff6bceb9d4e1b527a7c4abefe22cd7c996397b8f0ad3e6341391"
 
 [[node]]
 path = "src/config.rs"
@@ -332,7 +332,7 @@ hash = "b3:686eaca6b31c4c7ef9e14249cb952ee64031d6a9bfe2eff49cfe91a77002ce98"
 
 [[node]]
 path = "src/edges.rs"
-hash = "b3:be1dec67033a9c7cc489da7609beafedb6ce6ff043178ae908e6ceb8e9ac599b"
+hash = "b3:0b283749b6c5aa951115cf6e5425511aa9b9c5c913071025575a5c453854a2f4"
 
 [[node]]
 path = "src/graphs/mod.rs"
@@ -380,7 +380,7 @@ hash = "b3:d17d93b9838e4703720bafd4150e1dee5653416cb080218716ae21a5c615c3c7"
 
 [[node]]
 path = "src/projection.rs"
-hash = "b3:9be5c2676ffab19e0333023c9cd931ca6d324903c3b612b342bb1ca53fcec758"
+hash = "b3:df91b20142ada7ed0cc6f35da8941cf191a0554aa3eddab0a0d1a16b1572a783"
 
 [[node]]
 path = "src/rules/check.rs"
@@ -396,7 +396,7 @@ hash = "b3:f592a8dd3264b1975fbfc2da5958b0a5999efa513b2ca51b2a9df5fa602e388d"
 
 [[node]]
 path = "src/rules/structural.rs"
-hash = "b3:49abe68b2d847cfad0710db875cb14e5dc21c6bf0d8cee248aec6bfdf4203b5a"
+hash = "b3:b4f6ef39b51bd3d011595e4515c0d183b56fa3eff1f923a4fe6af1b42c71870e"
 
 [[node]]
 path = "src/sources/fs.rs"

--- a/drft.lock
+++ b/drft.lock
@@ -46,11 +46,11 @@ target_hash = "b3:48af6aaf933bc63dc2f2c1ef5fb4ac77dbf9dddb695779a751d8a77f10e203
 
 [[node.edge]]
 target = "docs/rules/README.md"
-target_hash = "b3:ce65c96837b8767ec1b3996394084f9d9d612a874decccf5aea552e0c3ec9ed1"
+target_hash = "b3:bbc772f4ff7c6af7b1e14301af78d01b6d872842384228706dfb99914755f38b"
 
 [[node.edge]]
 target = "src/builders/mod.rs"
-target_hash = "b3:60c89c7fbb02f44baa56064d7fdfe555badfeeff810ba072f5be97249990f95b"
+target_hash = "b3:23ba2ad44e3adf59cc9f67cff5450a6d01644469852caef9cadd52da70510392"
 
 [[node.edge]]
 target = "src/compose.rs"
@@ -145,7 +145,7 @@ target_hash = "b3:bd326b3f2f83e645a0970132aa928069e4188fa820524f8d4bc507dbb71892
 
 [[node.edge]]
 target = "docs/rules/README.md"
-target_hash = "b3:ce65c96837b8767ec1b3996394084f9d9d612a874decccf5aea552e0c3ec9ed1"
+target_hash = "b3:bbc772f4ff7c6af7b1e14301af78d01b6d872842384228706dfb99914755f38b"
 
 [[node]]
 path = "docs/config.md"
@@ -165,7 +165,7 @@ target_hash = "b3:bd326b3f2f83e645a0970132aa928069e4188fa820524f8d4bc507dbb71892
 
 [[node.edge]]
 target = "docs/rules/README.md"
-target_hash = "b3:ce65c96837b8767ec1b3996394084f9d9d612a874decccf5aea552e0c3ec9ed1"
+target_hash = "b3:bbc772f4ff7c6af7b1e14301af78d01b6d872842384228706dfb99914755f38b"
 
 [[node.edge]]
 target = "src/cli.rs"
@@ -249,11 +249,11 @@ target_hash = "b3:bd63f170e88bb37482e7384aa3becb20cea1d7dfcf2be4b4ab79a8e6363299
 
 [[node.edge]]
 target = "src/projection.rs"
-target_hash = "b3:df91b20142ada7ed0cc6f35da8941cf191a0554aa3eddab0a0d1a16b1572a783"
+target_hash = "b3:977a3c47ee9ee201e25f4f1d091939ea1212c4947f38a6732c3a7bde1da99599"
 
 [[node]]
 path = "docs/rules/README.md"
-hash = "b3:ce65c96837b8767ec1b3996394084f9d9d612a874decccf5aea552e0c3ec9ed1"
+hash = "b3:bbc772f4ff7c6af7b1e14301af78d01b6d872842384228706dfb99914755f38b"
 
 [[node.edge]]
 target = "docs/reading.md"
@@ -269,7 +269,7 @@ target_hash = "b3:f592a8dd3264b1975fbfc2da5958b0a5999efa513b2ca51b2a9df5fa602e38
 
 [[node.edge]]
 target = "src/rules/structural.rs"
-target_hash = "b3:b4f6ef39b51bd3d011595e4515c0d183b56fa3eff1f923a4fe6af1b42c71870e"
+target_hash = "b3:0aeb7415b4b0b62567d8840b1d29aadaef76a839bad5eae6d38f5fbc8273cdba"
 
 [[node]]
 path = "dprint.json"
@@ -312,7 +312,7 @@ hash = "b3:901fc388ed6053b7f980928172dd0fcced4ce0639ec05c1129c87da656fa5e78"
 
 [[node]]
 path = "src/builders/mod.rs"
-hash = "b3:60c89c7fbb02f44baa56064d7fdfe555badfeeff810ba072f5be97249990f95b"
+hash = "b3:23ba2ad44e3adf59cc9f67cff5450a6d01644469852caef9cadd52da70510392"
 
 [[node]]
 path = "src/cli.rs"
@@ -380,7 +380,7 @@ hash = "b3:d17d93b9838e4703720bafd4150e1dee5653416cb080218716ae21a5c615c3c7"
 
 [[node]]
 path = "src/projection.rs"
-hash = "b3:df91b20142ada7ed0cc6f35da8941cf191a0554aa3eddab0a0d1a16b1572a783"
+hash = "b3:977a3c47ee9ee201e25f4f1d091939ea1212c4947f38a6732c3a7bde1da99599"
 
 [[node]]
 path = "src/rules/check.rs"
@@ -396,7 +396,7 @@ hash = "b3:f592a8dd3264b1975fbfc2da5958b0a5999efa513b2ca51b2a9df5fa602e388d"
 
 [[node]]
 path = "src/rules/structural.rs"
-hash = "b3:b4f6ef39b51bd3d011595e4515c0d183b56fa3eff1f923a4fe6af1b42c71870e"
+hash = "b3:0aeb7415b4b0b62567d8840b1d29aadaef76a839bad5eae6d38f5fbc8273cdba"
 
 [[node]]
 path = "src/sources/fs.rs"

--- a/drft.lock
+++ b/drft.lock
@@ -50,7 +50,7 @@ target_hash = "b3:ce65c96837b8767ec1b3996394084f9d9d612a874decccf5aea552e0c3ec9e
 
 [[node.edge]]
 target = "src/builders/mod.rs"
-target_hash = "b3:f56fdcddee36a2cc7c9c55b619b80c0571ca85e89334e06741b157d4315d84d4"
+target_hash = "b3:60c89c7fbb02f44baa56064d7fdfe555badfeeff810ba072f5be97249990f95b"
 
 [[node.edge]]
 target = "src/compose.rs"
@@ -70,7 +70,7 @@ target_hash = "b3:59d5b59a2415a93ab85f45c4dbd746c1c0050f2edbfe2a326b9dbc613b1778
 
 [[node.edge]]
 target = "src/model.rs"
-target_hash = "b3:8c1fefc41499866612547a86607ed805cb3ad04adceaafbafaba59aa495a1c4e"
+target_hash = "b3:222c335163926dfcf8b652e30588b06b40d86717627388bbcb8900595800468f"
 
 [[node.edge]]
 target = "src/parsers/mod.rs"
@@ -114,7 +114,7 @@ target_hash = "b3:ba380aa56e9ff7a5cb6186ac81b46b93c01ca693f72e95e8156f79bc932b4f
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:806566726fc8d84f4d40e0ee50e4176e43db0941e7bf60b06670dc599cd01d25"
+target_hash = "b3:ffca817d1537b6c36f61d7b3143aae02497fab1545bb91816b9e64d782b9d063"
 
 [[node.edge]]
 target = "https://github.com/johnmdonahue/drft-cli/releases"
@@ -141,7 +141,7 @@ target_hash = "b3:48af6aaf933bc63dc2f2c1ef5fb4ac77dbf9dddb695779a751d8a77f10e203
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:806566726fc8d84f4d40e0ee50e4176e43db0941e7bf60b06670dc599cd01d25"
+target_hash = "b3:ffca817d1537b6c36f61d7b3143aae02497fab1545bb91816b9e64d782b9d063"
 
 [[node.edge]]
 target = "docs/rules/README.md"
@@ -157,11 +157,11 @@ target_hash = "b3:48af6aaf933bc63dc2f2c1ef5fb4ac77dbf9dddb695779a751d8a77f10e203
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
-target_hash = "b3:d413c0c11acbdc3bf668f1b5f98997ee44e635e35b45581a8de0877aec3c1ce5"
+target_hash = "b3:8afef0115e1a9bcd5d6605be78439fa1d80a72b5bbdd833199a0aa76328a5b1c"
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:806566726fc8d84f4d40e0ee50e4176e43db0941e7bf60b06670dc599cd01d25"
+target_hash = "b3:ffca817d1537b6c36f61d7b3143aae02497fab1545bb91816b9e64d782b9d063"
 
 [[node.edge]]
 target = "docs/rules/README.md"
@@ -181,11 +181,11 @@ hash = "b3:48af6aaf933bc63dc2f2c1ef5fb4ac77dbf9dddb695779a751d8a77f10e203ab"
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
-target_hash = "b3:d413c0c11acbdc3bf668f1b5f98997ee44e635e35b45581a8de0877aec3c1ce5"
+target_hash = "b3:8afef0115e1a9bcd5d6605be78439fa1d80a72b5bbdd833199a0aa76328a5b1c"
 
 [[node.edge]]
 target = "docs/parsers/markdown.md"
-target_hash = "b3:a44c5da7480f407327ee9ea2684212f90c4c49743296a98352764a90a2d58885"
+target_hash = "b3:cdcd2634e3a22bafd63cb6535565d453e7b5ee85728747b11f2f71bf718373c8"
 
 [[node.edge]]
 target = "src/parsers/mod.rs"
@@ -193,7 +193,7 @@ target_hash = "b3:d17d93b9838e4703720bafd4150e1dee5653416cb080218716ae21a5c615c3
 
 [[node]]
 path = "docs/parsers/frontmatter.md"
-hash = "b3:d413c0c11acbdc3bf668f1b5f98997ee44e635e35b45581a8de0877aec3c1ce5"
+hash = "b3:8afef0115e1a9bcd5d6605be78439fa1d80a72b5bbdd833199a0aa76328a5b1c"
 
 [[node.edge]]
 target = "docs/config.md"
@@ -205,7 +205,7 @@ target_hash = "b3:3141acca048acfba229b56cd48b537988a2e5d8091fd0eb01e7e47c9926c34
 
 [[node]]
 path = "docs/parsers/markdown.md"
-hash = "b3:a44c5da7480f407327ee9ea2684212f90c4c49743296a98352764a90a2d58885"
+hash = "b3:cdcd2634e3a22bafd63cb6535565d453e7b5ee85728747b11f2f71bf718373c8"
 
 [[node.edge]]
 target = "docs/config.md"
@@ -213,7 +213,7 @@ target_hash = "b3:ba380aa56e9ff7a5cb6186ac81b46b93c01ca693f72e95e8156f79bc932b4f
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
-target_hash = "b3:d413c0c11acbdc3bf668f1b5f98997ee44e635e35b45581a8de0877aec3c1ce5"
+target_hash = "b3:8afef0115e1a9bcd5d6605be78439fa1d80a72b5bbdd833199a0aa76328a5b1c"
 
 [[node.edge]]
 target = "src/parsers/markdown.rs"
@@ -221,7 +221,7 @@ target_hash = "b3:952fafe8eb3a776168da8ec935438fbd39de4599375f1c0e82334d3dd8d361
 
 [[node]]
 path = "docs/reading.md"
-hash = "b3:806566726fc8d84f4d40e0ee50e4176e43db0941e7bf60b06670dc599cd01d25"
+hash = "b3:ffca817d1537b6c36f61d7b3143aae02497fab1545bb91816b9e64d782b9d063"
 
 [[node.edge]]
 target = "src/cli.rs"
@@ -237,7 +237,7 @@ target_hash = "b3:be1dec67033a9c7cc489da7609beafedb6ce6ff043178ae908e6ceb8e9ac59
 
 [[node.edge]]
 target = "src/impact.rs"
-target_hash = "b3:297723111a36e1bf06d13b460e12175d1093505ec7df97149b52e6aa67921a55"
+target_hash = "b3:964899e67f4d2441011e8fa0258e7ab3c3b5c81124999d1882dd0ba79d353526"
 
 [[node.edge]]
 target = "src/main.rs"
@@ -249,7 +249,7 @@ target_hash = "b3:bd63f170e88bb37482e7384aa3becb20cea1d7dfcf2be4b4ab79a8e6363299
 
 [[node.edge]]
 target = "src/projection.rs"
-target_hash = "b3:c45f328c6d4cc3cb58e4d764ac360bde82d4ee17e411dbcb786fa7019a76c63b"
+target_hash = "b3:9be5c2676ffab19e0333023c9cd931ca6d324903c3b612b342bb1ca53fcec758"
 
 [[node]]
 path = "docs/rules/README.md"
@@ -257,7 +257,7 @@ hash = "b3:ce65c96837b8767ec1b3996394084f9d9d612a874decccf5aea552e0c3ec9ed1"
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:806566726fc8d84f4d40e0ee50e4176e43db0941e7bf60b06670dc599cd01d25"
+target_hash = "b3:ffca817d1537b6c36f61d7b3143aae02497fab1545bb91816b9e64d782b9d063"
 
 [[node.edge]]
 target = "src/config.rs"
@@ -269,7 +269,7 @@ target_hash = "b3:f592a8dd3264b1975fbfc2da5958b0a5999efa513b2ca51b2a9df5fa602e38
 
 [[node.edge]]
 target = "src/rules/structural.rs"
-target_hash = "b3:7f0d993aee0f2f39f64d6c019793cee7969b6d5f97acb4bf24d89cfa2923606e"
+target_hash = "b3:49abe68b2d847cfad0710db875cb14e5dc21c6bf0d8cee248aec6bfdf4203b5a"
 
 [[node]]
 path = "dprint.json"
@@ -312,7 +312,7 @@ hash = "b3:901fc388ed6053b7f980928172dd0fcced4ce0639ec05c1129c87da656fa5e78"
 
 [[node]]
 path = "src/builders/mod.rs"
-hash = "b3:f56fdcddee36a2cc7c9c55b619b80c0571ca85e89334e06741b157d4315d84d4"
+hash = "b3:60c89c7fbb02f44baa56064d7fdfe555badfeeff810ba072f5be97249990f95b"
 
 [[node]]
 path = "src/cli.rs"
@@ -344,7 +344,7 @@ hash = "b3:a62f9c29456c50ecc98eb6cacc751785d50bc27373dffc7755b1601323e79ce7"
 
 [[node]]
 path = "src/impact.rs"
-hash = "b3:297723111a36e1bf06d13b460e12175d1093505ec7df97149b52e6aa67921a55"
+hash = "b3:964899e67f4d2441011e8fa0258e7ab3c3b5c81124999d1882dd0ba79d353526"
 
 [[node]]
 path = "src/lib.rs"
@@ -360,7 +360,7 @@ hash = "b3:c71943a64bb40d63c27270ee960a4a58cb3d39e03e60886cd49beee0f652fb38"
 
 [[node]]
 path = "src/model.rs"
-hash = "b3:8c1fefc41499866612547a86607ed805cb3ad04adceaafbafaba59aa495a1c4e"
+hash = "b3:222c335163926dfcf8b652e30588b06b40d86717627388bbcb8900595800468f"
 
 [[node]]
 path = "src/nodes.rs"
@@ -380,7 +380,7 @@ hash = "b3:d17d93b9838e4703720bafd4150e1dee5653416cb080218716ae21a5c615c3c7"
 
 [[node]]
 path = "src/projection.rs"
-hash = "b3:c45f328c6d4cc3cb58e4d764ac360bde82d4ee17e411dbcb786fa7019a76c63b"
+hash = "b3:9be5c2676ffab19e0333023c9cd931ca6d324903c3b612b342bb1ca53fcec758"
 
 [[node]]
 path = "src/rules/check.rs"
@@ -396,7 +396,7 @@ hash = "b3:f592a8dd3264b1975fbfc2da5958b0a5999efa513b2ca51b2a9df5fa602e388d"
 
 [[node]]
 path = "src/rules/structural.rs"
-hash = "b3:7f0d993aee0f2f39f64d6c019793cee7969b6d5f97acb4bf24d89cfa2923606e"
+hash = "b3:49abe68b2d847cfad0710db875cb14e5dc21c6bf0d8cee248aec6bfdf4203b5a"
 
 [[node]]
 path = "src/sources/fs.rs"
@@ -420,7 +420,7 @@ hash = "b3:9ac502fbe6e46aa6ad8ec985b23592a63313730cb1af9459e43235663d4d7847"
 
 [[node]]
 path = "tests/edges.rs"
-hash = "b3:7d95c0b90b249a66ced8e39cfc3e3b13023d582019c405457e03eaa89170ffaf"
+hash = "b3:8e7a74efdcda6af80492e61235019353248b34aecb485f0d1cd7ae27ff489fd1"
 
 [[node]]
 path = "tests/graph.rs"

--- a/src/builders/mod.rs
+++ b/src/builders/mod.rs
@@ -6,7 +6,7 @@ pub mod frontmatter;
 pub mod fs;
 pub mod markdown;
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use serde_json::Value;
 
@@ -14,15 +14,21 @@ use crate::model::{Edge, Metadata};
 use crate::parsers::Link;
 use crate::util::{is_uri, resolve_link};
 
-/// Turn a raw link string discovered by a text builder into an edge from
-/// `source` to its resolved target.
+/// Resolve one discovered link into its edge target plus the **occurrence**
+/// metadata recording how the author wrote it: `line`, the fragment-qualified
+/// `link`, and the literal `raw` text.
 ///
 /// Returns `None` for links with no file target (empty or anchor-only). A
 /// fragment (`#heading`) is stripped from the target — which is the node
-/// identity — and preserved as the edge's `link` metadata. Non-URI targets are
-/// resolved relative to `source`; URIs pass through unchanged.
-pub fn link_edge(source: &str, raw: &str) -> Option<Edge> {
-    let trimmed = raw.trim();
+/// identity — and preserved on the occurrence. Non-URI targets are resolved
+/// relative to `source`; URIs pass through unchanged.
+///
+/// `raw` is kept only when resolution moved the path. The resolved target alone
+/// cannot distinguish `foo.md` from `./foo.md` — they resolve identically — and
+/// that distinction is what tells a wrong base from a deliberate doc-relative
+/// link. Graph-only, like `line`; never locked.
+fn occurrence(source: &str, link: &Link) -> Option<(String, Metadata)> {
+    let trimmed = link.target.trim();
     if trimmed.is_empty() || trimmed.starts_with('#') {
         return None;
     }
@@ -41,50 +47,64 @@ pub fn link_edge(source: &str, raw: &str) -> Option<Edge> {
         resolve_link(source, base)
     };
 
-    let mut metadata = Metadata::new();
-    if let Some(frag) = fragment {
-        metadata.insert("link".into(), Value::String(format!("{target}{frag}")));
+    let mut occurrence = Metadata::new();
+    if let Some(line) = link.line {
+        occurrence.insert("line".into(), Value::from(line as u64));
     }
-    // The literal text the author wrote, kept only when resolution moved it. The
-    // resolved target alone cannot distinguish `foo.md` from `./foo.md` — they
-    // resolve identically — and that distinction is what tells a wrong base from
-    // a deliberate doc-relative link. Graph-only, like `lines`; never locked.
+    if let Some(frag) = fragment {
+        occurrence.insert("link".into(), Value::String(format!("{target}{frag}")));
+    }
     if base != target {
-        metadata.insert("raw".into(), Value::String(base.to_string()));
+        occurrence.insert("raw".into(), Value::String(base.to_string()));
     }
 
-    Some(Edge::with_metadata(source, target, metadata))
+    Some((target, occurrence))
 }
 
 /// Resolve a parser's discovered links into edges, one per `(source, target)`.
 ///
 /// Multiple links to the same target collapse to a single edge: `compose` dedups
 /// by `(source, target)` and overwrites per-namespace metadata, so aggregation
-/// must happen here. Source lines are unioned into a sorted, deduped `lines`
-/// array (omitted entirely when no link carried a line); the first occurrence's
-/// `link` (fragment) metadata wins.
+/// must happen here. Each link contributes its own entry to the edge's
+/// `occurrences` array, sorted by line.
+///
+/// Per-occurrence is the point. A source citing two anchors of one target — six
+/// lines naming `#security-console` and one naming `#ngwaf-edge` — is one edge
+/// with two spellings, and a scalar `link` would attribute the first to all
+/// seven. Identical occurrences dedup; distinct ones both survive.
 pub fn link_edges(source: &str, links: &[Link]) -> Vec<Edge> {
-    let mut by_target: BTreeMap<String, (Edge, BTreeSet<usize>)> = BTreeMap::new();
+    let mut by_target: BTreeMap<String, Vec<Metadata>> = BTreeMap::new();
     for link in links {
-        let Some(edge) = link_edge(source, &link.target) else {
+        let Some((target, occurrence)) = occurrence(source, link) else {
             continue;
         };
-        let entry = by_target
-            .entry(edge.target.clone())
-            .or_insert_with(|| (edge, BTreeSet::new()));
-        if let Some(line) = link.line {
-            entry.1.insert(line);
+        // An occurrence with nothing known about it carries no information, so
+        // it stays out and the edge keeps today's no-metadata shape.
+        if occurrence.is_empty() {
+            by_target.entry(target).or_default();
+            continue;
+        }
+        let entry = by_target.entry(target).or_default();
+        if !entry.contains(&occurrence) {
+            entry.push(occurrence);
         }
     }
 
     by_target
-        .into_values()
-        .map(|(mut edge, lines)| {
-            if !lines.is_empty() {
-                let arr: Vec<Value> = lines.into_iter().map(|l| Value::from(l as u64)).collect();
-                edge.metadata.insert("lines".into(), Value::Array(arr));
+        .into_iter()
+        .map(|(target, mut occurrences)| {
+            let mut metadata = Metadata::new();
+            if !occurrences.is_empty() {
+                // Stable sort on the line, with line-less occurrences last, so
+                // the array reads in source order.
+                occurrences
+                    .sort_by_key(|o| o.get("line").and_then(Value::as_u64).unwrap_or(u64::MAX));
+                metadata.insert(
+                    "occurrences".into(),
+                    Value::Array(occurrences.into_iter().map(Value::Object).collect()),
+                );
             }
-            edge
+            Edge::with_metadata(source, target, metadata)
         })
         .collect()
 }
@@ -92,43 +112,7 @@ pub fn link_edges(source: &str, links: &[Link]) -> Vec<Edge> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn resolves_relative_target() {
-        let edge = link_edge("docs/guide.md", "setup.md").unwrap();
-        assert_eq!(edge.source, "docs/guide.md");
-        assert_eq!(edge.target, "docs/setup.md");
-        // Resolution moved the path, so the literal text is kept for diagnostics.
-        assert_eq!(edge.metadata["raw"], Value::String("setup.md".into()));
-    }
-
-    #[test]
-    fn no_raw_metadata_when_resolution_is_identity() {
-        // A link already written from the graph root resolves to itself — there is
-        // no second spelling worth recording.
-        let edge = link_edge("guide.md", "setup.md").unwrap();
-        assert_eq!(edge.target, "setup.md");
-        assert!(edge.metadata.is_empty());
-    }
-
-    #[test]
-    fn strips_fragment_into_link_metadata() {
-        let edge = link_edge("a.md", "b.md#heading").unwrap();
-        assert_eq!(edge.target, "b.md");
-        assert_eq!(edge.metadata["link"], Value::String("b.md#heading".into()));
-    }
-
-    #[test]
-    fn passes_through_uris() {
-        let edge = link_edge("a.md", "https://example.com/x").unwrap();
-        assert_eq!(edge.target, "https://example.com/x");
-    }
-
-    #[test]
-    fn drops_anchor_only_and_empty() {
-        assert!(link_edge("a.md", "#section").is_none());
-        assert!(link_edge("a.md", "   ").is_none());
-    }
+    use serde_json::json;
 
     fn link(target: &str, line: Option<usize>) -> Link {
         Link {
@@ -137,10 +121,58 @@ mod tests {
         }
     }
 
+    /// The single edge `link_edges` produces for one link, for the resolution tests.
+    fn one(source: &str, target: &str) -> Option<Edge> {
+        link_edges(source, &[link(target, Some(1))]).pop()
+    }
+
     #[test]
-    fn aggregates_lines_per_target() {
-        // The same target linked on two lines collapses to one edge whose `lines`
-        // is sorted and deduped; a distinct target is its own edge.
+    fn resolves_relative_target() {
+        let edge = one("docs/guide.md", "setup.md").unwrap();
+        assert_eq!(edge.source, "docs/guide.md");
+        assert_eq!(edge.target, "docs/setup.md");
+        // Resolution moved the path, so the literal text is kept for diagnostics.
+        assert_eq!(
+            edge.metadata["occurrences"],
+            json!([{ "line": 1, "raw": "setup.md" }])
+        );
+    }
+
+    #[test]
+    fn no_raw_metadata_when_resolution_is_identity() {
+        // A link already written from the graph root resolves to itself — there is
+        // no second spelling worth recording.
+        let edge = one("guide.md", "setup.md").unwrap();
+        assert_eq!(edge.target, "setup.md");
+        assert_eq!(edge.metadata["occurrences"], json!([{ "line": 1 }]));
+    }
+
+    #[test]
+    fn strips_fragment_into_link_metadata() {
+        let edge = one("a.md", "b.md#heading").unwrap();
+        assert_eq!(edge.target, "b.md");
+        assert_eq!(
+            edge.metadata["occurrences"],
+            json!([{ "line": 1, "link": "b.md#heading" }])
+        );
+    }
+
+    #[test]
+    fn passes_through_uris() {
+        let edge = one("a.md", "https://example.com/x").unwrap();
+        assert_eq!(edge.target, "https://example.com/x");
+    }
+
+    #[test]
+    fn drops_anchor_only_and_empty() {
+        assert!(one("a.md", "#section").is_none());
+        assert!(one("a.md", "   ").is_none());
+    }
+
+    #[test]
+    fn aggregates_occurrences_per_target() {
+        // The same target linked on two lines collapses to one edge whose
+        // occurrences are sorted and deduped; a distinct target is its own edge.
         let links = vec![
             link("b.md", Some(6)),
             link("b.md", Some(2)),
@@ -149,15 +181,54 @@ mod tests {
         ];
         let edges = link_edges("a.md", &links);
         let b = edges.iter().find(|e| e.target == "b.md").unwrap();
-        assert_eq!(b.metadata["lines"], serde_json::json!([2, 6]));
+        assert_eq!(
+            b.metadata["occurrences"],
+            json!([{ "line": 2 }, { "line": 6 }])
+        );
         let c = edges.iter().find(|e| e.target == "c.md").unwrap();
-        assert_eq!(c.metadata["lines"], serde_json::json!([3]));
+        assert_eq!(c.metadata["occurrences"], json!([{ "line": 3 }]));
     }
 
     #[test]
-    fn omits_lines_when_no_line_known() {
+    fn each_occurrence_keeps_its_own_fragment() {
+        // The defect per-occurrence metadata exists to fix: two anchors of one
+        // target must not collapse to whichever spelling came first.
+        let links = vec![
+            link("./owners.md#security-console", Some(53)),
+            link("./owners.md#ngwaf-edge", Some(77)),
+            link("./owners.md#security-console", Some(89)),
+        ];
+        let edges = link_edges("registers/work-items.md", &links);
+        assert_eq!(edges.len(), 1, "one edge, three occurrences");
+        assert_eq!(
+            edges[0].metadata["occurrences"],
+            json!([
+                { "line": 53, "link": "registers/owners.md#security-console", "raw": "./owners.md" },
+                { "line": 77, "link": "registers/owners.md#ngwaf-edge", "raw": "./owners.md" },
+                { "line": 89, "link": "registers/owners.md#security-console", "raw": "./owners.md" },
+            ])
+        );
+    }
+
+    #[test]
+    fn each_occurrence_keeps_its_own_spelling() {
+        // Two spellings that resolve identically are still two facts about the
+        // source; the edge records both.
+        let links = vec![link("./b.md", Some(4)), link("b.md", Some(9))];
+        let edges = link_edges("a.md", &links);
+        assert_eq!(edges.len(), 1);
+        assert_eq!(
+            edges[0].metadata["occurrences"],
+            json!([{ "line": 4, "raw": "./b.md" }, { "line": 9 }])
+        );
+    }
+
+    #[test]
+    fn omits_occurrences_when_nothing_is_known() {
+        // A parser that cannot locate its link contributes no facts, so the edge
+        // keeps the bare no-metadata shape.
         let edges = link_edges("a.md", &[link("b.md", None)]);
         assert_eq!(edges.len(), 1);
-        assert!(edges[0].metadata.get("lines").is_none());
+        assert!(edges[0].metadata.is_empty());
     }
 }

--- a/src/builders/mod.rs
+++ b/src/builders/mod.rs
@@ -224,6 +224,25 @@ mod tests {
     }
 
     #[test]
+    fn two_spellings_both_moved_by_resolution_keep_both_raws() {
+        // The aggregation the `unresolved-edge` wrong-base cause rides on: two
+        // spellings resolving to one target, each differing from it, must both
+        // survive so a rule scanning the occurrences can reach the second. A
+        // first-occurrence-wins aggregation would keep only `./config.md`.
+        let links = vec![link("./config.md", Some(3)), link("config.md", Some(5))];
+        let edges = link_edges("docs/guide.md", &links);
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].target, "docs/config.md");
+        assert_eq!(
+            edges[0].metadata["occurrences"],
+            json!([
+                { "line": 3, "raw": "./config.md" },
+                { "line": 5, "raw": "config.md" },
+            ])
+        );
+    }
+
+    #[test]
     fn omits_occurrences_when_nothing_is_known() {
         // A parser that cannot locate its link contributes no facts, so the edge
         // keeps the bare no-metadata shape.

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -160,12 +160,12 @@ mod tests {
         markdown.add_edge(Edge::with_metadata(
             "a.md",
             "b.md",
-            obj(json!({ "link": "b.md#x" })),
+            obj(json!({ "occurrences": [{ "line": 4, "link": "b.md#x" }] })),
         ));
         let composed = compose(&GraphSet::new(vec![markdown]));
         assert_eq!(
-            composed.edges[0].metadata["@markdown"]["link"],
-            json!("b.md#x")
+            composed.edges[0].metadata["@markdown"]["occurrences"],
+            json!([{ "line": 4, "link": "b.md#x" }])
         );
     }
 }

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -18,9 +18,10 @@ use crate::model::Graph;
 use crate::projection;
 
 /// A projected edge: its endpoints and the namespaced metadata that survived the
-/// namespace/field filters. `metadata` holds only `@<graph>` blocks (`lines`,
-/// `raw`, …); the `_graphs` provenance is dropped. An edge with no per-graph
-/// metadata projects with an empty object — it is still an edge.
+/// namespace/field filters. `metadata` holds only `@<graph>` blocks (each an
+/// `occurrences` array, one entry per link the author wrote); the `_graphs`
+/// provenance is dropped. An edge with no per-graph metadata projects with an
+/// empty object — it is still an edge.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct EdgeProjection {
     pub source: String,
@@ -96,9 +97,10 @@ mod tests {
         g.add_edge(Edge::with_metadata(
             "a.md",
             "b.md",
-            obj(
-                json!({ "@markdown": { "lines": [4], "raw": "./b.md" }, "_graphs": ["@markdown"] }),
-            ),
+            obj(json!({
+                "@markdown": { "occurrences": [{ "line": 4, "raw": "./b.md" }] },
+                "_graphs": ["@markdown"]
+            })),
         ));
         g.add_edge(Edge::with_metadata(
             "a.md",
@@ -109,7 +111,10 @@ mod tests {
         g.add_edge(Edge::with_metadata(
             "b.md",
             "c.md",
-            obj(json!({ "@frontmatter": { "lines": [2] }, "_graphs": ["@frontmatter"] })),
+            obj(json!({
+                "@frontmatter": { "occurrences": [{ "line": 2 }] },
+                "_graphs": ["@frontmatter"]
+            })),
         ));
         g.sort_edges();
         g
@@ -152,7 +157,7 @@ mod tests {
         assert_eq!(out.len(), 1);
         assert_eq!(
             out[0].metadata,
-            obj(json!({ "@frontmatter": { "lines": [2] } }))
+            obj(json!({ "@frontmatter": { "occurrences": [{ "line": 2 }] } }))
         );
     }
 
@@ -163,13 +168,14 @@ mod tests {
             &g,
             Some(&["a.md".into()]),
             &["@markdown".into()],
-            &["lines".into()],
+            &["line".into()],
         );
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].target, "b.md");
         assert_eq!(
             out[0].metadata,
-            obj(json!({ "@markdown": { "lines": [4] } }))
+            obj(json!({ "@markdown": { "occurrences": [{ "line": 4 }] } })),
+            "narrowed within each occurrence, dropping its `raw`"
         );
     }
 
@@ -180,11 +186,11 @@ mod tests {
             &g,
             Some(&["a.md".into()]),
             &["@markdown".into()],
-            &["lines".into()],
+            &["line".into()],
         );
         assert_eq!(
             format_text(&out),
-            "a.md → b.md\n  @markdown\n    lines: [4]\n"
+            "a.md → b.md\n  @markdown\n    occurrences\n      - line: 4\n"
         );
     }
 

--- a/src/impact.rs
+++ b/src/impact.rs
@@ -321,7 +321,10 @@ mod tests {
         g.set_node("dependent.md", fs_node());
         g.set_node("dep.md", fs_node());
         let mut meta = Metadata::new();
-        meta.insert("@markdown".into(), json!({ "lines": [49, 12] }));
+        meta.insert(
+            "@markdown".into(),
+            json!({ "occurrences": [{ "line": 49 }, { "line": 12 }] }),
+        );
         g.add_edge(Edge::with_metadata("dependent.md", "dep.md", meta));
 
         let inbound = compute(&g, &["dep.md".into()], Direction::Inbound, None);

--- a/src/model.rs
+++ b/src/model.rs
@@ -110,36 +110,42 @@ impl Edge {
         }
     }
 
-    /// The source line(s) where this edge's link appears, unioned across parser
-    /// namespaces (`@markdown`, `@frontmatter`, …) and sorted/deduped. Empty when
-    /// no parser recorded a line. The link lives in `source`, so these are
-    /// positions within `source`.
+    /// Every link occurrence on this edge, across contributing parser
+    /// namespaces (`@markdown`, `@frontmatter`, …). One entry per link the
+    /// author wrote, carrying that link's own `line`, fragment-qualified `link`,
+    /// and literal `raw` spelling. Namespace order is the metadata's sorted key
+    /// order, so the iteration is deterministic.
+    pub fn occurrences(&self) -> impl Iterator<Item = &Metadata> {
+        self.metadata
+            .iter()
+            .filter(|(key, _)| key.starts_with('@'))
+            .filter_map(|(_, value)| value.get("occurrences"))
+            .filter_map(Value::as_array)
+            .flatten()
+            .filter_map(Value::as_object)
+    }
+
+    /// The source line(s) where this edge's links appear, sorted and deduped
+    /// across parser namespaces. Empty when no parser located a link. The links
+    /// live in `source`, so these are positions within `source`.
     pub fn lines(&self) -> Vec<usize> {
         let mut lines = BTreeSet::new();
-        for (key, value) in &self.metadata {
-            if !key.starts_with('@') {
-                continue;
-            }
-            if let Some(arr) = value.get("lines").and_then(Value::as_array) {
-                for n in arr.iter().filter_map(Value::as_u64) {
-                    lines.insert(n as usize);
-                }
+        for occurrence in self.occurrences() {
+            if let Some(line) = occurrence.get("line").and_then(Value::as_u64) {
+                lines.insert(line as usize);
             }
         }
         lines.into_iter().collect()
     }
 
-    /// The literal link text(s) that produced this edge, across contributing
-    /// graphs. Present only where resolution moved the path, so an edge whose
-    /// target is exactly what the author typed reports nothing. Two graphs can
-    /// disagree — one doc may write `./x.md` where another writes `x.md`.
+    /// The literal link text(s) that produced this edge. Present only where
+    /// resolution moved the path, so a link whose target is exactly what the
+    /// author typed reports nothing. Two occurrences can disagree — one line may
+    /// write `./x.md` where another writes `x.md`.
     pub fn raw_links(&self) -> Vec<&str> {
         let mut raws = BTreeSet::new();
-        for (key, value) in &self.metadata {
-            if !key.starts_with('@') {
-                continue;
-            }
-            if let Some(raw) = value.get("raw").and_then(Value::as_str) {
+        for occurrence in self.occurrences() {
+            if let Some(raw) = occurrence.get("raw").and_then(Value::as_str) {
                 raws.insert(raw);
             }
         }
@@ -298,13 +304,20 @@ mod tests {
     }
 
     #[test]
-    fn edge_lines_unions_namespaces_sorted() {
+    fn edge_occurrences_union_namespaces_sorted() {
         let mut m = Metadata::new();
-        m.insert("@markdown".into(), json!({ "lines": [5, 2] }));
-        m.insert("@frontmatter".into(), json!({ "lines": [2, 9] }));
+        m.insert(
+            "@markdown".into(),
+            json!({ "occurrences": [{ "line": 5, "raw": "./b.md" }, { "line": 2 }] }),
+        );
+        m.insert(
+            "@frontmatter".into(),
+            json!({ "occurrences": [{ "line": 2 }, { "line": 9 }] }),
+        );
         m.insert("_graphs".into(), json!(["@markdown", "@frontmatter"]));
         let edge = Edge::with_metadata("a.md", "b.md", m);
         assert_eq!(edge.lines(), vec![2, 5, 9], "unioned, sorted, deduped");
+        assert_eq!(edge.raw_links(), vec!["./b.md"]);
         assert!(Edge::new("a.md", "b.md").lines().is_empty());
     }
 

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -30,17 +30,42 @@ pub fn filter_metadata(
             let Some(obj) = value.as_object() else {
                 continue;
             };
-            let filtered: Map<String, Value> = obj
-                .iter()
-                .filter(|(k, _)| fields.iter().any(|f| f == *k))
-                .map(|(k, v)| (k.clone(), v.clone()))
-                .collect();
+            let filtered = filter_fields(obj, fields);
             if filtered.is_empty() {
                 continue;
             }
             Value::Object(filtered)
         };
         out.insert(ns.clone(), block);
+    }
+    out
+}
+
+/// Narrow one namespace block to `fields`. A key whose own name matches is kept
+/// whole. A key holding an array of objects — an edge's `occurrences` — is kept
+/// with each entry narrowed the same way, so `--field line` reaches the
+/// per-occurrence facts without the caller naming the array it lives in. An entry
+/// that keeps nothing drops out, and a key whose entries all drop out goes with
+/// them.
+fn filter_fields(block: &Map<String, Value>, fields: &[String]) -> Map<String, Value> {
+    let mut out = Map::new();
+    for (key, value) in block {
+        if fields.iter().any(|f| f == key) {
+            out.insert(key.clone(), value.clone());
+            continue;
+        }
+        let Some(entries) = object_entries(value) else {
+            continue;
+        };
+        let narrowed: Vec<Value> = entries
+            .into_iter()
+            .map(|entry| filter_fields(entry, fields))
+            .filter(|entry| !entry.is_empty())
+            .map(Value::Object)
+            .collect();
+        if !narrowed.is_empty() {
+            out.insert(key.clone(), Value::Array(narrowed));
+        }
     }
     out
 }
@@ -65,14 +90,46 @@ pub fn push_metadata_lines(lines: &mut Vec<String>, metadata: &Map<String, Value
     for (ns, value) in metadata {
         lines.push(format!("  {ns}"));
         match value.as_object() {
-            Some(obj) => {
-                for (k, v) in obj {
-                    lines.push(format!("    {k}: {}", render_value(v)));
-                }
-            }
+            Some(obj) => push_fields(lines, obj, 4),
             None => lines.push(format!("    {}", render_value(value))),
         }
     }
+}
+
+/// Render one object's fields at `indent` spaces, one `key: value` per line.
+///
+/// A field holding an array of objects — an edge's `occurrences` — renders as a
+/// bare header line followed by a `- `-marked sub-block per entry, so each entry's
+/// fields keep their own lines. Rendering it through [`render_value`] instead
+/// would collapse the whole array onto one long JSON line, which is the opposite
+/// of what the text shape is for.
+fn push_fields(lines: &mut Vec<String>, obj: &Map<String, Value>, indent: usize) {
+    let pad = " ".repeat(indent);
+    for (key, value) in obj {
+        let Some(entries) = object_entries(value) else {
+            lines.push(format!("{pad}{key}: {}", render_value(value)));
+            continue;
+        };
+        lines.push(format!("{pad}{key}"));
+        for entry in entries {
+            for (i, (k, v)) in entry.iter().enumerate() {
+                let marker = if i == 0 { "- " } else { "  " };
+                lines.push(format!("{pad}  {marker}{k}: {}", render_value(v)));
+            }
+        }
+    }
+}
+
+/// The entries of an array whose every element is an object, with at least one
+/// carrying a field. Anything else — a scalar, a mixed array, an array of empty
+/// objects — returns `None` so the caller falls back to rendering the value whole.
+fn object_entries(value: &Value) -> Option<Vec<&Map<String, Value>>> {
+    let entries: Vec<&Map<String, Value>> = value
+        .as_array()?
+        .iter()
+        .map(Value::as_object)
+        .collect::<Option<Vec<_>>>()?;
+    entries.iter().any(|e| !e.is_empty()).then_some(entries)
 }
 
 /// Join per-entry blocks into the final text: one blank line between blocks and a
@@ -147,6 +204,77 @@ mod tests {
         }));
         let out = filter_metadata(&m, &["@markdown".into()], &["lines".into()]);
         assert_eq!(out, obj(json!({ "@markdown": { "lines": [4] } })));
+    }
+
+    #[test]
+    fn filter_reaches_into_occurrence_entries() {
+        // `--field line` narrows each occurrence without the caller naming the
+        // array it lives in.
+        let m = obj(json!({
+            "@markdown": { "occurrences": [
+                { "line": 53, "link": "b.md#x", "raw": "./b.md" },
+                { "line": 77, "link": "b.md#y", "raw": "./b.md" },
+            ] },
+            "_graphs": ["@markdown"],
+        }));
+        let out = filter_metadata(&m, &[], &["line".into()]);
+        assert_eq!(
+            out["@markdown"],
+            json!({ "occurrences": [{ "line": 53 }, { "line": 77 }] })
+        );
+    }
+
+    #[test]
+    fn filter_keeps_a_named_array_whole() {
+        let m = obj(json!({ "@markdown": { "occurrences": [{ "line": 4 }] } }));
+        let out = filter_metadata(&m, &[], &["occurrences".into()]);
+        assert_eq!(out["@markdown"], json!({ "occurrences": [{ "line": 4 }] }));
+    }
+
+    #[test]
+    fn filter_drops_a_block_matching_at_neither_level() {
+        let m = obj(json!({ "@markdown": { "occurrences": [{ "line": 4 }] } }));
+        assert!(filter_metadata(&m, &[], &["purpose".into()]).is_empty());
+    }
+
+    #[test]
+    fn occurrences_render_one_entry_per_sub_block() {
+        // The array must not collapse onto one JSON line — the text shape exists
+        // so a reader can see which line cites which anchor.
+        let mut lines = Vec::new();
+        push_metadata_lines(
+            &mut lines,
+            &obj(json!({ "@markdown": { "occurrences": [
+                { "line": 53, "link": "owners.md#security-console" },
+                { "line": 77, "link": "owners.md#ngwaf-edge" },
+            ] } })),
+        );
+        assert_eq!(
+            lines,
+            vec![
+                "  @markdown",
+                "    occurrences",
+                "      - line: 53",
+                "        link: owners.md#security-console",
+                "      - line: 77",
+                "        link: owners.md#ngwaf-edge",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_plain_array_still_renders_inline() {
+        // Only an array of objects gets the sub-block treatment; a scalar array
+        // keeps the one-line-per-field shape.
+        let mut lines = Vec::new();
+        push_metadata_lines(
+            &mut lines,
+            &obj(json!({ "@frontmatter": { "tags": ["graph", "core"] } })),
+        );
+        assert_eq!(
+            lines,
+            vec!["  @frontmatter", "    tags: [\"graph\",\"core\"]"]
+        );
     }
 
     #[test]

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -42,11 +42,12 @@ pub fn filter_metadata(
 }
 
 /// Narrow one namespace block to `fields`. A key whose own name matches is kept
-/// whole. A key holding an array of objects — an edge's `occurrences` — is kept
-/// with each entry narrowed the same way, so `--field line` reaches the
-/// per-occurrence facts without the caller naming the array it lives in. An entry
+/// whole. A key holding an array of objects is kept with each entry narrowed the
+/// same way, so a field names what it is wherever it is declared: `--field line`
+/// reaches an edge's per-occurrence facts, and `--field role` reaches an authored
+/// frontmatter list, without the caller naming the array it lives in. An entry
 /// that keeps nothing drops out, and a key whose entries all drop out goes with
-/// them.
+/// them — so the descent also decides whether a node survives `filtered_out`.
 fn filter_fields(block: &Map<String, Value>, fields: &[String]) -> Map<String, Value> {
     let mut out = Map::new();
     for (key, value) in block {
@@ -98,11 +99,15 @@ pub fn push_metadata_lines(lines: &mut Vec<String>, metadata: &Map<String, Value
 
 /// Render one object's fields at `indent` spaces, one `key: value` per line.
 ///
-/// A field holding an array of objects — an edge's `occurrences` — renders as a
-/// bare header line followed by a `- `-marked sub-block per entry, so each entry's
-/// fields keep their own lines. Rendering it through [`render_value`] instead
-/// would collapse the whole array onto one long JSON line, which is the opposite
-/// of what the text shape is for.
+/// A field holding an array of objects — an edge's `occurrences`, or an authored
+/// frontmatter list — renders as a bare header line followed by a `- `-marked
+/// sub-block per entry, so each entry's fields keep their own lines. Rendering it
+/// through [`render_value`] instead would collapse the whole array onto one long
+/// JSON line, which is the opposite of what the text shape is for.
+///
+/// An entry with no fields renders as `- {}`. It has no key to carry the marker,
+/// so emitting nothing would drop it from the rendering and silently misreport
+/// how many entries the array holds.
 fn push_fields(lines: &mut Vec<String>, obj: &Map<String, Value>, indent: usize) {
     let pad = " ".repeat(indent);
     for (key, value) in obj {
@@ -112,6 +117,10 @@ fn push_fields(lines: &mut Vec<String>, obj: &Map<String, Value>, indent: usize)
         };
         lines.push(format!("{pad}{key}"));
         for entry in entries {
+            if entry.is_empty() {
+                lines.push(format!("{pad}  - {{}}"));
+                continue;
+            }
             for (i, (k, v)) in entry.iter().enumerate() {
                 let marker = if i == 0 { "- " } else { "  " };
                 lines.push(format!("{pad}  {marker}{k}: {}", render_value(v)));
@@ -190,7 +199,10 @@ mod tests {
 
     #[test]
     fn filter_drops_provenance_and_keeps_all_by_default() {
-        let m = obj(json!({ "@markdown": { "lines": [4] }, "_graphs": ["@markdown"] }));
+        let m = obj(json!({
+            "@markdown": { "occurrences": [{ "line": 4 }] },
+            "_graphs": ["@markdown"]
+        }));
         let out = filter_metadata(&m, &[], &[]);
         assert_eq!(out.keys().collect::<Vec<_>>(), vec!["@markdown"]);
     }
@@ -198,12 +210,15 @@ mod tests {
     #[test]
     fn filter_by_namespace_and_field() {
         let m = obj(json!({
-            "@markdown": { "lines": [4], "raw": "./b.md" },
-            "@frontmatter": { "lines": [2] },
-            "_graphs": ["@frontmatter", "@markdown"]
+            "@frontmatter": { "purpose": "how the walk is scoped", "status": "draft" },
+            "@fs": { "type": "file", "hash": "b3:1" },
+            "_graphs": ["@frontmatter", "@fs"]
         }));
-        let out = filter_metadata(&m, &["@markdown".into()], &["lines".into()]);
-        assert_eq!(out, obj(json!({ "@markdown": { "lines": [4] } })));
+        let out = filter_metadata(&m, &["@frontmatter".into()], &["purpose".into()]);
+        assert_eq!(
+            out,
+            obj(json!({ "@frontmatter": { "purpose": "how the walk is scoped" } }))
+        );
     }
 
     #[test]
@@ -274,6 +289,49 @@ mod tests {
         assert_eq!(
             lines,
             vec!["  @frontmatter", "    tags: [\"graph\",\"core\"]"]
+        );
+    }
+
+    #[test]
+    fn filter_reaches_into_an_authored_frontmatter_list() {
+        // `filter_fields` is shared by `nodes` and `edges`, so the descent applies
+        // to authored frontmatter too: a field names what it is wherever it is
+        // declared, and a node declaring it only inside a list survives the filter.
+        let m = obj(json!({ "@frontmatter": { "authors": [
+            { "name": "Ana", "role": "lead" },
+            { "role": "reviewer" },
+        ] } }));
+        let out = filter_metadata(&m, &[], &["role".into()]);
+        assert_eq!(
+            out["@frontmatter"],
+            json!({ "authors": [{ "role": "lead" }, { "role": "reviewer" }] })
+        );
+        assert!(!filtered_out(&out, &[], &["role".into()]));
+    }
+
+    #[test]
+    fn an_empty_entry_still_renders() {
+        // An empty entry has no key to carry the `- ` marker. Emitting nothing
+        // would drop it and misreport how many entries the array holds.
+        let mut lines = Vec::new();
+        push_metadata_lines(
+            &mut lines,
+            &obj(json!({ "@frontmatter": { "authors": [
+                { "name": "Ana" },
+                {},
+                { "name": "Bo" },
+            ] } })),
+        );
+        assert_eq!(
+            lines,
+            vec![
+                "  @frontmatter",
+                "    authors",
+                "      - name: Ana",
+                "      - {}",
+                "      - name: Bo",
+            ],
+            "three entries in, three entries out"
         );
     }
 

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -121,24 +121,37 @@ fn push_fields(lines: &mut Vec<String>, obj: &Map<String, Value>, indent: usize)
                 lines.push(format!("{pad}  - {{}}"));
                 continue;
             }
-            for (i, (k, v)) in entry.iter().enumerate() {
-                let marker = if i == 0 { "- " } else { "  " };
-                lines.push(format!("{pad}  {marker}{k}: {}", render_value(v)));
+            // Render the entry as its own object so a nested list of objects
+            // descends too, then hang the marker on the first line by replacing
+            // the last two spaces of its indent. `filter_fields` narrows at any
+            // depth, so stopping here would print exactly the long JSON line the
+            // sub-block shape exists to avoid.
+            let mut entry_lines = Vec::new();
+            push_fields(&mut entry_lines, entry, indent + 4);
+            if let Some(first) = entry_lines.first_mut() {
+                first.replace_range(indent + 2..indent + 4, "- ");
             }
+            lines.extend(entry_lines);
         }
     }
 }
 
-/// The entries of an array whose every element is an object, with at least one
-/// carrying a field. Anything else — a scalar, a mixed array, an array of empty
-/// objects — returns `None` so the caller falls back to rendering the value whole.
+/// The entries of a non-empty array whose every element is an object. A scalar, a
+/// mixed array, or an empty array returns `None`, so the caller falls back to
+/// rendering the value whole.
+///
+/// Entries that carry no fields are admitted. Requiring one non-empty entry would
+/// make an entry's rendering depend on whether a *sibling* declared anything —
+/// the same list shape printing as sub-blocks or as inline JSON according to its
+/// contents — and there is nothing left to protect against, since a keyless entry
+/// renders as `- {}` rather than vanishing.
 fn object_entries(value: &Value) -> Option<Vec<&Map<String, Value>>> {
     let entries: Vec<&Map<String, Value>> = value
         .as_array()?
         .iter()
         .map(Value::as_object)
         .collect::<Option<Vec<_>>>()?;
-    entries.iter().any(|e| !e.is_empty()).then_some(entries)
+    (!entries.is_empty()).then_some(entries)
 }
 
 /// Join per-entry blocks into the final text: one blank line between blocks and a
@@ -273,6 +286,49 @@ mod tests {
                 "        link: owners.md#security-console",
                 "      - line: 77",
                 "        link: owners.md#ngwaf-edge",
+            ]
+        );
+    }
+
+    #[test]
+    fn an_all_empty_list_still_renders_as_entries() {
+        // The shape must not depend on whether a sibling entry declared a field.
+        let mut lines = Vec::new();
+        push_metadata_lines(
+            &mut lines,
+            &obj(json!({ "@frontmatter": { "slots": [{}, {}] } })),
+        );
+        assert_eq!(
+            lines,
+            vec!["  @frontmatter", "    slots", "      - {}", "      - {}"]
+        );
+    }
+
+    #[test]
+    fn a_nested_list_descends_as_far_as_the_filter_does() {
+        // `filter_fields` narrows at any depth, so the renderer has to reach the
+        // same depth: stopping one level down would print the long JSON line the
+        // sub-block shape exists to avoid.
+        let mut lines = Vec::new();
+        push_metadata_lines(
+            &mut lines,
+            &obj(json!({ "@frontmatter": { "teams": [
+                { "name": "alpha", "members": [
+                    { "name": "Ana", "role": "lead" },
+                    { "name": "Bo" },
+                ] },
+            ] } })),
+        );
+        assert_eq!(
+            lines,
+            vec![
+                "  @frontmatter",
+                "    teams",
+                "      - members",
+                "          - name: Ana",
+                "            role: lead",
+                "          - name: Bo",
+                "        name: alpha",
             ]
         );
     }

--- a/src/rules/structural.rs
+++ b/src/rules/structural.rs
@@ -122,7 +122,7 @@ mod tests {
             fs.set_node(*f, fs_node());
         }
         let mut meta = Metadata::new();
-        meta.insert("raw".into(), json!(raw));
+        meta.insert("occurrences".into(), json!([{ "raw": raw }]));
         fs.add_edge(Edge::with_metadata(source, target, meta));
         compose(&GraphSet::new(vec![fs]))
     }
@@ -194,7 +194,7 @@ mod tests {
         // A markdown link to a missing target on line 3 — the finding points there.
         let mut markdown = Graph::labeled("markdown");
         let mut meta = Metadata::new();
-        meta.insert("lines".into(), json!([3]));
+        meta.insert("occurrences".into(), json!([{ "line": 3 }]));
         markdown.add_edge(Edge::with_metadata("index.md", "gone.md", meta));
         let mut fs = Graph::labeled("fs");
         fs.set_node("index.md", fs_node());

--- a/src/rules/structural.rs
+++ b/src/rules/structural.rs
@@ -128,6 +128,39 @@ mod tests {
     }
 
     #[test]
+    fn wrong_base_cause_reaches_a_later_spelling() {
+        // Two spellings resolve to the same missing target: an explicitly relative
+        // one and a bare one that would resolve from the graph root. Because every
+        // occurrence keeps its own `raw`, the cause finds the second — the first
+        // is unambiguously relative by intent and names no cause on its own.
+        let mut fs = Graph::labeled("fs");
+        fs.set_node("docs/guide.md", fs_node());
+        fs.set_node("config.md", fs_node());
+        let mut meta = Metadata::new();
+        meta.insert(
+            "occurrences".into(),
+            json!([
+                { "line": 3, "raw": "./config.md" },
+                { "line": 5, "raw": "config.md" },
+            ]),
+        );
+        fs.add_edge(Edge::with_metadata("docs/guide.md", "docs/config.md", meta));
+        let composed = compose(&GraphSet::new(vec![fs]));
+
+        let findings = evaluate(&composed);
+        let f = findings
+            .iter()
+            .find(|f| f.name == "unresolved-edge")
+            .expect("target does not exist");
+        let cause = f.cause.as_deref().expect("expected a cause");
+        assert!(
+            cause.contains("`config.md` resolves from the graph root"),
+            "got: {cause}"
+        );
+        assert!(cause.contains("../config.md"), "got: {cause}");
+    }
+
+    #[test]
     fn wrong_base_cause_names_the_cause() {
         // The #72 case: a repo-relative path in a doc one level down. The target
         // reported is a path nobody wrote, so the finding reads as a typo.

--- a/src/rules/structural.rs
+++ b/src/rules/structural.rs
@@ -133,25 +133,35 @@ mod tests {
         // one and a bare one that would resolve from the graph root. Because every
         // occurrence keeps its own `raw`, the cause finds the second — the first
         // is unambiguously relative by intent and names no cause on its own.
+        //
+        // The edge is built through `link_edges` rather than hand-rolled, so this
+        // guards the aggregation as well as the rule: a first-occurrence-wins
+        // builder would drop the bare spelling and the cause with it.
         let mut fs = Graph::labeled("fs");
         fs.set_node("docs/guide.md", fs_node());
         fs.set_node("config.md", fs_node());
-        let mut meta = Metadata::new();
-        meta.insert(
-            "occurrences".into(),
-            json!([
-                { "line": 3, "raw": "./config.md" },
-                { "line": 5, "raw": "config.md" },
-            ]),
-        );
-        fs.add_edge(Edge::with_metadata("docs/guide.md", "docs/config.md", meta));
-        let composed = compose(&GraphSet::new(vec![fs]));
+        let links = [
+            crate::parsers::Link {
+                target: "./config.md".into(),
+                line: Some(3),
+            },
+            crate::parsers::Link {
+                target: "config.md".into(),
+                line: Some(5),
+            },
+        ];
+        let mut markdown = Graph::labeled("markdown");
+        for edge in crate::builders::link_edges("docs/guide.md", &links) {
+            markdown.add_edge(edge);
+        }
+        let composed = compose(&GraphSet::new(vec![fs, markdown]));
 
         let findings = evaluate(&composed);
         let f = findings
             .iter()
             .find(|f| f.name == "unresolved-edge")
-            .expect("target does not exist");
+            .expect("docs/config.md does not exist");
+        assert_eq!(f.lines, vec![3, 5]);
         let cause = f.cause.as_deref().expect("expected a cause");
         assert!(
             cause.contains("`config.md` resolves from the graph root"),

--- a/tests/edges.rs
+++ b/tests/edges.rs
@@ -123,24 +123,30 @@ fn namespace_filters_edge_set_and_metadata() {
     );
 }
 
-/// `--field` narrows the returned metadata to named keys within the namespace.
+/// `--field` narrows the returned metadata to named keys within the namespace,
+/// reaching into each link occurrence without the caller naming the array.
 #[test]
 fn field_narrows_metadata_within_namespace() {
     let dir = fixture();
     let v = edges_json(
         dir.path(),
-        &["docs/a.md", "--namespace", "markdown", "--field", "lines"],
+        &["docs/a.md", "--namespace", "markdown", "--field", "line"],
     );
-    // The markdown edge to b.md, with only `lines` (not `raw`).
+    // The markdown edge to b.md, each occurrence carrying only `line` (not `raw`).
     let edge = v["edges"]
         .as_array()
         .unwrap()
         .iter()
         .find(|e| e["target"] == "docs/b.md")
         .expect("markdown edge to docs/b.md");
-    let md = &edge["metadata"]["@markdown"];
-    assert!(md.get("lines").is_some());
-    assert!(md.get("raw").is_none(), "field narrows to lines only");
+    let occurrences = edge["metadata"]["@markdown"]["occurrences"]
+        .as_array()
+        .expect("occurrences survive the narrowing");
+    assert!(!occurrences.is_empty());
+    for occurrence in occurrences {
+        assert!(occurrence.get("line").is_some());
+        assert!(occurrence.get("raw").is_none(), "narrowed to line only");
+    }
 }
 
 /// An unknown namespace is a typo: it errors (exit 2) and lists the declared graphs.
@@ -217,7 +223,7 @@ fn text_format_is_source_arrow_target() {
             "--namespace",
             "frontmatter",
             "--field",
-            "lines",
+            "line",
         ])
         .output()
         .unwrap();
@@ -225,7 +231,7 @@ fn text_format_is_source_arrow_target() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert_eq!(
         stdout,
-        "docs/a.md → index.md\n  @frontmatter\n    lines: [3]\n"
+        "docs/a.md → index.md\n  @frontmatter\n    occurrences\n      - line: 3\n"
     );
 }
 


### PR DESCRIPTION
## The defect

An edge collapses every link from one source to one target, and its metadata described that set with scalars: a `lines` array, plus a single `link` (the fragment-qualified target) and `raw` (the literal spelling). Where the occurrences disagree, the scalars pick one and the rest vanish without trace.

A source citing two anchors of one target is the ordinary case. Six lines naming `#security` and one naming `#billing` produce one edge:

```json
{
  "source": "guide.md",
  "target": "owners.md",
  "metadata": { "@markdown": { "lines": [12, 20, 34, 41, 55, 63, 77], "link": "owners.md#security" } }
}
```

Line 77 cites `#billing`. The projection attributes `#security` to all seven, and nothing in the output signals a second spelling existed. `raw`'s absence is not a signal either, since it is recorded only where resolution moved the path. A reader auditing which anchor each line cites — the use `drft edges` is recommended for — reads a false statement about that line.

## The change

One `occurrences` entry per link the author wrote, each carrying its own `line`, `link`, and `raw`, sorted by line:

```json
{ "@markdown": { "occurrences": [
  { "line": 12, "link": "owners.md#security" },
  { "line": 77, "link": "owners.md#billing" }
] } }
```

The information was already in hand at parse time; only the aggregation discarded it. `Edge::lines()` and `Edge::raw_links()` keep their signatures and derive from the array, so `impact`, staleness, and the wrong-base cause are untouched.

Two knock-on changes, each keeping a surface the new shape would otherwise have broken:

- **`--field` reaches into the entries.** `occurrences` is the only edge field, so a top-level-only filter would leave `--field` with nothing to narrow. It now recurses into arrays of objects, so `--field line` reaches the per-occurrence facts without the caller naming the array. Generic — no key names hardcoded.
- **Text output renders an array of objects as sub-blocks.** Rendering it as a value would collapse the array onto one long JSON line, which is the opposite of what the text shape is for. A scalar array still renders inline. An entry with no fields renders `- {}`, so the rendering never misreports how many entries an array holds.

Both live in `src/projection.rs`, which `nodes`, `edges`, and `graph --format text` share, so **both reach authored frontmatter too** — deliberately. A field names what it is wherever it is declared, so `--field role` reaches an `authors:` list the way `--field line` reaches a link occurrence, and a node declaring a field only inside a list now survives the filter. An authored list of objects renders as entries rather than as one line of JSON.

```
guide.md → owners.md
  @markdown
    occurrences
      - line: 12
        link: owners.md#security
      - line: 77
        link: owners.md#billing
```

## Breaking

The JSON edge metadata shape changes. A consumer reading `.edges[].metadata["@markdown"].lines` reads `.occurrences[].line`; `link` and `raw` move into the same entries. `--field lines` becomes `--field line`. No alias, per no-backwards-compat. Findings are unaffected — `Finding.lines` still reports the source lines where a link appears.

Two smaller output changes ride along, both on the `nodes` and `graph` paths:

- `--field <name>` now also matches a key declared inside a list of objects, so a node that previously dropped out of a filter can survive it.
- An authored list of objects renders as `- `-marked entries in text output instead of one inline JSON line.

And one `check` change: because every occurrence keeps its own `raw`, `unresolved-edge`'s wrong-base `cause` reaches every spelling rather than only the first. A target linked twice — once `./config.md`, once bare `config.md` — now reports the cause that the first spelling alone withholds. This is the answer the rules reference already promised; the old aggregation had discarded the evidence.

Needs a CHANGELOG entry at release time.

## Why now

Prerequisite for fragment-level findings (#87, #98). A rule that reports a link to a heading no longer defined has to name the line that cites it, and a scalar `link` cannot supply it. Shipping it alone keeps the truth fix separable from the feature that needs it.

## Verification

`cargo test` (14 binaries), `cargo clippy --all-targets -- -D warnings`, `cargo fmt`, `dprint fmt`. New tests cover the defect directly: two anchors of one target keep their own lines, and two spellings that resolve identically both survive. `drft check` exits 0 — impacted docs reviewed and locked by name.
