### PR TITLE
feat: check a link's fragment against the anchors its target defines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
+ "unicode-general-category",
  "url",
 ]
 
@@ -1064,6 +1065,12 @@ name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 toml = "0.8"
+unicode-general-category = "1.1.0"
 url = "2.5.8"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ drft check                # now detects staleness too
 drft builds a **set of independent graphs** and merges them by path:
 
 - **`fs`** — walks the tree under the root (minus `ignore` and `.gitignore`), typing each file, symlink, and directory as a node and hashing the ones with content. This is the identity space.
-- **`markdown`** — link edges from `[text](path)` body links.
+- **`markdown`** — link edges from `[text](path)` body links, plus the `#fragment` anchors each file answers to.
 - **`frontmatter`** — edges from frontmatter link-target values, plus the parsed frontmatter block as node metadata. Paths resolve relative to the declaring file, as its markdown links do. Set `keys = ["sources"]` to scope edges to named keys instead of every path-shaped value.
 
 Composition merges the set into one graph, and `drft check` reads it to emit drift findings:
 
-- **Broken links** — edges to a target with no defining node (`unresolved-edge`)
+- **Broken links** — edges to a target with no defining node (`unresolved-edge`), and links whose `#fragment` names no anchor the target defines (`unresolved-fragment`)
 - **Staleness** — a node's content, or a dependency's, changed since the last lock (`stale-node`, `stale-edge`)
 - **Structure** — edges added or removed since lock, or a node with no connections (`new-edge`, `removed-edge`, `removed-node`, `detached-node`)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,8 @@ purpose: map of drft's reference documentation
 drft is a drift checker for linked files, built for LLMs and humans working in
 the same repo. It builds a dependency graph from your files and checks it for
 drift. The substrate is a **set of independent graphs** — `fs` (a node per file,
-typed and hashed), `markdown` (link edges), and `frontmatter` (edges plus
-metadata). A composition step merges them by path into one graph, and rules read
+typed and hashed), `markdown` (link edges plus heading anchors), and
+`frontmatter` (edges plus metadata). A composition step merges them by path into one graph, and rules read
 the composed graph to emit findings.
 
 ## Reference

--- a/docs/parsers/README.md
+++ b/docs/parsers/README.md
@@ -7,10 +7,12 @@ sources:
 # Parsers
 
 A parser interprets the files a graph's `files` globs select, emitting links that
-become edges. The frontmatter parser also emits the parsed frontmatter block as
-metadata on the file's node. A graph names its parser with `parser = "..."`.
+become edges. Each parser also emits node metadata about the file it read: the
+markdown parser the `#fragment` anchors that file answers to, the frontmatter
+parser the parsed frontmatter block. A graph names its parser with
+`parser = "..."`.
 
-| Parser                        | Emits                                      |
-| ----------------------------- | ------------------------------------------ |
-| [markdown](markdown.md)       | edges (inline, reference, autolink, image) |
-| [frontmatter](frontmatter.md) | edges (link-target values) + node metadata |
+| Parser                        | Emits                                                        |
+| ----------------------------- | ------------------------------------------------------------ |
+| [markdown](markdown.md)       | edges (inline, reference, autolink, image) + heading anchors |
+| [frontmatter](frontmatter.md) | edges (link-target values) + node metadata                   |

--- a/docs/parsers/frontmatter.md
+++ b/docs/parsers/frontmatter.md
@@ -76,6 +76,8 @@ Omitting `keys` keeps shape detection over the entire block. Prefer `keys` where
 
 The parser attaches the parsed frontmatter block to the file's node. In the composed graph it nests under the graph's `@<name>` namespace — `@frontmatter` for a graph named `frontmatter` — alongside the file's `@fs` facts.
 
+A block counts as frontmatter only when it parses as a YAML **mapping**. The [markdown parser](markdown.md) masks the same block before reading headings, so the two agree on where the document begins: a file opening with a `---` thematic break rather than frontmatter keeps its first heading and its links.
+
 ## Configuration
 
 Declare a graph that uses the frontmatter parser:

--- a/docs/parsers/frontmatter.md
+++ b/docs/parsers/frontmatter.md
@@ -76,7 +76,9 @@ Omitting `keys` keeps shape detection over the entire block. Prefer `keys` where
 
 The parser attaches the parsed frontmatter block to the file's node. In the composed graph it nests under the graph's `@<name>` namespace — `@frontmatter` for a graph named `frontmatter` — alongside the file's `@fs` facts.
 
-A block counts as frontmatter only when it parses as a YAML **mapping**. The [markdown parser](markdown.md) masks the same block before reading headings, so the two agree on where the document begins: a file opening with a `---` thematic break rather than frontmatter keeps its first heading and its links.
+A block counts as frontmatter only when it parses as a YAML **mapping**, and the [markdown parser](markdown.md) asks this parser where the block ends rather than deciding for itself. So a file opening with a `---` thematic break rather than frontmatter keeps its first heading and its links.
+
+A mapping is required rather than any valid YAML because YAML and markdown collide: `# First` is a YAML comment _and_ a markdown heading, so treating a comment-only block as frontmatter would delete the most ordinary heading in markdown from any document that opens with a rule. A block parsing to a bare scalar is ambiguous the same way — `---`, `My Title`, `---` is equally a rule above a setext heading. Both are read as content, which costs comment-only frontmatter its metadata and is the recoverable direction to be wrong in.
 
 ## Configuration
 

--- a/docs/parsers/frontmatter.md
+++ b/docs/parsers/frontmatter.md
@@ -76,7 +76,7 @@ Omitting `keys` keeps shape detection over the entire block. Prefer `keys` where
 
 The parser attaches the parsed frontmatter block to the file's node. In the composed graph it nests under the graph's `@<name>` namespace — `@frontmatter` for a graph named `frontmatter` — alongside the file's `@fs` facts.
 
-A block counts as frontmatter only when it parses as a YAML **mapping**, and the [markdown parser](markdown.md) asks this parser where the block ends rather than deciding for itself. So a file opening with a `---` thematic break rather than frontmatter keeps its first heading and its links.
+A block counts as frontmatter only when it parses as a YAML **mapping**, and one selector decides where it ends — for this parser's metadata, for its edges, and for the [markdown parser](markdown.md)'s mask. Code spans are blanked within that block, not used to find it: a backtick opened in frontmatter and closed in the body would otherwise move the boundary, and the two directions of that were a link lifted out of body prose and a declared `sources:` entry silently producing no edge. So a file opening with a `---` thematic break rather than frontmatter keeps its first heading and its links.
 
 A mapping is required rather than any valid YAML because YAML and markdown collide: `# First` is a YAML comment _and_ a markdown heading, so treating a comment-only block as frontmatter would delete the most ordinary heading in markdown from any document that opens with a rule. A block parsing to a bare scalar is ambiguous the same way — `---`, `My Title`, `---` is equally a rule above a setext heading. Both are read as content, which costs comment-only frontmatter its metadata and is the recoverable direction to be wrong in.
 

--- a/docs/parsers/markdown.md
+++ b/docs/parsers/markdown.md
@@ -63,6 +63,24 @@ Image references.
 
 Images follow the same resolution rules as inline links -- the graph builder strips fragments and skips anchor-only references.
 
+## Anchors
+
+The parser also records the `#fragment` addresses each file answers to, as
+`anchors` in its `markdown` node metadata: the GitHub slug of every heading, in
+document order, with GitHub's `-1` disambiguator when a slug repeats. Read them
+with `drft nodes <path> --field anchors`.
+
+The slug downcases the heading's rendered text, drops every character that is not
+a letter, digit, underscore, hyphen, or space, then turns spaces into hyphens.
+Punctuation is **removed rather than replaced**, so a character between two
+spaces leaves both behind: `## Sizing — notes` answers to `#sizing--notes`, with
+two hyphens. A `{#custom}` attribute is not honored, because GitHub ignores it
+too and an anchor resolving only in drft would 404 for a reader.
+
+A file the parser read defines an `anchors` list even when it has no headings, so
+an empty list is a fact rather than a silence. Anchors are what
+[`unresolved-fragment`](../rules/README.md) checks a link's fragment against.
+
 ## Configuration
 
 Declare a graph that uses the markdown parser:

--- a/docs/parsers/markdown.md
+++ b/docs/parsers/markdown.md
@@ -79,7 +79,10 @@ Two things define an address, because a reader's platform resolves both:
   heading rename stay addressable.
 
 YAML frontmatter is masked before parsing, so a single-key block's closing `---`
-is not read as a setext heading.
+is not read as a setext heading. The block has to parse as a YAML mapping to be
+masked — the same block the [frontmatter parser](frontmatter.md) consumes — so a
+document that merely opens with a `---` thematic break keeps its headings and its
+links.
 
 The slug downcases the heading's rendered text, drops every character that is not
 a letter, digit, combining mark, underscore, hyphen, or space, then turns spaces

--- a/docs/parsers/markdown.md
+++ b/docs/parsers/markdown.md
@@ -66,16 +66,29 @@ Images follow the same resolution rules as inline links -- the graph builder str
 ## Anchors
 
 The parser also records the `#fragment` addresses each file answers to, as
-`anchors` in its `markdown` node metadata: the GitHub slug of every heading, in
-document order, with GitHub's `-1` disambiguator when a slug repeats. Read them
-with `drft nodes <path> --field anchors`.
+`anchors` in its `markdown` node metadata, in document order. Read them with
+`drft nodes <path> --field anchors`.
+
+Two things define an address, because a reader's platform resolves both:
+
+- **A heading**, through the GitHub slug of its rendered text, with GitHub's `-1`
+  suffix when a slug repeats. The suffix is re-checked rather than appended, so a
+  document holding `a`, `a`, and a literal `a-1` yields `a`, `a-1`, `a-1-1`.
+- **A raw `<a id="…">` or `<a name="…">`**, verbatim and case-sensitive. This is
+  how a hand-rolled table of contents and a back-compat anchor kept after a
+  heading rename stay addressable.
+
+YAML frontmatter is masked before parsing, so a single-key block's closing `---`
+is not read as a setext heading.
 
 The slug downcases the heading's rendered text, drops every character that is not
-a letter, digit, underscore, hyphen, or space, then turns spaces into hyphens.
-Punctuation is **removed rather than replaced**, so a character between two
-spaces leaves both behind: `## Sizing — notes` answers to `#sizing--notes`, with
-two hyphens. A `{#custom}` attribute is not honored, because GitHub ignores it
-too and an anchor resolving only in drft would 404 for a reader.
+a letter, digit, combining mark, underscore, hyphen, or space, then turns spaces
+into hyphens. Punctuation is **removed rather than replaced**, so a character
+between two spaces leaves both behind: `## Sizing — notes` answers to
+`#sizing--notes`, with two hyphens. Rendered text excludes image alt text and
+inline HTML, which are not part of an element's text content. A `{#custom}`
+attribute is not honored, because GitHub ignores it too and an anchor resolving
+only in drft would 404 for a reader.
 
 A file the parser read defines an `anchors` list even when it has no headings, so
 an empty list is a fact rather than a silence. Anchors are what

--- a/docs/parsers/markdown.md
+++ b/docs/parsers/markdown.md
@@ -79,10 +79,10 @@ Two things define an address, because a reader's platform resolves both:
   heading rename stay addressable.
 
 YAML frontmatter is masked before parsing, so a single-key block's closing `---`
-is not read as a setext heading. The block has to parse as a YAML mapping to be
-masked — the same block the [frontmatter parser](frontmatter.md) consumes — so a
-document that merely opens with a `---` thematic break keeps its headings and its
-links.
+is not read as a setext heading. Where the block ends is the
+[frontmatter parser](frontmatter.md)'s call, not this one's: it has to parse as a
+YAML mapping, so a document that merely opens with a `---` thematic break keeps
+its headings and its links.
 
 The slug downcases the heading's rendered text, drops every character that is not
 a letter, digit, combining mark, underscore, hyphen, or space, then turns spaces

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -96,7 +96,14 @@ docs/guide.md
   @fs
     hash: b3:…
     type: file
+  @markdown
+    anchors: ["the-walk","scoping"]
 ```
+
+`anchors` are the `#fragment` addresses that file answers to — one per heading,
+in the flavor a reader's platform resolves. They are what makes a link's fragment
+checkable, and `drft nodes <path> --field anchors` is how to see what a file can
+be cited by.
 
 An edge block is `source → target`, then the same indented metadata:
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -31,15 +31,16 @@ The rule set is deliberately drift-focused. [`staleness.rs`](../../src/rules/sta
 derives the drift findings by joining the graph to the lockfile;
 [`structural.rs`](../../src/rules/structural.rs) derives the rest from graph shape.
 
-| Rule              | When                                                           |
-| ----------------- | -------------------------------------------------------------- |
-| `stale-node`      | A node's current hash differs from its locked hash             |
-| `stale-edge`      | An edge's locked target hash differs from the target's         |
-| `new-edge`        | A current edge has no locked target hash                       |
-| `removed-edge`    | The lockfile has an edge absent from the graph                 |
-| `removed-node`    | The lockfile has a node absent from the graph                  |
-| `unresolved-edge` | An edge target has no defining node (URIs excepted)            |
-| `detached-node`   | A node has no inbound or outbound edges (directories excepted) |
+| Rule                  | When                                                           |
+| --------------------- | -------------------------------------------------------------- |
+| `stale-node`          | A node's current hash differs from its locked hash             |
+| `stale-edge`          | An edge's locked target hash differs from the target's         |
+| `new-edge`            | A current edge has no locked target hash                       |
+| `removed-edge`        | The lockfile has an edge absent from the graph                 |
+| `removed-node`        | The lockfile has a node absent from the graph                  |
+| `unresolved-edge`     | An edge target has no defining node (URIs excepted)            |
+| `unresolved-fragment` | A link's `#fragment` names no anchor its target defines        |
+| `detached-node`       | A node has no inbound or outbound edges (directories excepted) |
 
 **A link to a directory tracks the directory, not its contents.** Directories are
 nodes, so the edge resolves and `unresolved-edge` stays quiet — but directories
@@ -57,6 +58,30 @@ check runs per link occurrence, so a target cited from several places carries th
 cause when any one of those links is bare — the finding names every line, and the
 cause describes the bare one. It renders as an indented line under the finding in
 text output and as a `cause` field in JSON.
+
+`unresolved-fragment` checks the other half of a link. A markdown parser
+publishes the `#fragment` addresses each file it reads answers to — the GitHub
+slug of every heading, in document order, with GitHub's `-1` disambiguator on a
+repeat — and a link carrying a fragment its target does not define is a broken
+reference that the file existing does not save. The finding names the citing line
+rather than the edge, so a source citing two anchors of one target implicates
+only the wrong one.
+
+Matching is exact, and deliberately so: drft slugs the **heading** and compares
+the fragment byte-for-byte, never slugging the citing side. Normalizing the
+fragment would accept `#OBS 92` for an `obs-92` anchor, which a browser sends as
+`#OBS%2092` and does not find — and certifying a link that 404s for a reader is
+the one thing sub-file addressing must not do. A fragment that matches an anchor
+once case is ignored carries a `cause` naming the anchor it meant; browsers do
+fall back to a case-insensitive match, so such a link works today and is fragile
+rather than broken.
+
+A fragment is only checked against a target some parser read. A link into a `.rs`
+file, or into a markdown file outside the graph's `files` scope, has **unknown**
+fragments rather than broken ones, and drft says nothing. A file that was read
+and defines no headings is the opposite case: every fragment into it is broken.
+An unresolvable target reports `unresolved-edge` alone — the fragment is the
+lesser half of the same mistake.
 
 A finding is about an item in the graph. A statement about the _run_ that
 produced it — an unknown rule name, a selector that matched nothing — is a

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -68,20 +68,34 @@ rather than the edge, so a source citing two anchors of one target implicates
 only the wrong one.
 
 Matching is exact, and deliberately so: drft slugs the **heading** and compares
-the fragment byte-for-byte, never slugging the citing side. Normalizing the
+the fragment to the result, never slugging the citing side. Normalizing the
 fragment would accept `#OBS 92` for an `obs-92` anchor, which a browser sends as
 `#OBS%2092` and does not find — and certifying a link that 404s for a reader is
-the one thing sub-file addressing must not do. A fragment that matches an anchor
-once case is ignored carries a `cause` naming the anchor it meant; browsers do
-fall back to a case-insensitive match, so such a link works today and is fragile
-rather than broken.
+the one thing sub-file addressing must not do.
+
+The one transformation drft does apply is percent-decoding, because a browser
+applies it too: `#caf%C3%A9` resolves to a `café` anchor, and a permalink copied
+from the address bar is encoded for any non-ASCII anchor. Decoding accepts
+exactly what the platform accepts and loosens nothing — `#OBS%2092` still decodes
+to `OBS 92` and still misses.
+
+Id matching is case-sensitive, so a fragment differing from an anchor only in
+case is broken rather than untidy. It carries a `cause` naming the anchor it
+meant, which makes the fix obvious without excusing it.
 
 A fragment is only checked against a target some parser read. A link into a `.rs`
-file, or into a markdown file outside the graph's `files` scope, has **unknown**
-fragments rather than broken ones, and drft says nothing. A file that was read
+file, into a symlink, or into a markdown file outside the graph's `files` scope
+has **unknown** fragments rather than broken ones, and drft says nothing. Only a
+graph whose parser publishes anchors is authoritative about them, so a file
+writing `anchors:` in its own frontmatter claims nothing. A file that was read
 and defines no headings is the opposite case: every fragment into it is broken.
 An unresolvable target reports `unresolved-edge` alone — the fragment is the
 lesser half of the same mistake.
+
+**Anchor-only links are not checked.** `[see](#section)` names no file, so it
+produces no edge and the rule never sees it — which is the most common broken
+fragment in a long document, and the gap worth knowing about. Write the path
+(`[see](./this-file.md#section)`) to have it checked.
 
 A finding is about an item in the graph. A statement about the _run_ that
 produced it — an unknown rule name, a selector that matched nothing — is a

--- a/drft.lock
+++ b/drft.lock
@@ -205,7 +205,7 @@ target_hash = "b3:3f462d3841e40b0b6e9eb79ebe63f8289695e9f51ba0dae761b639c5a58b6a
 
 [[node.edge]]
 target = "src/parsers/frontmatter.rs"
-target_hash = "b3:5743cdf7ba72bb239915cf9475d5703097a264ab8c093e9cdd743625c30cfa7c"
+target_hash = "b3:99e160bf6479d2eb5e558d6c4d3221f96eb25aa9e046581500ae52bd9755cd00"
 
 [[node]]
 path = "docs/parsers/markdown.md"
@@ -376,7 +376,7 @@ hash = "b3:bd63f170e88bb37482e7384aa3becb20cea1d7dfcf2be4b4ab79a8e636329920"
 
 [[node]]
 path = "src/parsers/frontmatter.rs"
-hash = "b3:5743cdf7ba72bb239915cf9475d5703097a264ab8c093e9cdd743625c30cfa7c"
+hash = "b3:99e160bf6479d2eb5e558d6c4d3221f96eb25aa9e046581500ae52bd9755cd00"
 
 [[node]]
 path = "src/parsers/markdown.rs"

--- a/drft.lock
+++ b/drft.lock
@@ -157,7 +157,7 @@ target_hash = "b3:202ad759d688b9521352cd639cd04706131d9e8b00b6362c6dd1f49283e902
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
-target_hash = "b3:09c7c7ccbcfe7acbcd4a2946af493aeba9eca41ec4419f70e474893f97825664"
+target_hash = "b3:808bf7247bc6b2fcb039f44176c6bd96023c6d9461d8d672e3d67db3414e5fc0"
 
 [[node.edge]]
 target = "docs/reading.md"
@@ -181,11 +181,11 @@ hash = "b3:202ad759d688b9521352cd639cd04706131d9e8b00b6362c6dd1f49283e90201"
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
-target_hash = "b3:09c7c7ccbcfe7acbcd4a2946af493aeba9eca41ec4419f70e474893f97825664"
+target_hash = "b3:808bf7247bc6b2fcb039f44176c6bd96023c6d9461d8d672e3d67db3414e5fc0"
 
 [[node.edge]]
 target = "docs/parsers/markdown.md"
-target_hash = "b3:3c45c124a1e046a85453b0bbac4e989ba0b55d89e0e86f10f6d4cc006d32f041"
+target_hash = "b3:3f462d3841e40b0b6e9eb79ebe63f8289695e9f51ba0dae761b639c5a58b6a84"
 
 [[node.edge]]
 target = "src/parsers/mod.rs"
@@ -193,7 +193,7 @@ target_hash = "b3:520ad18b8bb4fab4f1efce2913a0c59f2ab443f64178cd37cad77840b7f0b1
 
 [[node]]
 path = "docs/parsers/frontmatter.md"
-hash = "b3:09c7c7ccbcfe7acbcd4a2946af493aeba9eca41ec4419f70e474893f97825664"
+hash = "b3:808bf7247bc6b2fcb039f44176c6bd96023c6d9461d8d672e3d67db3414e5fc0"
 
 [[node.edge]]
 target = "docs/config.md"
@@ -201,15 +201,15 @@ target_hash = "b3:ba380aa56e9ff7a5cb6186ac81b46b93c01ca693f72e95e8156f79bc932b4f
 
 [[node.edge]]
 target = "docs/parsers/markdown.md"
-target_hash = "b3:3c45c124a1e046a85453b0bbac4e989ba0b55d89e0e86f10f6d4cc006d32f041"
+target_hash = "b3:3f462d3841e40b0b6e9eb79ebe63f8289695e9f51ba0dae761b639c5a58b6a84"
 
 [[node.edge]]
 target = "src/parsers/frontmatter.rs"
-target_hash = "b3:3e4d0a4120ff6bf7d9361a87a278361598af51b8865527e9c3a6e86a0cff9721"
+target_hash = "b3:5743cdf7ba72bb239915cf9475d5703097a264ab8c093e9cdd743625c30cfa7c"
 
 [[node]]
 path = "docs/parsers/markdown.md"
-hash = "b3:3c45c124a1e046a85453b0bbac4e989ba0b55d89e0e86f10f6d4cc006d32f041"
+hash = "b3:3f462d3841e40b0b6e9eb79ebe63f8289695e9f51ba0dae761b639c5a58b6a84"
 
 [[node.edge]]
 target = "docs/config.md"
@@ -217,7 +217,7 @@ target_hash = "b3:ba380aa56e9ff7a5cb6186ac81b46b93c01ca693f72e95e8156f79bc932b4f
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
-target_hash = "b3:09c7c7ccbcfe7acbcd4a2946af493aeba9eca41ec4419f70e474893f97825664"
+target_hash = "b3:808bf7247bc6b2fcb039f44176c6bd96023c6d9461d8d672e3d67db3414e5fc0"
 
 [[node.edge]]
 target = "docs/rules/README.md"
@@ -225,7 +225,7 @@ target_hash = "b3:d1b6f37e2efe0ac232d228624e8be281e1e8ef5ed997a3b84d23d9a525866c
 
 [[node.edge]]
 target = "src/parsers/markdown.rs"
-target_hash = "b3:96b3936ff8dfcd3ba6f9b1e2f7d03f3a62b286d21c95b22ad4b6ceda1943b5ed"
+target_hash = "b3:5cccff428d78c4982b68930ad7c58f8a11241125dad0f187e32b1965cca2d854"
 
 [[node]]
 path = "docs/reading.md"
@@ -376,11 +376,11 @@ hash = "b3:bd63f170e88bb37482e7384aa3becb20cea1d7dfcf2be4b4ab79a8e636329920"
 
 [[node]]
 path = "src/parsers/frontmatter.rs"
-hash = "b3:3e4d0a4120ff6bf7d9361a87a278361598af51b8865527e9c3a6e86a0cff9721"
+hash = "b3:5743cdf7ba72bb239915cf9475d5703097a264ab8c093e9cdd743625c30cfa7c"
 
 [[node]]
 path = "src/parsers/markdown.rs"
-hash = "b3:96b3936ff8dfcd3ba6f9b1e2f7d03f3a62b286d21c95b22ad4b6ceda1943b5ed"
+hash = "b3:5cccff428d78c4982b68930ad7c58f8a11241125dad0f187e32b1965cca2d854"
 
 [[node]]
 path = "src/parsers/mod.rs"

--- a/drft.lock
+++ b/drft.lock
@@ -42,11 +42,11 @@ hash = "b3:f50e039efee7e59f1379888cd90714d6bfafa933e50bc3a1091f3a485fad0b7d"
 
 [[node.edge]]
 target = "docs/parsers/README.md"
-target_hash = "b3:48af6aaf933bc63dc2f2c1ef5fb4ac77dbf9dddb695779a751d8a77f10e203ab"
+target_hash = "b3:202ad759d688b9521352cd639cd04706131d9e8b00b6362c6dd1f49283e90201"
 
 [[node.edge]]
 target = "docs/rules/README.md"
-target_hash = "b3:bbc772f4ff7c6af7b1e14301af78d01b6d872842384228706dfb99914755f38b"
+target_hash = "b3:c55aabac2eb8acf0488cd948494d83c7d2541768fee3ef26a277e2957577c41f"
 
 [[node.edge]]
 target = "src/builders/mod.rs"
@@ -58,7 +58,7 @@ target_hash = "b3:b1a7dc9621d4ff6bceb9d4e1b527a7c4abefe22cd7c996397b8f0ad3e63413
 
 [[node.edge]]
 target = "src/config.rs"
-target_hash = "b3:c104de3d28c807222a580baf8bdca01c09bb8512291b3b7c6e2fd6a55b8b0909"
+target_hash = "b3:933e9d19c3efca323b350ffbc8c8f36badd802abcfdd926631006ca67c25dd6d"
 
 [[node.edge]]
 target = "src/graphs/mod.rs"
@@ -70,11 +70,11 @@ target_hash = "b3:59d5b59a2415a93ab85f45c4dbd746c1c0050f2edbfe2a326b9dbc613b1778
 
 [[node.edge]]
 target = "src/model.rs"
-target_hash = "b3:222c335163926dfcf8b652e30588b06b40d86717627388bbcb8900595800468f"
+target_hash = "b3:bbf1a5d187ba9aa49c3fd99004e62f357cce05d96282193e0ef6654e8968c5a4"
 
 [[node.edge]]
 target = "src/parsers/mod.rs"
-target_hash = "b3:d17d93b9838e4703720bafd4150e1dee5653416cb080218716ae21a5c615c3c7"
+target_hash = "b3:520ad18b8bb4fab4f1efce2913a0c59f2ab443f64178cd37cad77840b7f0b1b7"
 
 [[node.edge]]
 target = "src/rules/check.rs"
@@ -114,7 +114,7 @@ target_hash = "b3:ba380aa56e9ff7a5cb6186ac81b46b93c01ca693f72e95e8156f79bc932b4f
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:bd326b3f2f83e645a0970132aa928069e4188fa820524f8d4bc507dbb71892de"
+target_hash = "b3:0cdc5fd29704fe11da05b636ddbce6e2c40ad380f618f85a8d1905aacca905ea"
 
 [[node.edge]]
 target = "https://github.com/johnmdonahue/drft-cli/releases"
@@ -137,15 +137,15 @@ target_hash = "b3:ba380aa56e9ff7a5cb6186ac81b46b93c01ca693f72e95e8156f79bc932b4f
 
 [[node.edge]]
 target = "docs/parsers/README.md"
-target_hash = "b3:48af6aaf933bc63dc2f2c1ef5fb4ac77dbf9dddb695779a751d8a77f10e203ab"
+target_hash = "b3:202ad759d688b9521352cd639cd04706131d9e8b00b6362c6dd1f49283e90201"
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:bd326b3f2f83e645a0970132aa928069e4188fa820524f8d4bc507dbb71892de"
+target_hash = "b3:0cdc5fd29704fe11da05b636ddbce6e2c40ad380f618f85a8d1905aacca905ea"
 
 [[node.edge]]
 target = "docs/rules/README.md"
-target_hash = "b3:bbc772f4ff7c6af7b1e14301af78d01b6d872842384228706dfb99914755f38b"
+target_hash = "b3:c55aabac2eb8acf0488cd948494d83c7d2541768fee3ef26a277e2957577c41f"
 
 [[node]]
 path = "docs/config.md"
@@ -153,7 +153,7 @@ hash = "b3:ba380aa56e9ff7a5cb6186ac81b46b93c01ca693f72e95e8156f79bc932b4f7d"
 
 [[node.edge]]
 target = "docs/parsers/README.md"
-target_hash = "b3:48af6aaf933bc63dc2f2c1ef5fb4ac77dbf9dddb695779a751d8a77f10e203ab"
+target_hash = "b3:202ad759d688b9521352cd639cd04706131d9e8b00b6362c6dd1f49283e90201"
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
@@ -161,11 +161,11 @@ target_hash = "b3:8afef0115e1a9bcd5d6605be78439fa1d80a72b5bbdd833199a0aa76328a5b
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:bd326b3f2f83e645a0970132aa928069e4188fa820524f8d4bc507dbb71892de"
+target_hash = "b3:0cdc5fd29704fe11da05b636ddbce6e2c40ad380f618f85a8d1905aacca905ea"
 
 [[node.edge]]
 target = "docs/rules/README.md"
-target_hash = "b3:bbc772f4ff7c6af7b1e14301af78d01b6d872842384228706dfb99914755f38b"
+target_hash = "b3:c55aabac2eb8acf0488cd948494d83c7d2541768fee3ef26a277e2957577c41f"
 
 [[node.edge]]
 target = "src/cli.rs"
@@ -173,11 +173,11 @@ target_hash = "b3:5f396f41a7ac62dc62594654290ade1d0ea53491a526ffcc8b5b856e5158f7
 
 [[node.edge]]
 target = "src/config.rs"
-target_hash = "b3:c104de3d28c807222a580baf8bdca01c09bb8512291b3b7c6e2fd6a55b8b0909"
+target_hash = "b3:933e9d19c3efca323b350ffbc8c8f36badd802abcfdd926631006ca67c25dd6d"
 
 [[node]]
 path = "docs/parsers/README.md"
-hash = "b3:48af6aaf933bc63dc2f2c1ef5fb4ac77dbf9dddb695779a751d8a77f10e203ab"
+hash = "b3:202ad759d688b9521352cd639cd04706131d9e8b00b6362c6dd1f49283e90201"
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
@@ -185,11 +185,11 @@ target_hash = "b3:8afef0115e1a9bcd5d6605be78439fa1d80a72b5bbdd833199a0aa76328a5b
 
 [[node.edge]]
 target = "docs/parsers/markdown.md"
-target_hash = "b3:cdcd2634e3a22bafd63cb6535565d453e7b5ee85728747b11f2f71bf718373c8"
+target_hash = "b3:1e1ea912352d723b20f20818ff54cb0395f063700574ca51eb180a710ce41590"
 
 [[node.edge]]
 target = "src/parsers/mod.rs"
-target_hash = "b3:d17d93b9838e4703720bafd4150e1dee5653416cb080218716ae21a5c615c3c7"
+target_hash = "b3:520ad18b8bb4fab4f1efce2913a0c59f2ab443f64178cd37cad77840b7f0b1b7"
 
 [[node]]
 path = "docs/parsers/frontmatter.md"
@@ -201,11 +201,11 @@ target_hash = "b3:ba380aa56e9ff7a5cb6186ac81b46b93c01ca693f72e95e8156f79bc932b4f
 
 [[node.edge]]
 target = "src/parsers/frontmatter.rs"
-target_hash = "b3:3141acca048acfba229b56cd48b537988a2e5d8091fd0eb01e7e47c9926c345f"
+target_hash = "b3:9e0212f666001b7093064bab0a76e81200885de12a942ba619e8b32c1f4c62db"
 
 [[node]]
 path = "docs/parsers/markdown.md"
-hash = "b3:cdcd2634e3a22bafd63cb6535565d453e7b5ee85728747b11f2f71bf718373c8"
+hash = "b3:1e1ea912352d723b20f20818ff54cb0395f063700574ca51eb180a710ce41590"
 
 [[node.edge]]
 target = "docs/config.md"
@@ -216,12 +216,16 @@ target = "docs/parsers/frontmatter.md"
 target_hash = "b3:8afef0115e1a9bcd5d6605be78439fa1d80a72b5bbdd833199a0aa76328a5b1c"
 
 [[node.edge]]
+target = "docs/rules/README.md"
+target_hash = "b3:c55aabac2eb8acf0488cd948494d83c7d2541768fee3ef26a277e2957577c41f"
+
+[[node.edge]]
 target = "src/parsers/markdown.rs"
-target_hash = "b3:952fafe8eb3a776168da8ec935438fbd39de4599375f1c0e82334d3dd8d36183"
+target_hash = "b3:046c07d1035eed5d0bb3446004b7236093a25999d79580f8d61e065e71e06dd0"
 
 [[node]]
 path = "docs/reading.md"
-hash = "b3:bd326b3f2f83e645a0970132aa928069e4188fa820524f8d4bc507dbb71892de"
+hash = "b3:0cdc5fd29704fe11da05b636ddbce6e2c40ad380f618f85a8d1905aacca905ea"
 
 [[node.edge]]
 target = "src/cli.rs"
@@ -229,7 +233,7 @@ target_hash = "b3:5f396f41a7ac62dc62594654290ade1d0ea53491a526ffcc8b5b856e5158f7
 
 [[node.edge]]
 target = "src/config.rs"
-target_hash = "b3:c104de3d28c807222a580baf8bdca01c09bb8512291b3b7c6e2fd6a55b8b0909"
+target_hash = "b3:933e9d19c3efca323b350ffbc8c8f36badd802abcfdd926631006ca67c25dd6d"
 
 [[node.edge]]
 target = "src/edges.rs"
@@ -253,15 +257,15 @@ target_hash = "b3:977a3c47ee9ee201e25f4f1d091939ea1212c4947f38a6732c3a7bde1da995
 
 [[node]]
 path = "docs/rules/README.md"
-hash = "b3:bbc772f4ff7c6af7b1e14301af78d01b6d872842384228706dfb99914755f38b"
+hash = "b3:c55aabac2eb8acf0488cd948494d83c7d2541768fee3ef26a277e2957577c41f"
 
 [[node.edge]]
 target = "docs/reading.md"
-target_hash = "b3:bd326b3f2f83e645a0970132aa928069e4188fa820524f8d4bc507dbb71892de"
+target_hash = "b3:0cdc5fd29704fe11da05b636ddbce6e2c40ad380f618f85a8d1905aacca905ea"
 
 [[node.edge]]
 target = "src/config.rs"
-target_hash = "b3:c104de3d28c807222a580baf8bdca01c09bb8512291b3b7c6e2fd6a55b8b0909"
+target_hash = "b3:933e9d19c3efca323b350ffbc8c8f36badd802abcfdd926631006ca67c25dd6d"
 
 [[node.edge]]
 target = "src/rules/staleness.rs"
@@ -269,7 +273,7 @@ target_hash = "b3:f592a8dd3264b1975fbfc2da5958b0a5999efa513b2ca51b2a9df5fa602e38
 
 [[node.edge]]
 target = "src/rules/structural.rs"
-target_hash = "b3:0aeb7415b4b0b62567d8840b1d29aadaef76a839bad5eae6d38f5fbc8273cdba"
+target_hash = "b3:bc428141e03787b54eeb6ac493e1e70418c838fc9eed05024054aa53990616b7"
 
 [[node]]
 path = "dprint.json"
@@ -308,7 +312,7 @@ hash = "b3:14212926d3fcfab0fbe79bf252ce172ce7cbea13ad8734b89b3f95737384b288"
 
 [[node]]
 path = "src/builders/markdown.rs"
-hash = "b3:901fc388ed6053b7f980928172dd0fcced4ce0639ec05c1129c87da656fa5e78"
+hash = "b3:368d6412c44f03cb2df4d21bc73f5673a722d7cba11cc67bfc52b988aa2bc525"
 
 [[node]]
 path = "src/builders/mod.rs"
@@ -324,7 +328,7 @@ hash = "b3:b1a7dc9621d4ff6bceb9d4e1b527a7c4abefe22cd7c996397b8f0ad3e6341391"
 
 [[node]]
 path = "src/config.rs"
-hash = "b3:c104de3d28c807222a580baf8bdca01c09bb8512291b3b7c6e2fd6a55b8b0909"
+hash = "b3:933e9d19c3efca323b350ffbc8c8f36badd802abcfdd926631006ca67c25dd6d"
 
 [[node]]
 path = "src/diagnostic.rs"
@@ -360,7 +364,7 @@ hash = "b3:c71943a64bb40d63c27270ee960a4a58cb3d39e03e60886cd49beee0f652fb38"
 
 [[node]]
 path = "src/model.rs"
-hash = "b3:222c335163926dfcf8b652e30588b06b40d86717627388bbcb8900595800468f"
+hash = "b3:bbf1a5d187ba9aa49c3fd99004e62f357cce05d96282193e0ef6654e8968c5a4"
 
 [[node]]
 path = "src/nodes.rs"
@@ -368,15 +372,19 @@ hash = "b3:bd63f170e88bb37482e7384aa3becb20cea1d7dfcf2be4b4ab79a8e636329920"
 
 [[node]]
 path = "src/parsers/frontmatter.rs"
-hash = "b3:3141acca048acfba229b56cd48b537988a2e5d8091fd0eb01e7e47c9926c345f"
+hash = "b3:9e0212f666001b7093064bab0a76e81200885de12a942ba619e8b32c1f4c62db"
 
 [[node]]
 path = "src/parsers/markdown.rs"
-hash = "b3:952fafe8eb3a776168da8ec935438fbd39de4599375f1c0e82334d3dd8d36183"
+hash = "b3:046c07d1035eed5d0bb3446004b7236093a25999d79580f8d61e065e71e06dd0"
 
 [[node]]
 path = "src/parsers/mod.rs"
-hash = "b3:d17d93b9838e4703720bafd4150e1dee5653416cb080218716ae21a5c615c3c7"
+hash = "b3:520ad18b8bb4fab4f1efce2913a0c59f2ab443f64178cd37cad77840b7f0b1b7"
+
+[[node]]
+path = "src/parsers/slug.rs"
+hash = "b3:f35fb73997a32bf23db0ba36fb951430d8b48101dc4e430f06105b60b1f97b62"
 
 [[node]]
 path = "src/projection.rs"
@@ -396,7 +404,7 @@ hash = "b3:f592a8dd3264b1975fbfc2da5958b0a5999efa513b2ca51b2a9df5fa602e388d"
 
 [[node]]
 path = "src/rules/structural.rs"
-hash = "b3:0aeb7415b4b0b62567d8840b1d29aadaef76a839bad5eae6d38f5fbc8273cdba"
+hash = "b3:bc428141e03787b54eeb6ac493e1e70418c838fc9eed05024054aa53990616b7"
 
 [[node]]
 path = "src/sources/fs.rs"
@@ -424,7 +432,7 @@ hash = "b3:8e7a74efdcda6af80492e61235019353248b34aecb485f0d1cd7ae27ff489fd1"
 
 [[node]]
 path = "tests/graph.rs"
-hash = "b3:d9ea0b837a0b894e3d5123a036e89ce832aa69b78044c17bb8134d3fd904c3b3"
+hash = "b3:153e1893885689f0e81ff501180c0983b76414b37fae31fca408d6083f5f0be8"
 
 [[node]]
 path = "tests/hints.rs"
@@ -456,4 +464,4 @@ hash = "b3:e4c83976b9be3fd4906a951c899db03296c99e19b239d667a57c1d48361f4b61"
 
 [[node]]
 path = "tests/rules.rs"
-hash = "b3:b3b96ee4d7be48d3c430a150873f911de90e9914d6e6a45f680d9223749ea172"
+hash = "b3:2ec8f0de281ce8f1d283496b9d49b515b36d6391ee9d5a78ba3540695ce0003b"

--- a/drft.lock
+++ b/drft.lock
@@ -225,7 +225,7 @@ target_hash = "b3:d1b6f37e2efe0ac232d228624e8be281e1e8ef5ed997a3b84d23d9a525866c
 
 [[node.edge]]
 target = "src/parsers/markdown.rs"
-target_hash = "b3:5cccff428d78c4982b68930ad7c58f8a11241125dad0f187e32b1965cca2d854"
+target_hash = "b3:18002cb9940bf73b27fe61d9c3e3b79c7eafcdc583113a46d5e10636b025f3f0"
 
 [[node]]
 path = "docs/reading.md"
@@ -380,7 +380,7 @@ hash = "b3:43e7c3afac8f6c0df08827c8a3676a01c7d9fee024a6d555f42be8c819396d22"
 
 [[node]]
 path = "src/parsers/markdown.rs"
-hash = "b3:5cccff428d78c4982b68930ad7c58f8a11241125dad0f187e32b1965cca2d854"
+hash = "b3:18002cb9940bf73b27fe61d9c3e3b79c7eafcdc583113a46d5e10636b025f3f0"
 
 [[node]]
 path = "src/parsers/mod.rs"

--- a/drft.lock
+++ b/drft.lock
@@ -157,7 +157,7 @@ target_hash = "b3:202ad759d688b9521352cd639cd04706131d9e8b00b6362c6dd1f49283e902
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
-target_hash = "b3:808bf7247bc6b2fcb039f44176c6bd96023c6d9461d8d672e3d67db3414e5fc0"
+target_hash = "b3:fe2591d2802ee4d2dad650f202952348cda27afd5b73f57e6d208bb8be1571fb"
 
 [[node.edge]]
 target = "docs/reading.md"
@@ -181,7 +181,7 @@ hash = "b3:202ad759d688b9521352cd639cd04706131d9e8b00b6362c6dd1f49283e90201"
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
-target_hash = "b3:808bf7247bc6b2fcb039f44176c6bd96023c6d9461d8d672e3d67db3414e5fc0"
+target_hash = "b3:fe2591d2802ee4d2dad650f202952348cda27afd5b73f57e6d208bb8be1571fb"
 
 [[node.edge]]
 target = "docs/parsers/markdown.md"
@@ -193,7 +193,7 @@ target_hash = "b3:520ad18b8bb4fab4f1efce2913a0c59f2ab443f64178cd37cad77840b7f0b1
 
 [[node]]
 path = "docs/parsers/frontmatter.md"
-hash = "b3:808bf7247bc6b2fcb039f44176c6bd96023c6d9461d8d672e3d67db3414e5fc0"
+hash = "b3:fe2591d2802ee4d2dad650f202952348cda27afd5b73f57e6d208bb8be1571fb"
 
 [[node.edge]]
 target = "docs/config.md"
@@ -205,7 +205,7 @@ target_hash = "b3:3f462d3841e40b0b6e9eb79ebe63f8289695e9f51ba0dae761b639c5a58b6a
 
 [[node.edge]]
 target = "src/parsers/frontmatter.rs"
-target_hash = "b3:99e160bf6479d2eb5e558d6c4d3221f96eb25aa9e046581500ae52bd9755cd00"
+target_hash = "b3:6426321395379e9d3d4e30878af59bbf445ce1055e50c7df5394340dc637ba82"
 
 [[node]]
 path = "docs/parsers/markdown.md"
@@ -217,7 +217,7 @@ target_hash = "b3:ba380aa56e9ff7a5cb6186ac81b46b93c01ca693f72e95e8156f79bc932b4f
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
-target_hash = "b3:808bf7247bc6b2fcb039f44176c6bd96023c6d9461d8d672e3d67db3414e5fc0"
+target_hash = "b3:fe2591d2802ee4d2dad650f202952348cda27afd5b73f57e6d208bb8be1571fb"
 
 [[node.edge]]
 target = "docs/rules/README.md"
@@ -376,7 +376,7 @@ hash = "b3:bd63f170e88bb37482e7384aa3becb20cea1d7dfcf2be4b4ab79a8e636329920"
 
 [[node]]
 path = "src/parsers/frontmatter.rs"
-hash = "b3:99e160bf6479d2eb5e558d6c4d3221f96eb25aa9e046581500ae52bd9755cd00"
+hash = "b3:6426321395379e9d3d4e30878af59bbf445ce1055e50c7df5394340dc637ba82"
 
 [[node]]
 path = "src/parsers/markdown.rs"

--- a/drft.lock
+++ b/drft.lock
@@ -205,7 +205,7 @@ target_hash = "b3:3f462d3841e40b0b6e9eb79ebe63f8289695e9f51ba0dae761b639c5a58b6a
 
 [[node.edge]]
 target = "src/parsers/frontmatter.rs"
-target_hash = "b3:6426321395379e9d3d4e30878af59bbf445ce1055e50c7df5394340dc637ba82"
+target_hash = "b3:43e7c3afac8f6c0df08827c8a3676a01c7d9fee024a6d555f42be8c819396d22"
 
 [[node]]
 path = "docs/parsers/markdown.md"
@@ -376,7 +376,7 @@ hash = "b3:bd63f170e88bb37482e7384aa3becb20cea1d7dfcf2be4b4ab79a8e636329920"
 
 [[node]]
 path = "src/parsers/frontmatter.rs"
-hash = "b3:6426321395379e9d3d4e30878af59bbf445ce1055e50c7df5394340dc637ba82"
+hash = "b3:43e7c3afac8f6c0df08827c8a3676a01c7d9fee024a6d555f42be8c819396d22"
 
 [[node]]
 path = "src/parsers/markdown.rs"

--- a/drft.lock
+++ b/drft.lock
@@ -46,11 +46,11 @@ target_hash = "b3:202ad759d688b9521352cd639cd04706131d9e8b00b6362c6dd1f49283e902
 
 [[node.edge]]
 target = "docs/rules/README.md"
-target_hash = "b3:c55aabac2eb8acf0488cd948494d83c7d2541768fee3ef26a277e2957577c41f"
+target_hash = "b3:d1b6f37e2efe0ac232d228624e8be281e1e8ef5ed997a3b84d23d9a525866ce0"
 
 [[node.edge]]
 target = "src/builders/mod.rs"
-target_hash = "b3:23ba2ad44e3adf59cc9f67cff5450a6d01644469852caef9cadd52da70510392"
+target_hash = "b3:ae67a35ee250ecd151d8e57df4277b28a908b6727d76c130527db0663ebf4d13"
 
 [[node.edge]]
 target = "src/compose.rs"
@@ -58,7 +58,7 @@ target_hash = "b3:b1a7dc9621d4ff6bceb9d4e1b527a7c4abefe22cd7c996397b8f0ad3e63413
 
 [[node.edge]]
 target = "src/config.rs"
-target_hash = "b3:933e9d19c3efca323b350ffbc8c8f36badd802abcfdd926631006ca67c25dd6d"
+target_hash = "b3:71ee3ac5b374ebefdcc0dd9db863ac86cd4dfbfa0052b18fc86427f0de13e8da"
 
 [[node.edge]]
 target = "src/graphs/mod.rs"
@@ -70,7 +70,7 @@ target_hash = "b3:59d5b59a2415a93ab85f45c4dbd746c1c0050f2edbfe2a326b9dbc613b1778
 
 [[node.edge]]
 target = "src/model.rs"
-target_hash = "b3:bbf1a5d187ba9aa49c3fd99004e62f357cce05d96282193e0ef6654e8968c5a4"
+target_hash = "b3:4bff522a597da301480a34ed3d8c61eca85277e93f6ed1f173b8f84db49b33e1"
 
 [[node.edge]]
 target = "src/parsers/mod.rs"
@@ -78,7 +78,7 @@ target_hash = "b3:520ad18b8bb4fab4f1efce2913a0c59f2ab443f64178cd37cad77840b7f0b1
 
 [[node.edge]]
 target = "src/rules/check.rs"
-target_hash = "b3:eb2f3748fa8b147fa1823efbe6bc77a2cf63369b0c180d7ca366f9bd2ceb9847"
+target_hash = "b3:d2dbd0cbbfecc2d0681b0860cb9e29d982f44d4a1a8d0fff39ff56665cd07731"
 
 [[node.edge]]
 target = "src/sources/fs.rs"
@@ -90,7 +90,7 @@ target_hash = "b3:6ce4d5c42026071af2b68201e9debff0112ad9d9d8d8fc75d16d562d5fc1a7
 
 [[node]]
 path = "Cargo.toml"
-hash = "b3:68026886493ded605187c01e6f0089e5a415bceda8c114125e9722d3f94879b5"
+hash = "b3:88647d4cec1e9c7d24d531c2afb5d8b08cef2410cb12f0a65641c183aa69fc2d"
 
 [[node]]
 path = "LICENSE"
@@ -98,7 +98,7 @@ hash = "b3:871c2fd5cdfe89fa6ff01664a1420bf40d0ab18c0e250e59a3ab27225f31bb0e"
 
 [[node]]
 path = "README.md"
-hash = "b3:86a61e65fb8a20fe95454b3bb829c00918218c3361c622a186d3d0b50c25e690"
+hash = "b3:cb68820093cc3174fb7ec675c4a412d7158086c0cc1576f663a250276abaeb32"
 
 [[node.edge]]
 target = "CLAUDE.md"
@@ -106,7 +106,7 @@ target_hash = "b3:f0ef1960837ebcd537416d01eb040e1c6ef97510319887bcd9f183efc10ee6
 
 [[node.edge]]
 target = "docs/README.md"
-target_hash = "b3:e0338d05e8cc7dda9065e6542aed0cf9527000af48983f8468b3678802ecdf78"
+target_hash = "b3:c30b2ff12152bf7e937087e664461ed7b845d3aa7b266a38aac5a7e98b872a59"
 
 [[node.edge]]
 target = "docs/config.md"
@@ -129,7 +129,7 @@ hash = "b3:70c1b3ef7b655bf68cbb1a35b6d9683924c97b34b9f6647f9aef507ef116cebf"
 
 [[node]]
 path = "docs/README.md"
-hash = "b3:e0338d05e8cc7dda9065e6542aed0cf9527000af48983f8468b3678802ecdf78"
+hash = "b3:c30b2ff12152bf7e937087e664461ed7b845d3aa7b266a38aac5a7e98b872a59"
 
 [[node.edge]]
 target = "docs/config.md"
@@ -145,7 +145,7 @@ target_hash = "b3:0cdc5fd29704fe11da05b636ddbce6e2c40ad380f618f85a8d1905aacca905
 
 [[node.edge]]
 target = "docs/rules/README.md"
-target_hash = "b3:c55aabac2eb8acf0488cd948494d83c7d2541768fee3ef26a277e2957577c41f"
+target_hash = "b3:d1b6f37e2efe0ac232d228624e8be281e1e8ef5ed997a3b84d23d9a525866ce0"
 
 [[node]]
 path = "docs/config.md"
@@ -165,7 +165,7 @@ target_hash = "b3:0cdc5fd29704fe11da05b636ddbce6e2c40ad380f618f85a8d1905aacca905
 
 [[node.edge]]
 target = "docs/rules/README.md"
-target_hash = "b3:c55aabac2eb8acf0488cd948494d83c7d2541768fee3ef26a277e2957577c41f"
+target_hash = "b3:d1b6f37e2efe0ac232d228624e8be281e1e8ef5ed997a3b84d23d9a525866ce0"
 
 [[node.edge]]
 target = "src/cli.rs"
@@ -173,7 +173,7 @@ target_hash = "b3:5f396f41a7ac62dc62594654290ade1d0ea53491a526ffcc8b5b856e5158f7
 
 [[node.edge]]
 target = "src/config.rs"
-target_hash = "b3:933e9d19c3efca323b350ffbc8c8f36badd802abcfdd926631006ca67c25dd6d"
+target_hash = "b3:71ee3ac5b374ebefdcc0dd9db863ac86cd4dfbfa0052b18fc86427f0de13e8da"
 
 [[node]]
 path = "docs/parsers/README.md"
@@ -185,7 +185,7 @@ target_hash = "b3:8afef0115e1a9bcd5d6605be78439fa1d80a72b5bbdd833199a0aa76328a5b
 
 [[node.edge]]
 target = "docs/parsers/markdown.md"
-target_hash = "b3:1e1ea912352d723b20f20818ff54cb0395f063700574ca51eb180a710ce41590"
+target_hash = "b3:3e59f218419ca388fd3d981e71dc62248dd05cc6885622650549807f7f604e27"
 
 [[node.edge]]
 target = "src/parsers/mod.rs"
@@ -205,7 +205,7 @@ target_hash = "b3:9e0212f666001b7093064bab0a76e81200885de12a942ba619e8b32c1f4c62
 
 [[node]]
 path = "docs/parsers/markdown.md"
-hash = "b3:1e1ea912352d723b20f20818ff54cb0395f063700574ca51eb180a710ce41590"
+hash = "b3:3e59f218419ca388fd3d981e71dc62248dd05cc6885622650549807f7f604e27"
 
 [[node.edge]]
 target = "docs/config.md"
@@ -217,11 +217,11 @@ target_hash = "b3:8afef0115e1a9bcd5d6605be78439fa1d80a72b5bbdd833199a0aa76328a5b
 
 [[node.edge]]
 target = "docs/rules/README.md"
-target_hash = "b3:c55aabac2eb8acf0488cd948494d83c7d2541768fee3ef26a277e2957577c41f"
+target_hash = "b3:d1b6f37e2efe0ac232d228624e8be281e1e8ef5ed997a3b84d23d9a525866ce0"
 
 [[node.edge]]
 target = "src/parsers/markdown.rs"
-target_hash = "b3:046c07d1035eed5d0bb3446004b7236093a25999d79580f8d61e065e71e06dd0"
+target_hash = "b3:c51f4969a87b322277ea06d942f5a4a45adbd9b64d9157ff4635e71e36ee064f"
 
 [[node]]
 path = "docs/reading.md"
@@ -233,7 +233,7 @@ target_hash = "b3:5f396f41a7ac62dc62594654290ade1d0ea53491a526ffcc8b5b856e5158f7
 
 [[node.edge]]
 target = "src/config.rs"
-target_hash = "b3:933e9d19c3efca323b350ffbc8c8f36badd802abcfdd926631006ca67c25dd6d"
+target_hash = "b3:71ee3ac5b374ebefdcc0dd9db863ac86cd4dfbfa0052b18fc86427f0de13e8da"
 
 [[node.edge]]
 target = "src/edges.rs"
@@ -257,7 +257,7 @@ target_hash = "b3:977a3c47ee9ee201e25f4f1d091939ea1212c4947f38a6732c3a7bde1da995
 
 [[node]]
 path = "docs/rules/README.md"
-hash = "b3:c55aabac2eb8acf0488cd948494d83c7d2541768fee3ef26a277e2957577c41f"
+hash = "b3:d1b6f37e2efe0ac232d228624e8be281e1e8ef5ed997a3b84d23d9a525866ce0"
 
 [[node.edge]]
 target = "docs/reading.md"
@@ -265,7 +265,7 @@ target_hash = "b3:0cdc5fd29704fe11da05b636ddbce6e2c40ad380f618f85a8d1905aacca905
 
 [[node.edge]]
 target = "src/config.rs"
-target_hash = "b3:933e9d19c3efca323b350ffbc8c8f36badd802abcfdd926631006ca67c25dd6d"
+target_hash = "b3:71ee3ac5b374ebefdcc0dd9db863ac86cd4dfbfa0052b18fc86427f0de13e8da"
 
 [[node.edge]]
 target = "src/rules/staleness.rs"
@@ -273,7 +273,7 @@ target_hash = "b3:f592a8dd3264b1975fbfc2da5958b0a5999efa513b2ca51b2a9df5fa602e38
 
 [[node.edge]]
 target = "src/rules/structural.rs"
-target_hash = "b3:bc428141e03787b54eeb6ac493e1e70418c838fc9eed05024054aa53990616b7"
+target_hash = "b3:7f2008340051f32e747b64439c5d43d9689d01c9f96f187117754479e0323a58"
 
 [[node]]
 path = "dprint.json"
@@ -316,7 +316,7 @@ hash = "b3:368d6412c44f03cb2df4d21bc73f5673a722d7cba11cc67bfc52b988aa2bc525"
 
 [[node]]
 path = "src/builders/mod.rs"
-hash = "b3:23ba2ad44e3adf59cc9f67cff5450a6d01644469852caef9cadd52da70510392"
+hash = "b3:ae67a35ee250ecd151d8e57df4277b28a908b6727d76c130527db0663ebf4d13"
 
 [[node]]
 path = "src/cli.rs"
@@ -328,11 +328,11 @@ hash = "b3:b1a7dc9621d4ff6bceb9d4e1b527a7c4abefe22cd7c996397b8f0ad3e6341391"
 
 [[node]]
 path = "src/config.rs"
-hash = "b3:933e9d19c3efca323b350ffbc8c8f36badd802abcfdd926631006ca67c25dd6d"
+hash = "b3:71ee3ac5b374ebefdcc0dd9db863ac86cd4dfbfa0052b18fc86427f0de13e8da"
 
 [[node]]
 path = "src/diagnostic.rs"
-hash = "b3:686eaca6b31c4c7ef9e14249cb952ee64031d6a9bfe2eff49cfe91a77002ce98"
+hash = "b3:453d539a154acd8da484f882cb867f1486fb517afedc5bcabbc95762c9d535cd"
 
 [[node]]
 path = "src/edges.rs"
@@ -364,7 +364,7 @@ hash = "b3:c71943a64bb40d63c27270ee960a4a58cb3d39e03e60886cd49beee0f652fb38"
 
 [[node]]
 path = "src/model.rs"
-hash = "b3:bbf1a5d187ba9aa49c3fd99004e62f357cce05d96282193e0ef6654e8968c5a4"
+hash = "b3:4bff522a597da301480a34ed3d8c61eca85277e93f6ed1f173b8f84db49b33e1"
 
 [[node]]
 path = "src/nodes.rs"
@@ -376,7 +376,7 @@ hash = "b3:9e0212f666001b7093064bab0a76e81200885de12a942ba619e8b32c1f4c62db"
 
 [[node]]
 path = "src/parsers/markdown.rs"
-hash = "b3:046c07d1035eed5d0bb3446004b7236093a25999d79580f8d61e065e71e06dd0"
+hash = "b3:c51f4969a87b322277ea06d942f5a4a45adbd9b64d9157ff4635e71e36ee064f"
 
 [[node]]
 path = "src/parsers/mod.rs"
@@ -384,7 +384,7 @@ hash = "b3:520ad18b8bb4fab4f1efce2913a0c59f2ab443f64178cd37cad77840b7f0b1b7"
 
 [[node]]
 path = "src/parsers/slug.rs"
-hash = "b3:f35fb73997a32bf23db0ba36fb951430d8b48101dc4e430f06105b60b1f97b62"
+hash = "b3:25b3d0cfb5577d50ad2a1fe04c4f3a2de261f16f2b1f6d84328e8edd5a6c29a0"
 
 [[node]]
 path = "src/projection.rs"
@@ -392,7 +392,7 @@ hash = "b3:977a3c47ee9ee201e25f4f1d091939ea1212c4947f38a6732c3a7bde1da99599"
 
 [[node]]
 path = "src/rules/check.rs"
-hash = "b3:eb2f3748fa8b147fa1823efbe6bc77a2cf63369b0c180d7ca366f9bd2ceb9847"
+hash = "b3:d2dbd0cbbfecc2d0681b0860cb9e29d982f44d4a1a8d0fff39ff56665cd07731"
 
 [[node]]
 path = "src/rules/mod.rs"
@@ -404,7 +404,7 @@ hash = "b3:f592a8dd3264b1975fbfc2da5958b0a5999efa513b2ca51b2a9df5fa602e388d"
 
 [[node]]
 path = "src/rules/structural.rs"
-hash = "b3:bc428141e03787b54eeb6ac493e1e70418c838fc9eed05024054aa53990616b7"
+hash = "b3:7f2008340051f32e747b64439c5d43d9689d01c9f96f187117754479e0323a58"
 
 [[node]]
 path = "src/sources/fs.rs"
@@ -464,4 +464,4 @@ hash = "b3:e4c83976b9be3fd4906a951c899db03296c99e19b239d667a57c1d48361f4b61"
 
 [[node]]
 path = "tests/rules.rs"
-hash = "b3:2ec8f0de281ce8f1d283496b9d49b515b36d6391ee9d5a78ba3540695ce0003b"
+hash = "b3:c6a071f2c93046d26b7f93103866437f7dec24111474c44eb59b35f77e7b3450"

--- a/drft.lock
+++ b/drft.lock
@@ -157,7 +157,7 @@ target_hash = "b3:202ad759d688b9521352cd639cd04706131d9e8b00b6362c6dd1f49283e902
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
-target_hash = "b3:8afef0115e1a9bcd5d6605be78439fa1d80a72b5bbdd833199a0aa76328a5b1c"
+target_hash = "b3:09c7c7ccbcfe7acbcd4a2946af493aeba9eca41ec4419f70e474893f97825664"
 
 [[node.edge]]
 target = "docs/reading.md"
@@ -181,11 +181,11 @@ hash = "b3:202ad759d688b9521352cd639cd04706131d9e8b00b6362c6dd1f49283e90201"
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
-target_hash = "b3:8afef0115e1a9bcd5d6605be78439fa1d80a72b5bbdd833199a0aa76328a5b1c"
+target_hash = "b3:09c7c7ccbcfe7acbcd4a2946af493aeba9eca41ec4419f70e474893f97825664"
 
 [[node.edge]]
 target = "docs/parsers/markdown.md"
-target_hash = "b3:3e59f218419ca388fd3d981e71dc62248dd05cc6885622650549807f7f604e27"
+target_hash = "b3:3c45c124a1e046a85453b0bbac4e989ba0b55d89e0e86f10f6d4cc006d32f041"
 
 [[node.edge]]
 target = "src/parsers/mod.rs"
@@ -193,19 +193,23 @@ target_hash = "b3:520ad18b8bb4fab4f1efce2913a0c59f2ab443f64178cd37cad77840b7f0b1
 
 [[node]]
 path = "docs/parsers/frontmatter.md"
-hash = "b3:8afef0115e1a9bcd5d6605be78439fa1d80a72b5bbdd833199a0aa76328a5b1c"
+hash = "b3:09c7c7ccbcfe7acbcd4a2946af493aeba9eca41ec4419f70e474893f97825664"
 
 [[node.edge]]
 target = "docs/config.md"
 target_hash = "b3:ba380aa56e9ff7a5cb6186ac81b46b93c01ca693f72e95e8156f79bc932b4f7d"
 
 [[node.edge]]
+target = "docs/parsers/markdown.md"
+target_hash = "b3:3c45c124a1e046a85453b0bbac4e989ba0b55d89e0e86f10f6d4cc006d32f041"
+
+[[node.edge]]
 target = "src/parsers/frontmatter.rs"
-target_hash = "b3:9e0212f666001b7093064bab0a76e81200885de12a942ba619e8b32c1f4c62db"
+target_hash = "b3:3e4d0a4120ff6bf7d9361a87a278361598af51b8865527e9c3a6e86a0cff9721"
 
 [[node]]
 path = "docs/parsers/markdown.md"
-hash = "b3:3e59f218419ca388fd3d981e71dc62248dd05cc6885622650549807f7f604e27"
+hash = "b3:3c45c124a1e046a85453b0bbac4e989ba0b55d89e0e86f10f6d4cc006d32f041"
 
 [[node.edge]]
 target = "docs/config.md"
@@ -213,7 +217,7 @@ target_hash = "b3:ba380aa56e9ff7a5cb6186ac81b46b93c01ca693f72e95e8156f79bc932b4f
 
 [[node.edge]]
 target = "docs/parsers/frontmatter.md"
-target_hash = "b3:8afef0115e1a9bcd5d6605be78439fa1d80a72b5bbdd833199a0aa76328a5b1c"
+target_hash = "b3:09c7c7ccbcfe7acbcd4a2946af493aeba9eca41ec4419f70e474893f97825664"
 
 [[node.edge]]
 target = "docs/rules/README.md"
@@ -221,7 +225,7 @@ target_hash = "b3:d1b6f37e2efe0ac232d228624e8be281e1e8ef5ed997a3b84d23d9a525866c
 
 [[node.edge]]
 target = "src/parsers/markdown.rs"
-target_hash = "b3:c51f4969a87b322277ea06d942f5a4a45adbd9b64d9157ff4635e71e36ee064f"
+target_hash = "b3:96b3936ff8dfcd3ba6f9b1e2f7d03f3a62b286d21c95b22ad4b6ceda1943b5ed"
 
 [[node]]
 path = "docs/reading.md"
@@ -273,7 +277,7 @@ target_hash = "b3:f592a8dd3264b1975fbfc2da5958b0a5999efa513b2ca51b2a9df5fa602e38
 
 [[node.edge]]
 target = "src/rules/structural.rs"
-target_hash = "b3:7f2008340051f32e747b64439c5d43d9689d01c9f96f187117754479e0323a58"
+target_hash = "b3:b9c6d4ae5a708ccf3178e18b9d3c22e5839b0b1f612f68f008eb9f8baaf09b00"
 
 [[node]]
 path = "dprint.json"
@@ -372,11 +376,11 @@ hash = "b3:bd63f170e88bb37482e7384aa3becb20cea1d7dfcf2be4b4ab79a8e636329920"
 
 [[node]]
 path = "src/parsers/frontmatter.rs"
-hash = "b3:9e0212f666001b7093064bab0a76e81200885de12a942ba619e8b32c1f4c62db"
+hash = "b3:3e4d0a4120ff6bf7d9361a87a278361598af51b8865527e9c3a6e86a0cff9721"
 
 [[node]]
 path = "src/parsers/markdown.rs"
-hash = "b3:c51f4969a87b322277ea06d942f5a4a45adbd9b64d9157ff4635e71e36ee064f"
+hash = "b3:96b3936ff8dfcd3ba6f9b1e2f7d03f3a62b286d21c95b22ad4b6ceda1943b5ed"
 
 [[node]]
 path = "src/parsers/mod.rs"
@@ -404,7 +408,7 @@ hash = "b3:f592a8dd3264b1975fbfc2da5958b0a5999efa513b2ca51b2a9df5fa602e388d"
 
 [[node]]
 path = "src/rules/structural.rs"
-hash = "b3:7f2008340051f32e747b64439c5d43d9689d01c9f96f187117754479e0323a58"
+hash = "b3:b9c6d4ae5a708ccf3178e18b9d3c22e5839b0b1f612f68f008eb9f8baaf09b00"
 
 [[node]]
 path = "src/sources/fs.rs"

--- a/src/builders/markdown.rs
+++ b/src/builders/markdown.rs
@@ -1,17 +1,27 @@
-//! The `markdown` builder: emits link edges from `[text](path)` body links. It
-//! contributes no node metadata — cross-graph linkage to `fs` nodes happens at
+//! The `markdown` builder: emits link edges from `[text](path)` body links, plus
+//! the `#fragment` addresses each file answers to. It is colocated — the anchors
+//! are about its own file — so its drift rides the file's `fs` hash; it
+//! contributes no hash of its own. Cross-graph linkage to `fs` nodes happens at
 //! compose by path coincidence.
 
 use globset::GlobSet;
+use serde_json::Value;
 
 use crate::builders::link_edges;
-use crate::model::Graph;
+use crate::model::{Graph, Metadata, Node};
 use crate::parsers::Parser;
 use crate::parsers::markdown::MarkdownParser;
 
 /// Build the `markdown` graph fragment from text files, labeled `label`.
 /// `filter` scopes which paths the builder reads (`None` reads all). The
-/// fragment carries only edges.
+/// fragment carries link edges plus a node per read file listing its `anchors`.
+///
+/// A file the builder read gets a node even when it defines no anchors, so the
+/// empty array is a fact rather than a silence. The distinction is load-bearing:
+/// a link to `notes.md#missing` where `notes.md` was read and has no headings is
+/// a broken reference, while the same link into a file the markdown graph never
+/// read is simply unknown, and only a present-but-empty `anchors` tells them
+/// apart.
 pub fn build(label: &str, texts: &[(String, String)], filter: Option<GlobSet>) -> Graph {
     let parser = MarkdownParser {
         file_filter: filter,
@@ -22,7 +32,16 @@ pub fn build(label: &str, texts: &[(String, String)], filter: Option<GlobSet>) -
         if !parser.matches(path) {
             continue;
         }
-        for edge in link_edges(path, &parser.parse(path, content).links) {
+        let result = parser.parse(path, content);
+
+        let mut metadata = Metadata::new();
+        metadata.insert(
+            "anchors".into(),
+            Value::Array(result.anchors.into_iter().map(Value::String).collect()),
+        );
+        graph.set_node(path.clone(), Node::new(metadata));
+
+        for edge in link_edges(path, &result.links) {
             graph.add_edge(edge);
         }
     }
@@ -47,9 +66,42 @@ mod tests {
         let t = texts(&[("docs/index.md", "[setup](setup.md) and [faq](../faq.md)")]);
         let graph = build("markdown", &t, None);
         assert_eq!(graph.label.as_deref(), Some("markdown"));
-        assert!(graph.nodes.is_empty(), "markdown contributes no nodes");
         let targets: Vec<&str> = graph.edges.iter().map(|e| e.target.as_str()).collect();
         assert_eq!(targets, vec!["docs/setup.md", "faq.md"]);
+    }
+
+    #[test]
+    fn publishes_the_anchors_a_file_answers_to() {
+        let t = texts(&[("log.md", "# Log\n\n## OBS-92\n\ntext\n\n## OBS-40\n")]);
+        let graph = build("markdown", &t, None);
+        assert_eq!(
+            graph.nodes["log.md"].metadata["anchors"],
+            serde_json::json!(["log", "obs-92", "obs-40"]),
+            "document order, so a repeated slug's disambiguator is legible"
+        );
+    }
+
+    #[test]
+    fn a_read_file_with_no_headings_still_gets_an_empty_anchor_list() {
+        // Present-and-empty is what separates "read, defines nothing" from "never
+        // read", which is the difference between a broken fragment and an unknown
+        // one.
+        let t = texts(&[("plain.md", "just prose\n")]);
+        let graph = build("markdown", &t, None);
+        assert_eq!(
+            graph.nodes["plain.md"].metadata["anchors"],
+            serde_json::json!([])
+        );
+    }
+
+    #[test]
+    fn an_unread_file_gets_no_node() {
+        let mut builder = globset::GlobSetBuilder::new();
+        builder.add(globset::Glob::new("**/*.md").unwrap());
+        let t = texts(&[("a.md", "# A"), ("notes.txt", "# Not markdown here")]);
+        let graph = build("markdown", &t, Some(builder.build().unwrap()));
+        assert!(graph.nodes.contains_key("a.md"));
+        assert!(!graph.nodes.contains_key("notes.txt"));
     }
 
     #[test]

--- a/src/builders/mod.rs
+++ b/src/builders/mod.rs
@@ -1,6 +1,7 @@
 //! Builders turn a source's `(path, bytes)` records into graph nodes and edges.
 //! v0.8 ships the `fs` node builder plus two text builders (parsers):
-//! `markdown` (edges) and `frontmatter` (edges + metadata).
+//! `markdown` (edges + the anchors a file answers to) and `frontmatter`
+//! (edges + metadata).
 
 pub mod frontmatter;
 pub mod fs;

--- a/src/config.rs
+++ b/src/config.rs
@@ -163,6 +163,11 @@ const BUILTIN_RULES: &[&str] = &[
 /// a parser) and is intentionally absent — `parser = "fs"` is rejected.
 const KNOWN_PARSERS: &[&str] = &["markdown", "frontmatter"];
 
+/// Parsers that publish the `#fragment` addresses a file answers to. Metadata
+/// from any other graph — frontmatter especially, which is the author's own
+/// YAML — is not a claim about what a file can be cited by.
+const PARSERS_WITH_ANCHORS: &[&str] = &["markdown"];
+
 /// Parsers that accept `keys`. Markdown has no keyed structure to scope.
 const PARSERS_WITH_KEYS: &[&str] = &["frontmatter"];
 
@@ -185,6 +190,16 @@ impl Config {
             config_dir: None,
             hints: Vec::new(),
         }
+    }
+
+    /// The `@<graph>` namespaces whose parser publishes anchors — the ones a
+    /// fragment may be checked against.
+    pub fn anchor_namespaces(&self) -> Vec<String> {
+        self.graphs
+            .iter()
+            .filter(|(_, graph)| PARSERS_WITH_ANCHORS.contains(&graph.parser.as_str()))
+            .map(|(name, _)| crate::model::namespace(name))
+            .collect()
     }
 
     pub fn load(root: &Path) -> Result<Self> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -155,6 +155,7 @@ const BUILTIN_RULES: &[&str] = &[
     "removed-edge",
     "removed-node",
     "unresolved-edge",
+    "unresolved-fragment",
     "detached-node",
 ];
 

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -4,8 +4,10 @@ use serde::Serialize;
 /// A v0.8 check finding over the composed graph. Serializes to the diagnostic
 /// shape `{name, severity, subject, target?, lines?, _graphs, message, cause?}`:
 /// `subject` is the implicated path (the source node for edge-level findings),
-/// `target` is the edge's destination on edge-level findings (absent on
-/// node-level ones), `lines` is the source line(s) where an edge finding's link
+/// `target` is what the link points at on edge-level findings (absent on
+/// node-level ones) — usually the destination node's path, but
+/// `unresolved-fragment` reports `path#fragment`, so a consumer must not assume
+/// it is a node id, `lines` is the source line(s) where an edge finding's link
 /// appears (absent otherwise), `_graphs` carries the same provenance key the node
 /// or edge does, so a consumer never has to parse anything, and `cause` names the
 /// likely reason when the finding is correct but reads as the wrong problem.

--- a/src/model.rs
+++ b/src/model.rs
@@ -76,6 +76,31 @@ impl Node {
     pub fn is_resolved(&self) -> bool {
         self.metadata.contains_key(FS_NAMESPACE)
     }
+
+    /// The `#fragment` addresses this node answers to, across contributing
+    /// graphs. The namespace is not hardcoded — a graph declaring
+    /// `parser = "markdown"` may carry any name — so any graph publishing an
+    /// `anchors` list contributes.
+    ///
+    /// `None` means no graph published one: nothing read this node as a document
+    /// with addressable positions, so its fragments are **unknown** rather than
+    /// broken. An empty `Some` means a parser read it and it defines no
+    /// addresses, which makes every fragment into it broken. Callers must keep
+    /// those apart.
+    pub fn anchors(&self) -> Option<Vec<&str>> {
+        let mut anchors: Option<Vec<&str>> = None;
+        for (key, value) in &self.metadata {
+            if !key.starts_with('@') {
+                continue;
+            }
+            if let Some(published) = value.get("anchors").and_then(Value::as_array) {
+                anchors
+                    .get_or_insert_with(Vec::new)
+                    .extend(published.iter().filter_map(Value::as_str));
+            }
+        }
+        anchors
+    }
 }
 
 /// A directed edge from `source` to `target` (both node-identity paths).
@@ -319,6 +344,22 @@ mod tests {
         assert_eq!(edge.lines(), vec![2, 5, 9], "unioned, sorted, deduped");
         assert_eq!(edge.raw_links(), vec!["./b.md"]);
         assert!(Edge::new("a.md", "b.md").lines().is_empty());
+    }
+
+    #[test]
+    fn node_anchors_separate_unknown_from_empty() {
+        let unread = Node::new(meta(json!({ "@fs": { "type": "file" } })));
+        assert!(unread.anchors().is_none(), "no parser read it: unknown");
+
+        let read = Node::new(meta(json!({
+            "@fs": { "type": "file" },
+            "@markdown": { "anchors": [] }
+        })));
+        assert_eq!(read.anchors(), Some(Vec::new()), "read, defines nothing");
+
+        // The graph name is configurable, so the namespace is not hardcoded.
+        let named = Node::new(meta(json!({ "@docs": { "anchors": ["obs-92"] } })));
+        assert_eq!(named.anchors(), Some(vec!["obs-92"]));
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -77,27 +77,35 @@ impl Node {
         self.metadata.contains_key(FS_NAMESPACE)
     }
 
-    /// The `#fragment` addresses this node answers to, across contributing
-    /// graphs. The namespace is not hardcoded — a graph declaring
-    /// `parser = "markdown"` may carry any name — so any graph publishing an
-    /// `anchors` list contributes.
+    /// The `#fragment` addresses this node answers to, as published by the
+    /// namespaces in `authoritative`.
     ///
-    /// `None` means no graph published one: nothing read this node as a document
-    /// with addressable positions, so its fragments are **unknown** rather than
-    /// broken. An empty `Some` means a parser read it and it defines no
-    /// addresses, which makes every fragment into it broken. Callers must keep
+    /// The namespace is not hardcoded — a graph declaring `parser = "markdown"`
+    /// may carry any name — but neither is it open: node metadata under
+    /// `@frontmatter` is the **author's** YAML, so a file writing
+    /// `anchors: [invented]` in its frontmatter would otherwise mint addresses it
+    /// does not answer to and silently certify links to them. The caller passes
+    /// the namespaces whose parser actually publishes anchors.
+    ///
+    /// `None` means none of them published a list: nothing read this node as a
+    /// document with addressable positions, so its fragments are **unknown**
+    /// rather than broken. An empty `Some` means a parser read it and it defines
+    /// no addresses, which makes every fragment into it broken. Callers must keep
     /// those apart.
-    pub fn anchors(&self) -> Option<Vec<&str>> {
+    pub fn anchors(&self, authoritative: &[String]) -> Option<Vec<&str>> {
         let mut anchors: Option<Vec<&str>> = None;
-        for (key, value) in &self.metadata {
-            if !key.starts_with('@') {
+        for namespace in authoritative {
+            let Some(published) = self
+                .metadata
+                .get(namespace)
+                .and_then(|block| block.get("anchors"))
+                .and_then(Value::as_array)
+            else {
                 continue;
-            }
-            if let Some(published) = value.get("anchors").and_then(Value::as_array) {
-                anchors
-                    .get_or_insert_with(Vec::new)
-                    .extend(published.iter().filter_map(Value::as_str));
-            }
+            };
+            anchors
+                .get_or_insert_with(Vec::new)
+                .extend(published.iter().filter_map(Value::as_str));
         }
         anchors
     }
@@ -348,18 +356,33 @@ mod tests {
 
     #[test]
     fn node_anchors_separate_unknown_from_empty() {
+        let md = [namespace("markdown")];
         let unread = Node::new(meta(json!({ "@fs": { "type": "file" } })));
-        assert!(unread.anchors().is_none(), "no parser read it: unknown");
+        assert!(unread.anchors(&md).is_none(), "no parser read it: unknown");
 
         let read = Node::new(meta(json!({
             "@fs": { "type": "file" },
             "@markdown": { "anchors": [] }
         })));
-        assert_eq!(read.anchors(), Some(Vec::new()), "read, defines nothing");
+        assert_eq!(read.anchors(&md), Some(Vec::new()), "read, defines nothing");
 
         // The graph name is configurable, so the namespace is not hardcoded.
         let named = Node::new(meta(json!({ "@docs": { "anchors": ["obs-92"] } })));
-        assert_eq!(named.anchors(), Some(vec!["obs-92"]));
+        assert_eq!(named.anchors(&[namespace("docs")]), Some(vec!["obs-92"]));
+    }
+
+    #[test]
+    fn node_anchors_ignore_an_unauthoritative_namespace() {
+        // Frontmatter metadata is the author's YAML. A file claiming its own
+        // addresses would otherwise certify every link written to them.
+        let claimed = Node::new(meta(json!({
+            "@fs": { "type": "file" },
+            "@frontmatter": { "anchors": ["invented"] }
+        })));
+        assert!(
+            claimed.anchors(&[namespace("markdown")]).is_none(),
+            "an unread file stays unknown however its frontmatter is written"
+        );
     }
 
     #[test]

--- a/src/parsers/frontmatter.rs
+++ b/src/parsers/frontmatter.rs
@@ -127,7 +127,7 @@ impl Parser for FrontmatterParser {
     }
 
     fn parse(&self, _path: &str, content: &str) -> ParseResult {
-        // Two independent buffers, one per job. The edge scan runs on a *masked*
+        // Two independent parses over one block, one per job. The edge scan runs on a *masked*
         // copy — `strip_code` blanks code spans so a `path.md` written in prose
         // can't be mistaken for a link target. Metadata runs on the *raw*
         // frontmatter, so a code span in a value survives as the prose it is.
@@ -146,7 +146,7 @@ impl Parser for FrontmatterParser {
 impl FrontmatterParser {
     /// Extract frontmatter link edges from the *masked* frontmatter block, where
     /// code spans are blanked so a `path.md` written in prose is never a link
-    /// target. An absent or malformed masked block yields no links.
+    /// target. An absent or malformed block yields no links.
     fn extract_links(&self, content: &str) -> Vec<Link> {
         // The boundary is the shared one; only the masking is this job's own.
         // Finding the block in a masked copy of the *whole file* let a code span
@@ -207,6 +207,10 @@ fn extract_metadata(content: &str) -> Option<serde_json::Value> {
     for candidate in [Cow::Borrowed(block), Cow::Owned(strip_code(block))] {
         if let Ok(docs) = MarkedYaml::load_from_str(candidate.as_ref())
             && let Some(root) = docs.first()
+            // `parsed_block` already gated on one of these parsing as a mapping,
+            // but not necessarily *this* one. Checking here keeps the return type
+            // honest without resting on an argument about what blanking can do.
+            && matches!(root.data, YamlData::Mapping(_))
         {
             return Some(to_json(root));
         }
@@ -215,7 +219,7 @@ fn extract_metadata(content: &str) -> Option<serde_json::Value> {
 }
 
 /// The frontmatter block this parser recognizes: where it ends in `content`, and
-/// its parsed mapping.
+/// its raw text.
 ///
 /// One selector, so the offset the markdown parser masks and the metadata this
 /// parser contributes can never describe different spans. They did: this looked

--- a/src/parsers/frontmatter.rs
+++ b/src/parsers/frontmatter.rs
@@ -131,8 +131,8 @@ impl Parser for FrontmatterParser {
         // copy — `strip_code` blanks code spans so a `path.md` written in prose
         // can't be mistaken for a link target. Metadata runs on the *raw*
         // frontmatter, so a code span in a value survives as the prose it is.
-        // Neither gates the other: a stray backtick that blanks the closing `---`
-        // in the masked copy must not also erase the metadata, and vice versa.
+        // Both read the same block — one boundary, decided by `parsed_block` —
+        // and differ only in whether spans are blanked within it.
         ParseResult {
             links: self.extract_links(content),
             // Frontmatter defines no addressable sub-file positions; anchors come
@@ -148,11 +148,19 @@ impl FrontmatterParser {
     /// code spans are blanked so a `path.md` written in prose is never a link
     /// target. An absent or malformed masked block yields no links.
     fn extract_links(&self, content: &str) -> Vec<Link> {
-        // `stripped` is owned and outlives the borrowed marked AST below.
-        let stripped = strip_code(content);
-        let Some(yaml_str) = frontmatter_block(&stripped) else {
+        // The boundary is the shared one; only the masking is this job's own.
+        // Finding the block in a masked copy of the *whole file* let a code span
+        // crossing the closing fence move the boundary — lifting a link out of
+        // body prose in one direction, and silently dropping every declared
+        // `sources:` edge in the other, on a file whose metadata still reported
+        // them. `strip_code` blanks whole spans, newlines included, so a moved
+        // boundary also misreports the lines it does find.
+        let Some((_, block)) = parsed_block(content) else {
             return Vec::new();
         };
+        // `stripped` is owned and outlives the borrowed marked AST below.
+        let stripped = strip_code(block);
+        let yaml_str = stripped.as_str();
         // Malformed YAML contributes nothing — drft is not a YAML linter.
         let Ok(docs) = MarkedYaml::load_from_str(yaml_str) else {
             return Vec::new();
@@ -195,7 +203,15 @@ impl FrontmatterParser {
 ///
 /// The masking applies to the block, not to the file — see [`parsed_block`].
 fn extract_metadata(content: &str) -> Option<serde_json::Value> {
-    parsed_block(content).map(|(_, metadata)| metadata)
+    let (_, block) = parsed_block(content)?;
+    for candidate in [Cow::Borrowed(block), Cow::Owned(strip_code(block))] {
+        if let Ok(docs) = MarkedYaml::load_from_str(candidate.as_ref())
+            && let Some(root) = docs.first()
+        {
+            return Some(to_json(root));
+        }
+    }
+    None
 }
 
 /// The frontmatter block this parser recognizes: where it ends in `content`, and
@@ -212,19 +228,39 @@ fn extract_metadata(content: &str) -> Option<serde_json::Value> {
 /// Masking is applied to the block text instead, which serves the reason it
 /// exists — a code span can hide a `:` that would otherwise break the mapping —
 /// without letting a span decide where the block ends.
-fn parsed_block(content: &str) -> Option<(usize, serde_json::Value)> {
+fn parsed_block(content: &str) -> Option<(usize, &str)> {
     let block = frontmatter_block(content)?;
     let end = "---".len() + block.len() + "\n---".len();
-    // Raw first, so a code span survives as the prose it is.
-    for candidate in [Cow::Borrowed(block), Cow::Owned(strip_code(block))] {
-        if let Ok(docs) = MarkedYaml::load_from_str(candidate.as_ref())
-            && let Some(root) = docs.first()
-            && matches!(root.data, YamlData::Mapping(_))
-        {
-            return Some((end, to_json(root)));
-        }
-    }
-    None
+    // Raw first, so a code span survives as the prose it is; then the same block
+    // with spans blanked, since one can hide a `:` that breaks the mapping.
+    let parses = is_mapping(block) || is_mapping(&strip_code(block));
+    parses.then_some((end, block))
+}
+
+/// Whether `block` parses as a YAML **mapping** — the shape that separates
+/// frontmatter from a document opening with a `---` thematic break.
+///
+/// A mapping is required rather than any valid YAML because YAML and markdown
+/// collide on two constructs, and accepting either would delete real content:
+///
+/// - A comment-only block parses to no document at all. But `# First` is a YAML
+///   comment *and* a markdown ATX heading, so treating one as frontmatter reads
+///   `---\n\n# First\n\n---` as a block and deletes the most ordinary heading in
+///   markdown, along with any link beneath it.
+/// - A block parsing to a bare scalar is ambiguous the same way:
+///   `---\nMy Title\n---` is equally a rule above a setext heading.
+///
+/// Both are left as content. The cost is that comment-only frontmatter has its
+/// text read as prose; the alternative deletes a document's headings and edges,
+/// and only one of those is recoverable by reading the page.
+fn is_mapping(block: &str) -> bool {
+    MarkedYaml::load_from_str(block)
+        .ok()
+        .and_then(|docs| {
+            docs.first()
+                .map(|doc| matches!(doc.data, YamlData::Mapping(_)))
+        })
+        .unwrap_or(false)
 }
 
 /// The byte offset just past a leading YAML frontmatter block, or `None` when the
@@ -241,14 +277,14 @@ pub fn mapping_block_end(content: &str) -> Option<usize> {
 }
 
 /// Extract the YAML frontmatter block — the text between the opening `---` and the
-/// next `\n---`, or `None` when there is no well-formed block. Callable on the raw
-/// content (for metadata) or the masked copy (for the edge scan). The two usually
-/// agree on the block, but need not: `strip_code` blanks a whole span, newlines
-/// included, so a `\n---` hidden inside a code span survives in the raw content but
-/// not the masked copy, and the two then find different boundaries — one reason
-/// metadata and the edge scan run as independent buffers. The slice keeps the
-/// newline after the opening fence, so a node's line within the block equals its
-/// line within the file.
+/// next `\n---`, or `None` when there is no well-formed block.
+///
+/// Called on the **raw** content only, through [`parsed_block`]. Calling it on a
+/// `strip_code` copy of the whole file finds a different boundary whenever a span
+/// crosses the closing fence, because blanking the span takes the fence with it —
+/// which is how the edge scan came to read a block nothing else agreed on. The
+/// slice keeps the newline after the opening fence, so a node's line within the
+/// block equals its line within the file.
 fn frontmatter_block(stripped: &str) -> Option<&str> {
     let rest = stripped.strip_prefix("---")?;
     // The opening fence has to be a line of its own. `---key: v` is not
@@ -589,22 +625,54 @@ mod tests {
     }
 
     #[test]
-    fn metadata_survives_when_a_stray_backtick_breaks_the_masked_block() {
-        // An unclosed backtick in a value pairs with one in the body, so the mask
-        // blanks everything between — including the closing `---` — and the edge
-        // scan finds no block. Metadata reads the raw frontmatter on its own buffer,
-        // so it is still captured. (The masked edge scan finds nothing, unchanged.)
+    fn a_stray_backtick_keeps_both_the_metadata_and_the_edges() {
+        // An unclosed backtick in a value pairs with one in the body. Finding the
+        // block in a masked copy of the whole file blanked everything between —
+        // the closing `---` included — so the edge scan found no block and the
+        // declared `sources:` entry produced nothing, on a file whose metadata
+        // reported that same entry. The boundary comes from the raw content now,
+        // so both agree.
         let content =
             "---\npurpose: a `widget\nsources:\n  - b.md\n---\n\n# Body with a `code span`\n";
         let result = parse(content);
-        let meta = result
-            .metadata
-            .expect("metadata comes from the raw block, not the masked one");
+        let meta = result.metadata.expect("metadata comes from the raw block");
         assert_eq!(meta["purpose"], "a `widget");
+        assert_eq!(
+            result.links.len(),
+            1,
+            "the declared source is still an edge"
+        );
+        assert_eq!(result.links[0].target, "b.md");
+        assert_eq!(
+            result.links[0].line,
+            Some(4),
+            "and its line is file-accurate"
+        );
+    }
+
+    #[test]
+    fn a_span_crossing_the_fence_neither_drops_nor_invents_an_edge() {
+        // Direction one: a span that swallows the closing fence used to pull body
+        // prose into the block, so a `deps:` line below it became a declared
+        // source — with a line number off by the newlines the mask ate.
+        let lifted = "---\na: `x\n---\ny`\ndeps: ./t.md\n---\n\n# Body\n";
+        let result = parse(lifted);
         assert!(
             result.links.is_empty(),
-            "the masked edge scan finds no block"
+            "body prose is not a declared source"
         );
+        assert!(
+            result.metadata.is_none(),
+            "and the block is not frontmatter"
+        );
+
+        // Direction two: one backtick inside a properly quoted string, plus an
+        // ordinary code span in the body, silently deleted every declared edge.
+        let dropped =
+            "---\nsources:\n  - ./t.md\nnote: \"has a ` backtick\"\n---\n\n# B\n\nA `code` span.\n";
+        let result = parse(dropped);
+        assert_eq!(result.links.len(), 1, "the declared source survives");
+        assert_eq!(result.links[0].target, "./t.md");
     }
 
     #[test]

--- a/src/parsers/frontmatter.rs
+++ b/src/parsers/frontmatter.rs
@@ -1,4 +1,5 @@
 use saphyr::{LoadableYamlNode, MarkedYaml, Scalar, YamlData};
+use std::borrow::Cow;
 
 use super::{Link, ParseResult, Parser};
 
@@ -191,20 +192,39 @@ impl FrontmatterParser {
 /// fields structured at the cost of blanking that one span; the author's fix is to
 /// quote the value or use a `|` block scalar, both of which the raw path captures
 /// verbatim. Returns `None` when there is no frontmatter block at all.
+///
+/// The masking applies to the block, not to the file — see [`parsed_block`].
 fn extract_metadata(content: &str) -> Option<serde_json::Value> {
-    // Prefer the raw block so code spans survive as prose.
-    if let Some(block) = frontmatter_block(content)
-        && let Ok(docs) = MarkedYaml::load_from_str(block)
-        && let Some(root) = docs.first()
-    {
-        return Some(to_json(root));
+    parsed_block(content).map(|(_, metadata)| metadata)
+}
+
+/// The frontmatter block this parser recognizes: where it ends in `content`, and
+/// its parsed mapping.
+///
+/// One selector, so the offset the markdown parser masks and the metadata this
+/// parser contributes can never describe different spans. They did: this looked
+/// for its block in a copy of the **whole file** with code spans blanked, so a
+/// backtick opened in frontmatter and closed in the body blanked the closing
+/// fence and moved the boundary past it. The mask, working from the raw content,
+/// saw no frontmatter at all — and the file published anchors slugged from a
+/// block this parser had already claimed.
+///
+/// Masking is applied to the block text instead, which serves the reason it
+/// exists — a code span can hide a `:` that would otherwise break the mapping —
+/// without letting a span decide where the block ends.
+fn parsed_block(content: &str) -> Option<(usize, serde_json::Value)> {
+    let block = frontmatter_block(content)?;
+    let end = "---".len() + block.len() + "\n---".len();
+    // Raw first, so a code span survives as the prose it is.
+    for candidate in [Cow::Borrowed(block), Cow::Owned(strip_code(block))] {
+        if let Ok(docs) = MarkedYaml::load_from_str(candidate.as_ref())
+            && let Some(root) = docs.first()
+            && matches!(root.data, YamlData::Mapping(_))
+        {
+            return Some((end, to_json(root)));
+        }
     }
-    // Fall back to the masked block only when the raw block is not valid YAML on its
-    // own — a code span can hide a `:` that would otherwise break the mapping.
-    let stripped = strip_code(content);
-    let block = frontmatter_block(&stripped)?;
-    let docs = MarkedYaml::load_from_str(block).ok()?;
-    docs.first().map(to_json)
+    None
 }
 
 /// The byte offset just past a leading YAML frontmatter block, or `None` when the
@@ -217,40 +237,7 @@ fn extract_metadata(content: &str) -> Option<serde_json::Value> {
 /// what this one claims, rather than guessing at the boundary a second time and
 /// disagreeing.
 pub fn mapping_block_end(content: &str) -> Option<usize> {
-    let block = frontmatter_block(content)?;
-    // The boundary always comes from the raw content, so the offset indexes the
-    // string the caller holds. `strip_code` rebuilds lines — dropping `\r`, adding
-    // a trailing newline — so an offset taken from its output would not. It is
-    // applied to the block text alone and only to decide whether the block parses,
-    // which is the same raw-then-masked order `extract_metadata` uses: a code span
-    // can hide a `:` that would otherwise break the mapping.
-    (is_mapping(block) || is_mapping(&strip_code(block)))
-        .then_some("---".len() + block.len() + "\n---".len())
-}
-
-/// Whether `block` parses as a YAML **mapping** — the shape that separates
-/// frontmatter from a document opening with a `---` thematic break.
-///
-/// A mapping is required rather than any valid YAML, and the reason is that YAML
-/// and markdown collide on two constructs. A block carrying only comments parses
-/// to no document at all — but `# First` is a YAML comment *and* a markdown ATX
-/// heading, so accepting it would read `---\n\n# First\n\n---` as frontmatter and
-/// delete the most ordinary heading in markdown, along with any link beneath it.
-/// A block parsing to a bare scalar is ambiguous the same way:
-/// `---\nMy Title\n---` is equally a rule above a setext heading.
-///
-/// So both are left as content. The cost is that comment-only frontmatter, which
-/// other tools do recognize, has its text read as prose; the alternative is
-/// deleting real content, and only one of those is recoverable by reading the
-/// page.
-fn is_mapping(block: &str) -> bool {
-    MarkedYaml::load_from_str(block)
-        .ok()
-        .and_then(|docs| {
-            docs.first()
-                .map(|doc| matches!(doc.data, YamlData::Mapping(_)))
-        })
-        .unwrap_or(false)
+    parsed_block(content).map(|(end, _)| end)
 }
 
 /// Extract the YAML frontmatter block — the text between the opening `---` and the
@@ -381,6 +368,17 @@ mod tests {
             keys: None,
         };
         parser.parse("test.md", content)
+    }
+
+    #[test]
+    fn a_code_span_crossing_the_fence_does_not_move_the_block() {
+        // A backtick opened in frontmatter and closed in the body. Masking the
+        // whole file would blank the closing fence and push the block past it, so
+        // this parser would claim a span the markdown parser cannot see — and the
+        // file would publish anchors slugged out of what this one had claimed.
+        let content = "---\npurpose: `a: b\n---\nc: d` tail\nkey: v\n---\n\n# Body\n";
+        assert!(parse(content).metadata.is_none());
+        assert!(mapping_block_end(content).is_none(), "and the mask agrees");
     }
 
     #[test]

--- a/src/parsers/frontmatter.rs
+++ b/src/parsers/frontmatter.rs
@@ -207,6 +207,30 @@ fn extract_metadata(content: &str) -> Option<serde_json::Value> {
     docs.first().map(to_json)
 }
 
+/// The byte offset just past a leading YAML frontmatter block, or `None` when the
+/// file does not open with one.
+///
+/// The block has to parse as a **mapping**, which is what separates frontmatter
+/// from a document that merely opens with a `---` thematic break. Only a mapping
+/// contributes node metadata (see [`crate::builders::frontmatter`]), so this is
+/// the same block this parser consumes — and the markdown parser masks exactly
+/// what this one claims, rather than guessing at the boundary a second time and
+/// disagreeing.
+pub fn mapping_block_end(content: &str) -> Option<usize> {
+    let rest = content.strip_prefix("---")?;
+    // The opening fence has to be a line of its own.
+    if !rest.starts_with('\n') && !rest.starts_with("\r\n") {
+        return None;
+    }
+    let end = rest.find("\n---")?;
+    let block = &rest[..end];
+    if block.trim().is_empty() {
+        return None;
+    }
+    let docs = MarkedYaml::load_from_str(block).ok()?;
+    matches!(docs.first()?.data, YamlData::Mapping(_)).then_some("---".len() + end + "\n---".len())
+}
+
 /// Extract the YAML frontmatter block — the text between the opening `---` and the
 /// next `\n---`, or `None` when there is no well-formed block. Callable on the raw
 /// content (for metadata) or the masked copy (for the edge scan). The two usually

--- a/src/parsers/frontmatter.rs
+++ b/src/parsers/frontmatter.rs
@@ -134,6 +134,9 @@ impl Parser for FrontmatterParser {
         // in the masked copy must not also erase the metadata, and vice versa.
         ParseResult {
             links: self.extract_links(content),
+            // Frontmatter defines no addressable sub-file positions; anchors come
+            // from the markdown body's headings.
+            anchors: Vec::new(),
             metadata: extract_metadata(content),
         }
     }

--- a/src/parsers/frontmatter.rs
+++ b/src/parsers/frontmatter.rs
@@ -217,18 +217,40 @@ fn extract_metadata(content: &str) -> Option<serde_json::Value> {
 /// what this one claims, rather than guessing at the boundary a second time and
 /// disagreeing.
 pub fn mapping_block_end(content: &str) -> Option<usize> {
-    let rest = content.strip_prefix("---")?;
-    // The opening fence has to be a line of its own.
-    if !rest.starts_with('\n') && !rest.starts_with("\r\n") {
-        return None;
-    }
-    let end = rest.find("\n---")?;
-    let block = &rest[..end];
-    if block.trim().is_empty() {
-        return None;
-    }
-    let docs = MarkedYaml::load_from_str(block).ok()?;
-    matches!(docs.first()?.data, YamlData::Mapping(_)).then_some("---".len() + end + "\n---".len())
+    let block = frontmatter_block(content)?;
+    // The boundary always comes from the raw content, so the offset indexes the
+    // string the caller holds. `strip_code` rebuilds lines — dropping `\r`, adding
+    // a trailing newline — so an offset taken from its output would not. It is
+    // applied to the block text alone and only to decide whether the block parses,
+    // which is the same raw-then-masked order `extract_metadata` uses: a code span
+    // can hide a `:` that would otherwise break the mapping.
+    (is_mapping(block) || is_mapping(&strip_code(block)))
+        .then_some("---".len() + block.len() + "\n---".len())
+}
+
+/// Whether `block` parses as a YAML **mapping** — the shape that separates
+/// frontmatter from a document opening with a `---` thematic break.
+///
+/// A mapping is required rather than any valid YAML, and the reason is that YAML
+/// and markdown collide on two constructs. A block carrying only comments parses
+/// to no document at all — but `# First` is a YAML comment *and* a markdown ATX
+/// heading, so accepting it would read `---\n\n# First\n\n---` as frontmatter and
+/// delete the most ordinary heading in markdown, along with any link beneath it.
+/// A block parsing to a bare scalar is ambiguous the same way:
+/// `---\nMy Title\n---` is equally a rule above a setext heading.
+///
+/// So both are left as content. The cost is that comment-only frontmatter, which
+/// other tools do recognize, has its text read as prose; the alternative is
+/// deleting real content, and only one of those is recoverable by reading the
+/// page.
+fn is_mapping(block: &str) -> bool {
+    MarkedYaml::load_from_str(block)
+        .ok()
+        .and_then(|docs| {
+            docs.first()
+                .map(|doc| matches!(doc.data, YamlData::Mapping(_)))
+        })
+        .unwrap_or(false)
 }
 
 /// Extract the YAML frontmatter block — the text between the opening `---` and the
@@ -242,6 +264,12 @@ pub fn mapping_block_end(content: &str) -> Option<usize> {
 /// line within the file.
 fn frontmatter_block(stripped: &str) -> Option<&str> {
     let rest = stripped.strip_prefix("---")?;
+    // The opening fence has to be a line of its own. `---key: v` is not
+    // frontmatter under any convention that writes it, and reading it as one
+    // invents metadata out of a document's first paragraph.
+    if !rest.starts_with('\n') && !rest.starts_with("\r\n") {
+        return None;
+    }
     let end = rest.find("\n---")?;
     let yaml_str = &rest[..end];
     if yaml_str.trim().is_empty() {
@@ -353,6 +381,37 @@ mod tests {
             keys: None,
         };
         parser.parse("test.md", content)
+    }
+
+    #[test]
+    fn an_opening_fence_must_own_its_line() {
+        // `---key: v` is a paragraph, not frontmatter; reading it as one invents
+        // metadata out of a document's first line.
+        let result = parse("---key: v\n---\n\n# Body\n");
+        assert!(result.metadata.is_none());
+    }
+
+    #[test]
+    fn mapping_block_end_agrees_with_what_this_parser_extracts() {
+        // The markdown parser masks whatever this returns, so a disagreement
+        // publishes an address the file does not answer to — or deletes content
+        // that was never frontmatter.
+        let frontmatter = "---\ntitle: Doc\n---\n\n# Body\n";
+        assert_eq!(
+            mapping_block_end(frontmatter),
+            Some("---\ntitle: Doc\n---".len())
+        );
+        assert!(parse(frontmatter).metadata.is_some());
+
+        // A code span hiding a `:`: this parser recovers via the masked copy, so
+        // the boundary has to as well.
+        let masked_only = "---\npurpose: use `a: b` here\n---\n\n# Body\n";
+        assert!(mapping_block_end(masked_only).is_some());
+        assert!(parse(masked_only).metadata.is_some());
+
+        // A thematic break above a setext title is not frontmatter either way.
+        assert!(mapping_block_end("---\nJust A Title\n---\n\nBody\n").is_none());
+        assert!(mapping_block_end("---\n\n# First\n\n---\n\n# Second\n").is_none());
     }
 
     #[test]

--- a/src/parsers/markdown.rs
+++ b/src/parsers/markdown.rs
@@ -248,15 +248,11 @@ fn attribute(html: &str, from: usize) -> Option<(&str, String, usize)> {
     match bytes[i] {
         quote @ (b'"' | b'\'') => {
             value_start = i + 1;
-            match html[value_start..].find(quote as char) {
-                Some(offset) => {
-                    value_end = value_start + offset;
-                    i = value_end + 1;
-                }
-                // An unterminated quote runs to the end of the chunk; taking the
-                // rest as a value would mint an address out of prose.
-                None => return None,
-            }
+            // An unterminated quote runs to the end of the chunk; taking the rest
+            // as a value would mint an address out of prose, so the tag is
+            // abandoned instead.
+            value_end = value_start + html[value_start..].find(quote as char)?;
+            i = value_end + 1;
         }
         _ => {
             value_start = i;

--- a/src/parsers/markdown.rs
+++ b/src/parsers/markdown.rs
@@ -182,12 +182,20 @@ fn html_anchor_ids(html: &str) -> Vec<String> {
             continue;
         }
         i += 2;
+        // HTML keeps the first of a repeated attribute, so a second `id` names an
+        // address the page does not have.
+        let (mut seen_id, mut seen_name) = (false, false);
         while let Some((name, value, next)) = attribute(html, i) {
             i = next;
             if value.is_empty() {
                 continue;
             }
-            if name.eq_ignore_ascii_case("id") || name.eq_ignore_ascii_case("name") {
+            let taken = match () {
+                _ if name.eq_ignore_ascii_case("id") => &mut seen_id,
+                _ if name.eq_ignore_ascii_case("name") => &mut seen_name,
+                _ => continue,
+            };
+            if !std::mem::replace(taken, true) {
                 ids.push(value);
             }
         }
@@ -395,6 +403,35 @@ mod tests {
         // bails on an unterminated quote rather than taking prose as a value.
         assert!(anchors("<a id=\"unclosed name=\"real\"></a>\n").is_empty());
         assert!(anchors("<a id=\"never closed\n").is_empty());
+    }
+
+    #[test]
+    fn a_repeated_attribute_names_one_address() {
+        // HTML keeps the first, so a second `id` is an address the page lacks.
+        assert_eq!(
+            anchors("<a id=\"first\" id=\"second\" name=\"nm\" name=\"nm2\"></a>\n"),
+            vec!["first", "nm"]
+        );
+    }
+
+    #[test]
+    fn a_code_span_in_frontmatter_does_not_leak_an_anchor() {
+        // A backtick span can hide a `:` that breaks the mapping. The frontmatter
+        // parser falls back to a code-masked parse, and the mask has to agree or
+        // the fabricated-anchor bug comes back for exactly this file.
+        let content = "---\npurpose: use `a: b` here\n---\n\n# Real\n";
+        assert_eq!(anchors(content), vec!["real"]);
+    }
+
+    #[test]
+    fn a_comment_only_block_is_read_as_content() {
+        // A YAML comment and a markdown ATX heading are the same syntax, so
+        // accepting a comment-only block would delete `# First` from any document
+        // that opens with a thematic break above a heading.
+        assert_eq!(
+            anchors("---\n# just a comment\n---\n\n# Real\n"),
+            vec!["just-a-comment", "real"]
+        );
     }
 
     #[test]

--- a/src/parsers/markdown.rs
+++ b/src/parsers/markdown.rs
@@ -1,4 +1,4 @@
-use super::{Link, ParseResult, Parser};
+use super::{Link, ParseResult, Parser, slug};
 use pulldown_cmark::{Event, LinkType, Options, Parser as CmarkParser, Tag, TagEnd};
 
 /// Built-in markdown parser. Extracts inline/reference/autolinks and images.
@@ -16,27 +16,58 @@ impl Parser for MarkdownParser {
     }
 
     fn parse(&self, _path: &str, content: &str) -> ParseResult {
+        let (links, headings) = extract(content);
         ParseResult {
-            links: extract_markdown_links(content),
+            links,
+            anchors: slug::anchors(headings.iter().map(String::as_str)),
             metadata: None,
         }
     }
 }
 
-fn extract_markdown_links(content: &str) -> Vec<Link> {
+/// Walk the document once, collecting link targets and heading text.
+///
+/// Heading text is the *rendered* text — the concatenated text and code-span
+/// content between a heading's start and end — because that is what GitHub
+/// slugs. Inline HTML is excluded for the same reason, so an `<a id>` written
+/// beside a heading does not leak into the anchor it would override. A link
+/// inside a heading contributes both an edge and its text.
+fn extract(content: &str) -> (Vec<Link>, Vec<String>) {
     let newlines = newline_offsets(content);
     let mut links = Vec::new();
+    let mut headings = Vec::new();
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
     // The offset iterator yields each event's byte range so we can locate links.
     let parser = CmarkParser::new_ext(content, options).into_offset_iter();
 
     let mut in_code_block = false;
+    // `Some` while inside a heading, accumulating its rendered text.
+    let mut heading: Option<String> = None;
 
     for (event, range) in parser {
         match event {
             Event::Start(Tag::CodeBlock(_)) => in_code_block = true,
             Event::End(TagEnd::CodeBlock) => in_code_block = false,
+            // The `id` on `Tag::Heading` carries a `{#custom}` attribute, which
+            // GitHub ignores in favor of the slug. Honoring it here would mint an
+            // anchor that resolves in drft and 404s for a reader.
+            Event::Start(Tag::Heading { .. }) => heading = Some(String::new()),
+            Event::End(TagEnd::Heading(_)) => {
+                if let Some(text) = heading.take() {
+                    headings.push(text);
+                }
+            }
+            Event::Text(text) | Event::Code(text) => {
+                if let Some(buffer) = &mut heading {
+                    buffer.push_str(&text);
+                }
+            }
+            Event::SoftBreak | Event::HardBreak => {
+                if let Some(buffer) = &mut heading {
+                    buffer.push(' ');
+                }
+            }
             Event::Start(Tag::Link {
                 link_type,
                 dest_url,
@@ -66,7 +97,7 @@ fn extract_markdown_links(content: &str) -> Vec<Link> {
         }
     }
 
-    links
+    (links, headings)
 }
 
 /// Byte offsets of every `\n` in `content`, ascending — a reusable index for
@@ -97,6 +128,67 @@ mod tests {
             .into_iter()
             .map(|l| l.target)
             .collect()
+    }
+
+    fn anchors(content: &str) -> Vec<String> {
+        let parser = MarkdownParser { file_filter: None };
+        parser.parse("test.md", content).anchors
+    }
+
+    #[test]
+    fn collects_anchors_from_atx_and_setext_headings() {
+        assert_eq!(
+            anchors("# Title\n\n## OBS-92\n\nSetext\n------\n"),
+            vec!["title", "obs-92", "setext"]
+        );
+    }
+
+    #[test]
+    fn a_hash_inside_a_code_fence_is_not_a_heading() {
+        let content = "# Real\n\n```sh\n# not a heading\n```\n";
+        assert_eq!(anchors(content), vec!["real"]);
+    }
+
+    #[test]
+    fn heading_text_is_the_rendered_text() {
+        // Emphasis markers and code-span backticks are not part of what GitHub
+        // slugs; the text inside them is.
+        assert_eq!(anchors("## The **fs** graph\n"), vec!["the-fs-graph"]);
+        assert_eq!(anchors("## The `fs` graph\n"), vec!["the-fs-graph"]);
+    }
+
+    #[test]
+    fn a_link_in_a_heading_contributes_its_text_and_its_edge() {
+        let parser = MarkdownParser { file_filter: None };
+        let result = parser.parse("t.md", "## See [config](config.md)\n");
+        assert_eq!(result.anchors, vec!["see-config"]);
+        assert_eq!(result.links[0].target, "config.md");
+    }
+
+    #[test]
+    fn inline_html_in_a_heading_is_not_part_of_the_slug() {
+        // GitHub slugs the rendered text, so an `<a id>` beside a heading does not
+        // leak into the anchor. (It would *override* it on GitHub — a separate
+        // feature, deliberately not honored yet.)
+        assert_eq!(anchors("## <a id=\"obs-92\"></a>OBS-92\n"), vec!["obs-92"]);
+    }
+
+    #[test]
+    fn a_repeated_heading_takes_the_disambiguator() {
+        assert_eq!(
+            anchors("## Notes\n\ntext\n\n## Notes\n"),
+            vec!["notes", "notes-1"]
+        );
+    }
+
+    #[test]
+    fn a_curly_id_attribute_is_ignored() {
+        // GitHub ignores `{#custom}`, so honoring it would mint a tool-only anchor
+        // that 404s for a reader.
+        // The braces are literal text to a parser without heading attributes
+        // enabled, so they slug like any other punctuation — which is what a
+        // reader on GitHub gets too.
+        assert_eq!(anchors("## OBS-92 {#custom}\n"), vec!["obs-92-custom"]);
     }
 
     #[test]

--- a/src/parsers/markdown.rs
+++ b/src/parsers/markdown.rs
@@ -16,26 +16,58 @@ impl Parser for MarkdownParser {
     }
 
     fn parse(&self, _path: &str, content: &str) -> ParseResult {
-        let (links, headings) = extract(content);
+        // Frontmatter is the frontmatter parser's to read. Masked rather than
+        // skipped so byte offsets — and the link line numbers taken from them —
+        // stay file-accurate.
+        let masked = mask_frontmatter(content);
+        let (links, anchors) = extract(masked.as_deref().unwrap_or(content));
         ParseResult {
             links,
-            anchors: slug::anchors(headings.iter().map(String::as_str)),
+            anchors,
             metadata: None,
         }
     }
 }
 
-/// Walk the document once, collecting link targets and heading text.
+/// Blank a leading YAML frontmatter block, preserving every newline so line
+/// numbers are unchanged. `None` when the file opens with no well-formed block.
 ///
-/// Heading text is the *rendered* text — the concatenated text and code-span
-/// content between a heading's start and end — because that is what GitHub
-/// slugs. Inline HTML is excluded for the same reason, so an `<a id>` written
-/// beside a heading does not leak into the anchor it would override. A link
-/// inside a heading contributes both an edge and its text.
+/// Without this, a single-key block reads as a **setext heading**: `purpose: x`
+/// followed by the closing `---` is a paragraph underlined by dashes, so the
+/// document publishes `#purpose-x` as an address it does not answer to — a
+/// fabricated anchor that also silently accepts any link written to it.
+fn mask_frontmatter(content: &str) -> Option<String> {
+    let rest = content.strip_prefix("---")?;
+    // The opening fence has to be a line of its own.
+    if !rest.starts_with('\n') && !rest.starts_with("\r\n") {
+        return None;
+    }
+    let close = 3 + rest.find("\n---")? + "\n---".len();
+    let masked = content
+        .char_indices()
+        .map(|(i, ch)| {
+            if i < close && ch != '\n' && ch != '\r' {
+                ' '
+            } else {
+                ch
+            }
+        })
+        .collect();
+    Some(masked)
+}
+
+/// Walk the document once, collecting link targets and the anchors it defines.
+///
+/// Anchors come from two places, both of which a reader's platform resolves:
+/// a heading, through the slug of its **rendered** text, and a raw
+/// `<a id>`/`<a name>` element, verbatim. Heading text excludes image alt text,
+/// because the alt attribute is not part of an element's text content and so is
+/// not part of what gets slugged.
 fn extract(content: &str) -> (Vec<Link>, Vec<String>) {
     let newlines = newline_offsets(content);
     let mut links = Vec::new();
-    let mut headings = Vec::new();
+    let mut anchors = Vec::new();
+    let mut slugger = slug::Slugger::default();
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
     // The offset iterator yields each event's byte range so we can locate links.
@@ -44,6 +76,8 @@ fn extract(content: &str) -> (Vec<Link>, Vec<String>) {
     let mut in_code_block = false;
     // `Some` while inside a heading, accumulating its rendered text.
     let mut heading: Option<String> = None;
+    // Nesting depth of image tags, whose alt text is not rendered text.
+    let mut in_image = 0usize;
 
     for (event, range) in parser {
         match event {
@@ -55,19 +89,42 @@ fn extract(content: &str) -> (Vec<Link>, Vec<String>) {
             Event::Start(Tag::Heading { .. }) => heading = Some(String::new()),
             Event::End(TagEnd::Heading(_)) => {
                 if let Some(text) = heading.take() {
-                    headings.push(text);
+                    anchors.push(slugger.heading(&text));
                 }
             }
             Event::Text(text) | Event::Code(text) => {
-                if let Some(buffer) = &mut heading {
+                if let Some(buffer) = &mut heading
+                    && in_image == 0
+                {
                     buffer.push_str(&text);
                 }
             }
+            // A line break renders as markup, not as a space, so it contributes
+            // no character to the text content. The slug drops it either way;
+            // pushing a space would join the halves with a hyphen instead.
             Event::SoftBreak | Event::HardBreak => {
                 if let Some(buffer) = &mut heading {
-                    buffer.push(' ');
+                    buffer.push('\n');
                 }
             }
+            Event::Html(html) | Event::InlineHtml(html) => {
+                if !in_code_block {
+                    anchors.extend(html_anchor_ids(&html));
+                }
+            }
+            Event::Start(Tag::Image { dest_url, .. }) => {
+                in_image += 1;
+                if !in_code_block {
+                    let link = dest_url.trim();
+                    if !link.is_empty() {
+                        links.push(Link {
+                            target: link.to_string(),
+                            line: Some(line_at(range.start, &newlines)),
+                        });
+                    }
+                }
+            }
+            Event::End(TagEnd::Image) => in_image = in_image.saturating_sub(1),
             Event::Start(Tag::Link {
                 link_type,
                 dest_url,
@@ -84,20 +141,87 @@ fn extract(content: &str) -> (Vec<Link>, Vec<String>) {
                     });
                 }
             }
-            Event::Start(Tag::Image { dest_url, .. }) if !in_code_block => {
-                let link = dest_url.trim();
-                if !link.is_empty() {
-                    links.push(Link {
-                        target: link.to_string(),
-                        line: Some(line_at(range.start, &newlines)),
-                    });
-                }
-            }
             _ => {}
         }
     }
 
-    (links, headings)
+    // An address the document answers to more than once — an `<a id>` beside the
+    // heading whose slug matches it — is still one address. The slugger already
+    // keeps heading slugs distinct, so this only collapses a genuine repeat.
+    let mut seen = std::collections::HashSet::new();
+    anchors.retain(|anchor| seen.insert(anchor.clone()));
+
+    (links, anchors)
+}
+
+/// The ids declared by `<a id="…">` / `<a name="…">` in a chunk of raw HTML.
+///
+/// GitHub resolves both, so a document using them really does answer to those
+/// fragments and drft has to see them — a hand-rolled table of contents and a
+/// back-compat anchor kept after a heading rename are the usual sources. Values
+/// keep their case: GitHub prefixes the rendered id but matches the fragment as
+/// written, so `#FAQ` and `#faq` are different addresses.
+fn html_anchor_ids(html: &str) -> Vec<String> {
+    let lower = html.to_ascii_lowercase();
+    let mut ids = Vec::new();
+    let mut search = 0;
+
+    while let Some(found) = lower[search..].find("<a") {
+        let after_name = search + found + "<a".len();
+        search = after_name;
+        // `<abbr>` is not `<a>`: the tag name has to end here.
+        if !lower[after_name..].starts_with([' ', '\t', '\n', '\r', '/', '>']) {
+            continue;
+        }
+        let Some(close) = lower[after_name..].find('>') else {
+            break;
+        };
+        let end = after_name + close;
+        for key in ["id", "name"] {
+            if let Some(id) = attribute(&html[after_name..end], &lower[after_name..end], key) {
+                ids.push(id);
+            }
+        }
+        search = end;
+    }
+
+    ids
+}
+
+/// The value of attribute `key` in a tag's attribute text, or `None`.
+///
+/// `raw` and `lower` are the same span, cased and lowercased; the name is matched
+/// against `lower` and the value read from `raw`. The name has to be whole —
+/// preceded by whitespace or the span's start — so `data-id=` does not answer to
+/// `id`.
+fn attribute(raw: &str, lower: &str, key: &str) -> Option<String> {
+    let mut search = 0;
+    while let Some(found) = lower[search..].find(key) {
+        let at = search + found;
+        search = at + key.len();
+        let whole = at == 0 || lower.as_bytes()[at - 1].is_ascii_whitespace();
+        let Some(rest) = lower[search..].trim_start().strip_prefix('=') else {
+            continue;
+        };
+        if !whole {
+            continue;
+        }
+        let value = &raw[raw.len() - rest.len()..].trim_start();
+        let mut chars = value.chars();
+        return match chars.next()? {
+            quote @ ('"' | '\'') => {
+                let end = value[1..].find(quote)?;
+                Some(value[1..1 + end].to_string())
+            }
+            _ => {
+                let end = value
+                    .find(|c: char| c.is_whitespace() || c == '>' || c == '/')
+                    .unwrap_or(value.len());
+                (end > 0).then(|| value[..end].to_string())
+            }
+        };
+    }
+    None
 }
 
 /// Byte offsets of every `\n` in `content`, ascending — a reusable index for
@@ -167,10 +291,74 @@ mod tests {
 
     #[test]
     fn inline_html_in_a_heading_is_not_part_of_the_slug() {
-        // GitHub slugs the rendered text, so an `<a id>` beside a heading does not
-        // leak into the anchor. (It would *override* it on GitHub — a separate
-        // feature, deliberately not honored yet.)
+        // The `<a id>` is not slugged as text — it declares an address of its own.
+        // Here both routes name `obs-92`, which is one address, not two.
         assert_eq!(anchors("## <a id=\"obs-92\"></a>OBS-92\n"), vec!["obs-92"]);
+        // When they differ, the file answers to both.
+        assert_eq!(
+            anchors("## <a id=\"legacy\"></a>OBS-92\n"),
+            vec!["legacy", "obs-92"]
+        );
+    }
+
+    #[test]
+    fn html_anchors_outside_headings_are_addresses_too() {
+        // GitHub resolves `<a id>` and `<a name>` wherever they sit, so a
+        // hand-rolled table of contents target is a real address.
+        assert_eq!(
+            anchors("<a id=\"faq\"></a>\n\n## Questions\n\n<a name=\"legacy\"></a>\n"),
+            vec!["faq", "questions", "legacy"]
+        );
+    }
+
+    #[test]
+    fn html_anchor_ids_keep_their_case_and_reject_lookalikes() {
+        // GitHub matches the fragment as written, so `#FAQ` and `#faq` differ.
+        assert_eq!(anchors("<a id=\"FAQ\"></a>\n"), vec!["FAQ"]);
+        // `<abbr>` is not `<a>`, and `data-id` is not `id`.
+        assert!(anchors("<abbr id=\"x\">a</abbr>\n").is_empty());
+        assert!(anchors("<a data-id=\"x\"></a>\n").is_empty());
+    }
+
+    #[test]
+    fn frontmatter_is_not_a_setext_heading() {
+        // A single-key block's last line plus the closing `---` reads as a setext
+        // heading to a bare parser, publishing an address the file does not have.
+        let content = "---\npurpose: the design of the widget\n---\n\n# Real\n";
+        assert_eq!(anchors(content), vec!["real"]);
+    }
+
+    #[test]
+    fn masking_frontmatter_keeps_link_lines_accurate() {
+        let parser = MarkdownParser { file_filter: None };
+        let content = "---\ntitle: Doc\n---\n\n# T\n\nSee [setup](setup.md).\n";
+        let links = parser.parse("t.md", content).links;
+        assert_eq!(
+            links[0].line,
+            Some(7),
+            "masking must not shift line numbers"
+        );
+    }
+
+    #[test]
+    fn image_alt_text_is_not_part_of_the_slug() {
+        // Alt text is an attribute, not text content, so GitHub does not slug it.
+        let parser = MarkdownParser { file_filter: None };
+        let result = parser.parse("t.md", "# ![logo](logo.png) Project\n");
+        assert_eq!(result.anchors, vec!["-project"]);
+        assert_eq!(
+            result.links[0].target, "logo.png",
+            "the image is still an edge"
+        );
+    }
+
+    #[test]
+    fn a_line_break_in_a_setext_heading_contributes_no_character() {
+        // The break renders as markup, so the halves join with nothing between.
+        assert_eq!(
+            anchors("Line one\nline two\n---\n"),
+            vec!["line-oneline-two"]
+        );
     }
 
     #[test]

--- a/src/parsers/markdown.rs
+++ b/src/parsers/markdown.rs
@@ -1,4 +1,4 @@
-use super::{Link, ParseResult, Parser, slug};
+use super::{Link, ParseResult, Parser, frontmatter, slug};
 use pulldown_cmark::{Event, LinkType, Options, Parser as CmarkParser, Tag, TagEnd};
 
 /// Built-in markdown parser. Extracts inline/reference/autolinks and images.
@@ -30,19 +30,20 @@ impl Parser for MarkdownParser {
 }
 
 /// Blank a leading YAML frontmatter block, preserving every newline so line
-/// numbers are unchanged. `None` when the file opens with no well-formed block.
+/// numbers are unchanged. `None` when the file opens with no such block.
 ///
 /// Without this, a single-key block reads as a **setext heading**: `purpose: x`
 /// followed by the closing `---` is a paragraph underlined by dashes, so the
 /// document publishes `#purpose-x` as an address it does not answer to — a
 /// fabricated anchor that also silently accepts any link written to it.
+///
+/// The boundary comes from the frontmatter parser rather than being re-derived
+/// here. Guessing it a second time is how the two disagree, and the failure is
+/// not symmetric: masking a document that merely opens with a `---` thematic
+/// break deletes its headings **and its links** from the graph, which reaches
+/// staleness and `drft impact`, not just this parser's anchors.
 fn mask_frontmatter(content: &str) -> Option<String> {
-    let rest = content.strip_prefix("---")?;
-    // The opening fence has to be a line of its own.
-    if !rest.starts_with('\n') && !rest.starts_with("\r\n") {
-        return None;
-    }
-    let close = 3 + rest.find("\n---")? + "\n---".len();
+    let close = frontmatter::mapping_block_end(content)?;
     let masked = content
         .char_indices()
         .map(|(i, ch)| {
@@ -161,67 +162,104 @@ fn extract(content: &str) -> (Vec<Link>, Vec<String>) {
 /// back-compat anchor kept after a heading rename are the usual sources. Values
 /// keep their case: GitHub prefixes the rendered id but matches the fragment as
 /// written, so `#FAQ` and `#faq` are different addresses.
+///
+/// Attributes are tokenized rather than searched for by name. Searching finds
+/// `name=` inside a quoted value and mints it as an attribute, and takes the
+/// first `>` as the tag end even when it sits inside a value — so
+/// `<a title="a > b" id="x">` would lose a real address.
 fn html_anchor_ids(html: &str) -> Vec<String> {
-    let lower = html.to_ascii_lowercase();
     let mut ids = Vec::new();
-    let mut search = 0;
+    let bytes = html.as_bytes();
+    let mut i = 0;
 
-    while let Some(found) = lower[search..].find("<a") {
-        let after_name = search + found + "<a".len();
-        search = after_name;
-        // `<abbr>` is not `<a>`: the tag name has to end here.
-        if !lower[after_name..].starts_with([' ', '\t', '\n', '\r', '/', '>']) {
+    while i < bytes.len() {
+        // `<a` has to be the whole tag name: `<abbr>` is a different element.
+        if bytes[i] != b'<'
+            || !html[i + 1..].starts_with(['a', 'A'])
+            || !html[i + 2..].starts_with([' ', '\t', '\n', '\r', '/', '>'])
+        {
+            i += 1;
             continue;
         }
-        let Some(close) = lower[after_name..].find('>') else {
-            break;
-        };
-        let end = after_name + close;
-        for key in ["id", "name"] {
-            if let Some(id) = attribute(&html[after_name..end], &lower[after_name..end], key) {
-                ids.push(id);
+        i += 2;
+        while let Some((name, value, next)) = attribute(html, i) {
+            i = next;
+            if value.is_empty() {
+                continue;
+            }
+            if name.eq_ignore_ascii_case("id") || name.eq_ignore_ascii_case("name") {
+                ids.push(value);
             }
         }
-        search = end;
     }
 
     ids
 }
 
-/// The value of attribute `key` in a tag's attribute text, or `None`.
-///
-/// `raw` and `lower` are the same span, cased and lowercased; the name is matched
-/// against `lower` and the value read from `raw`. The name has to be whole —
-/// preceded by whitespace or the span's start — so `data-id=` does not answer to
-/// `id`.
-fn attribute(raw: &str, lower: &str, key: &str) -> Option<String> {
-    let mut search = 0;
-    while let Some(found) = lower[search..].find(key) {
-        let at = search + found;
-        search = at + key.len();
-        let whole = at == 0 || lower.as_bytes()[at - 1].is_ascii_whitespace();
-        let Some(rest) = lower[search..].trim_start().strip_prefix('=') else {
-            continue;
-        };
-        if !whole {
-            continue;
-        }
-        let value = &raw[raw.len() - rest.len()..].trim_start();
-        let mut chars = value.chars();
-        return match chars.next()? {
-            quote @ ('"' | '\'') => {
-                let end = value[1..].find(quote)?;
-                Some(value[1..1 + end].to_string())
-            }
-            _ => {
-                let end = value
-                    .find(|c: char| c.is_whitespace() || c == '>' || c == '/')
-                    .unwrap_or(value.len());
-                (end > 0).then(|| value[..end].to_string())
-            }
-        };
+/// The next attribute in a tag body starting at `from`, as `(name, value, next)`.
+/// `None` at the tag's `>` or at the end of the input, which is what ends the
+/// caller's loop.
+fn attribute(html: &str, from: usize) -> Option<(&str, String, usize)> {
+    let bytes = html.as_bytes();
+    let mut i = from;
+
+    while i < bytes.len() && (bytes[i].is_ascii_whitespace() || bytes[i] == b'/') {
+        i += 1;
     }
-    None
+    if i >= bytes.len() || bytes[i] == b'>' {
+        return None;
+    }
+
+    let name_start = i;
+    while i < bytes.len()
+        && !bytes[i].is_ascii_whitespace()
+        && !matches!(bytes[i], b'=' | b'>' | b'/')
+    {
+        i += 1;
+    }
+    let name = &html[name_start..i];
+
+    // A bare attribute (`<a hidden>`) has no value; the caller skips it.
+    let mut after_name = i;
+    while after_name < bytes.len() && bytes[after_name].is_ascii_whitespace() {
+        after_name += 1;
+    }
+    if after_name >= bytes.len() || bytes[after_name] != b'=' {
+        return Some((name, String::new(), i));
+    }
+    i = after_name + 1;
+    while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    if i >= bytes.len() {
+        return Some((name, String::new(), i));
+    }
+
+    let value_start;
+    let value_end;
+    match bytes[i] {
+        quote @ (b'"' | b'\'') => {
+            value_start = i + 1;
+            match html[value_start..].find(quote as char) {
+                Some(offset) => {
+                    value_end = value_start + offset;
+                    i = value_end + 1;
+                }
+                // An unterminated quote runs to the end of the chunk; taking the
+                // rest as a value would mint an address out of prose.
+                None => return None,
+            }
+        }
+        _ => {
+            value_start = i;
+            while i < bytes.len() && !bytes[i].is_ascii_whitespace() && bytes[i] != b'>' {
+                i += 1;
+            }
+            value_end = i;
+        }
+    }
+
+    Some((name, html[value_start..value_end].to_string(), i))
 }
 
 /// Byte offsets of every `\n` in `content`, ascending — a reusable index for
@@ -318,6 +356,62 @@ mod tests {
         // `<abbr>` is not `<a>`, and `data-id` is not `id`.
         assert!(anchors("<abbr id=\"x\">a</abbr>\n").is_empty());
         assert!(anchors("<a data-id=\"x\"></a>\n").is_empty());
+    }
+
+    #[test]
+    fn a_quoted_angle_bracket_does_not_end_the_tag() {
+        // Searching for the first `>` would truncate the tag and lose a real
+        // address, turning every link to it into a false positive.
+        assert_eq!(
+            anchors("<a title=\"a > b\" id=\"kept\"></a>\n"),
+            vec!["kept"]
+        );
+    }
+
+    #[test]
+    fn an_attribute_value_is_not_rescanned_for_attribute_names() {
+        // `name=` inside a quoted value is text, not an attribute.
+        assert_eq!(
+            anchors("<a title=\"name=x\" id=\"only\"></a>\n"),
+            vec!["only"]
+        );
+    }
+
+    #[test]
+    fn a_bare_attribute_and_an_empty_value_are_skipped() {
+        assert_eq!(
+            anchors("<a hidden id=\"after-bare\"></a>\n"),
+            vec!["after-bare"]
+        );
+        assert!(
+            anchors("<a id=\"\"></a>\n").is_empty(),
+            "empty is not an address"
+        );
+    }
+
+    #[test]
+    fn a_malformed_tag_mints_nothing() {
+        // The parser's own tag grammar rejects it before the scan, and the scan
+        // bails on an unterminated quote rather than taking prose as a value.
+        assert!(anchors("<a id=\"unclosed name=\"real\"></a>\n").is_empty());
+        assert!(anchors("<a id=\"never closed\n").is_empty());
+    }
+
+    #[test]
+    fn a_leading_thematic_break_is_not_frontmatter() {
+        // Masking a document that merely opens with `---` deletes its headings
+        // *and* its links from the graph, which reaches far past this parser.
+        let parser = MarkdownParser { file_filter: None };
+        let content = "---\n\n# First\n\nSee [a](t.md).\n\n---\n\n# Second\n";
+        let result = parser.parse("hr.md", content);
+        assert_eq!(result.anchors, vec!["first", "second"]);
+        assert_eq!(result.links[0].target, "t.md");
+        assert_eq!(result.links[0].line, Some(5));
+    }
+
+    #[test]
+    fn a_rule_above_a_setext_title_is_not_frontmatter() {
+        assert_eq!(anchors("---\nMy Title\n---\n\nBody\n"), vec!["my-title"]);
     }
 
     #[test]

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod frontmatter;
 pub mod markdown;
+pub mod slug;
 
 /// One link discovered by a parser: its raw target string as it appears in the
 /// source, plus the 1-based source line where it occurs (`None` when the parser
@@ -15,10 +16,14 @@ pub struct Link {
     pub line: Option<usize>,
 }
 
-/// Combined output from parsing a single file: links + optional metadata.
+/// Combined output from parsing a single file: links, the anchors it defines,
+/// and optional metadata.
 #[derive(Debug, Clone, Default)]
 pub struct ParseResult {
     pub links: Vec<Link>,
+    /// The `#fragment` addresses this file answers to, in document order. Empty
+    /// for a parser that defines no addressable sub-file positions.
+    pub anchors: Vec<String>,
     /// Structured metadata extracted from the file.
     pub metadata: Option<serde_json::Value>,
 }

--- a/src/parsers/slug.rs
+++ b/src/parsers/slug.rs
@@ -8,12 +8,13 @@
 //! nothing — and certifying a link that 404s for a reader is the one thing
 //! sub-file addressing must not do.
 //!
-//! The algorithm is undocumented; this follows `html-pipeline`'s
-//! `TableOfContentsFilter`, which is what GitHub renders with. Its surprises are
-//! pinned by the tests below rather than described here, because the tests are
-//! what a future change is measured against.
+//! The algorithm is undocumented; this follows `github-slugger`, which is what
+//! GitHub's markdown pipeline runs. Its surprises are pinned by the tests below
+//! rather than described here, because the tests are what a future change is
+//! measured against.
 
 use std::collections::HashMap;
+use unicode_general_category::{GeneralCategory, get_general_category};
 
 /// The anchor a heading's rendered text answers to.
 ///
@@ -23,38 +24,72 @@ use std::collections::HashMap;
 /// behind and yields a double hyphen — `Sizing — notes` becomes
 /// `sizing--notes`, which is the trap worth knowing about when a heading is also
 /// an identity.
+///
+/// "Letter, digit, underscore" approximates the `\p{Word}` class the reference
+/// implementation keeps. Combining marks are part of that class and are kept
+/// here too, so an NFD-normalized `café` does not lose its accent and slug as
+/// `cafe`.
 pub fn slug(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     for ch in text.chars().flat_map(char::to_lowercase) {
         if ch == ' ' {
             out.push('-');
-        } else if ch == '-' || ch == '_' || ch.is_alphanumeric() {
+        } else if ch == '-' || ch == '_' || ch.is_alphanumeric() || is_mark(ch) {
             out.push(ch);
         }
     }
     out
 }
 
-/// Resolve a document's headings, in order, to the anchors they define.
+/// Whether `ch` is a Unicode combining mark (`\p{M}`) — kept by the slug so a
+/// decomposed character survives as the character it composes.
+fn is_mark(ch: char) -> bool {
+    matches!(
+        get_general_category(ch),
+        GeneralCategory::NonspacingMark
+            | GeneralCategory::SpacingMark
+            | GeneralCategory::EnclosingMark
+    )
+}
+
+/// Assigns anchors across one document, disambiguating repeats.
 ///
-/// A slug that repeats takes GitHub's `-1`, `-2` disambiguator, so the second
+/// A slug that repeats takes GitHub's `-1`, `-2` suffix, so the second
 /// `## Notes` answers to `#notes-1`. Order therefore decides identity for a
 /// repeated heading — worth knowing before a heading becomes a node key.
-pub fn anchors<'a>(headings: impl IntoIterator<Item = &'a str>) -> Vec<String> {
-    let mut seen: HashMap<String, usize> = HashMap::new();
+///
+/// The suffix is re-checked rather than merely appended, so a document holding
+/// `a`, `a`, and a literal `a-1` yields `a`, `a-1`, `a-1-1` instead of emitting
+/// `a-1` twice. Two headings claiming one anchor is a real collision on the
+/// page, and a published list that repeats an address cannot be checked against.
+#[derive(Debug, Default)]
+pub struct Slugger {
+    /// Every anchor handed out, plus the suffix counter for each base slug.
+    occurrences: HashMap<String, usize>,
+}
+
+impl Slugger {
+    /// The anchor this heading text answers to, given everything assigned so far.
+    pub fn heading(&mut self, text: &str) -> String {
+        let base = slug(text);
+        let mut anchor = base.clone();
+        while self.occurrences.contains_key(&anchor) {
+            let counter = self.occurrences.entry(base.clone()).or_insert(0);
+            *counter += 1;
+            anchor = format!("{base}-{counter}");
+        }
+        self.occurrences.insert(anchor.clone(), 0);
+        anchor
+    }
+}
+
+/// Resolve a document's headings, in order, to the anchors they define.
+#[cfg(test)]
+fn anchors<'a>(headings: impl IntoIterator<Item = &'a str>) -> Vec<String> {
+    let mut slugger = Slugger::default();
     headings
         .into_iter()
-        .map(|text| {
-            let base = slug(text);
-            let count = seen.entry(base.clone()).or_insert(0);
-            let anchor = if *count == 0 {
-                base.clone()
-            } else {
-                format!("{base}-{count}")
-            };
-            *count += 1;
-            anchor
-        })
+        .map(|text| slugger.heading(text))
         .collect()
 }
 
@@ -118,6 +153,24 @@ mod tests {
             anchors(["Notes", "Notes", "Other", "Notes"]),
             vec!["notes", "notes-1", "other", "notes-2"]
         );
+    }
+
+    #[test]
+    fn a_suffix_that_would_collide_is_bumped_again() {
+        // Appending without re-checking would hand `a-1` to two headings, and an
+        // address list that repeats itself cannot be checked against.
+        assert_eq!(
+            anchors(["a", "a", "a-1", "a"]),
+            vec!["a", "a-1", "a-1-1", "a-2"]
+        );
+    }
+
+    #[test]
+    fn combining_marks_survive() {
+        // Decomposed `café`: `e` followed by U+0301. Dropping the mark would slug
+        // it `cafe` and reject the `#café` a reader's browser resolves.
+        assert_eq!(slug("Cafe\u{301}"), "cafe\u{301}");
+        assert_eq!(slug("Café"), "café");
     }
 
     #[test]

--- a/src/parsers/slug.rs
+++ b/src/parsers/slug.rs
@@ -1,0 +1,128 @@
+//! GitHub's heading-anchor algorithm: the function that decides what `#fragment`
+//! a heading answers to.
+//!
+//! drft runs this over the **heading** and compares a link's fragment to the
+//! result byte-for-byte. It never runs over the fragment. Normalizing the citing
+//! side would buy acceptances the platform does not grant — slugging `#OBS 92`
+//! yields `obs-92` and would match, where a browser sends `#OBS%2092` and finds
+//! nothing — and certifying a link that 404s for a reader is the one thing
+//! sub-file addressing must not do.
+//!
+//! The algorithm is undocumented; this follows `html-pipeline`'s
+//! `TableOfContentsFilter`, which is what GitHub renders with. Its surprises are
+//! pinned by the tests below rather than described here, because the tests are
+//! what a future change is measured against.
+
+use std::collections::HashMap;
+
+/// The anchor a heading's rendered text answers to.
+///
+/// Downcase, drop every character that is not a letter, digit, underscore,
+/// hyphen, or space, then turn spaces into hyphens. Punctuation is **removed
+/// rather than replaced**, so a character sitting between two spaces leaves both
+/// behind and yields a double hyphen — `Sizing — notes` becomes
+/// `sizing--notes`, which is the trap worth knowing about when a heading is also
+/// an identity.
+pub fn slug(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars().flat_map(char::to_lowercase) {
+        if ch == ' ' {
+            out.push('-');
+        } else if ch == '-' || ch == '_' || ch.is_alphanumeric() {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Resolve a document's headings, in order, to the anchors they define.
+///
+/// A slug that repeats takes GitHub's `-1`, `-2` disambiguator, so the second
+/// `## Notes` answers to `#notes-1`. Order therefore decides identity for a
+/// repeated heading — worth knowing before a heading becomes a node key.
+pub fn anchors<'a>(headings: impl IntoIterator<Item = &'a str>) -> Vec<String> {
+    let mut seen: HashMap<String, usize> = HashMap::new();
+    headings
+        .into_iter()
+        .map(|text| {
+            let base = slug(text);
+            let count = seen.entry(base.clone()).or_insert(0);
+            let anchor = if *count == 0 {
+                base.clone()
+            } else {
+                format!("{base}-{count}")
+            };
+            *count += 1;
+            anchor
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_bare_id_heading_slugs_to_itself_lowercased() {
+        // The shape a record container uses: the heading is the id and nothing
+        // else, so the anchor is the id a reader would write.
+        assert_eq!(slug("OBS-92"), "obs-92");
+        assert_eq!(slug("W-01"), "w-01");
+    }
+
+    #[test]
+    fn a_title_joins_with_hyphens() {
+        assert_eq!(slug("OBS-92: Sampling gap"), "obs-92-sampling-gap");
+        assert_eq!(slug("Reading the graph"), "reading-the-graph");
+    }
+
+    #[test]
+    fn punctuation_is_removed_not_replaced() {
+        // The double-hyphen trap: the em dash goes, both spaces around it stay,
+        // and each becomes a hyphen.
+        assert_eq!(slug("Sizing — notes"), "sizing--notes");
+        assert_eq!(slug("What now?"), "what-now");
+        assert_eq!(slug("a.b.c"), "abc");
+        assert_eq!(slug("50% done"), "50-done");
+    }
+
+    #[test]
+    fn underscores_and_hyphens_survive() {
+        assert_eq!(
+            slug("snake_case and kebab-case"),
+            "snake_case-and-kebab-case"
+        );
+    }
+
+    #[test]
+    fn a_stripped_leading_character_leaves_a_leading_hyphen() {
+        // An emoji is not a word character, so it is dropped and the space after
+        // it becomes the first character of the anchor.
+        assert_eq!(slug("🚀 Launch"), "-launch");
+    }
+
+    #[test]
+    fn non_ascii_letters_and_digits_are_kept() {
+        assert_eq!(slug("Café Ω 42"), "café-ω-42");
+    }
+
+    #[test]
+    fn empty_and_punctuation_only_headings_slug_to_nothing() {
+        assert_eq!(slug(""), "");
+        assert_eq!(slug("!!!"), "");
+    }
+
+    #[test]
+    fn a_repeated_slug_takes_the_github_disambiguator() {
+        assert_eq!(
+            anchors(["Notes", "Notes", "Other", "Notes"]),
+            vec!["notes", "notes-1", "other", "notes-2"]
+        );
+    }
+
+    #[test]
+    fn headings_differing_only_in_case_collide() {
+        // Downcasing happens before disambiguation, so these are one slug space.
+        assert_eq!(anchors(["Setup", "SETUP"]), vec!["setup", "setup-1"]);
+    }
+}

--- a/src/rules/check.rs
+++ b/src/rules/check.rs
@@ -19,7 +19,7 @@ pub fn run(graph: &Graph, lock: Option<&Lock>, config: &Config) -> Vec<Finding> 
     if let Some(lock) = lock {
         findings.extend(staleness::evaluate(graph, lock));
     }
-    findings.extend(structural::evaluate(graph));
+    findings.extend(structural::evaluate(graph, &config.anchor_namespaces()));
 
     findings.retain_mut(|finding| {
         // Default severity is warn unless config overrides the rule.
@@ -38,10 +38,13 @@ pub fn run(graph: &Graph, lock: Option<&Lock>, config: &Config) -> Vec<Finding> 
         true
     });
 
+    // Lines before message, so several findings on one subject read in the order
+    // a reader would walk the file rather than in fragment byte order.
     findings.sort_by(|a, b| {
         a.name
             .cmp(&b.name)
             .then_with(|| a.subject.cmp(&b.subject))
+            .then_with(|| a.lines.cmp(&b.lines))
             .then_with(|| a.message.cmp(&b.message))
     });
     findings

--- a/src/rules/structural.rs
+++ b/src/rules/structural.rs
@@ -14,8 +14,10 @@ use crate::model::{Graph, Node};
 use crate::rules::{edge_provenance, provenance};
 use crate::util::is_uri;
 
-/// Evaluate structural findings for `graph`.
-pub fn evaluate(graph: &Graph) -> Vec<Finding> {
+/// Evaluate structural findings for `graph`. `anchor_namespaces` names the
+/// graphs whose parser publishes the addresses a fragment may be checked
+/// against; with none, `unresolved-fragment` cannot fire.
+pub fn evaluate(graph: &Graph, anchor_namespaces: &[String]) -> Vec<Finding> {
     let mut findings = Vec::new();
 
     // unresolved-edge: a non-URI edge target with no defining node.
@@ -55,7 +57,7 @@ pub fn evaluate(graph: &Graph) -> Vec<Finding> {
         };
         // `None` means nothing read the target as a document with addressable
         // positions, so its fragments are unknown, not broken.
-        let Some(anchors) = target.anchors() else {
+        let Some(anchors) = target.anchors(anchor_namespaces) else {
             continue;
         };
 
@@ -73,7 +75,13 @@ pub fn evaluate(graph: &Graph) -> Vec<Finding> {
             else {
                 continue;
             };
-            if anchors.contains(&fragment) {
+            // A browser percent-decodes the fragment before looking for an id,
+            // and GitHub's own copied permalink is percent-encoded for any
+            // non-ASCII anchor. Decoding accepts exactly what the platform
+            // accepts; it is not the loosening that slugging the fragment would
+            // be, since `#OBS%2092` still decodes to `OBS 92` and still misses.
+            let decoded = percent_decode(fragment);
+            if anchors.contains(&fragment) || anchors.iter().any(|a| *a == decoded) {
                 continue;
             }
             let lines = missing.entry(fragment).or_default();
@@ -123,20 +131,40 @@ pub fn evaluate(graph: &Graph) -> Vec<Finding> {
     findings
 }
 
+/// Percent-decode a fragment, resolving `%XX` byte escapes as UTF-8. Invalid
+/// escapes and invalid UTF-8 leave the text as written, which then simply fails
+/// to match — a fragment drft cannot decode is not one it should guess at.
+fn percent_decode(fragment: &str) -> String {
+    let bytes = fragment.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%'
+            && let Some(hex) = fragment.get(i + 1..i + 3)
+            && let Ok(byte) = u8::from_str_radix(hex, 16)
+        {
+            out.push(byte);
+            i += 3;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).unwrap_or_else(|_| fragment.to_string())
+}
+
 /// A fragment that matches an anchor once case is ignored is almost certainly a
 /// typo, so name the anchor it meant.
 ///
-/// Browsers fall back to an ASCII-case-insensitive match when no id matches
-/// exactly, so this link is not broken for a reader today — it is fragile across
-/// renderers and trivially fixable, which makes it worth surfacing rather than
-/// silently resolving. Resolution stays exact: matching case-insensitively here
-/// would normalize the citing side, and the whole point of running one slug
-/// function over the heading alone is to never accept more than the platform
-/// does.
+/// Id matching is case-sensitive, so this link is broken rather than merely
+/// untidy — the cause exists to make the fix obvious, not to excuse it.
+/// Resolution stays exact: matching case-insensitively here would accept an
+/// address the platform does not resolve.
 fn case_mismatch_cause(anchors: &[&str], fragment: &str) -> Option<String> {
+    let lowered = fragment.to_lowercase();
     let anchor = anchors
         .iter()
-        .find(|anchor| anchor.eq_ignore_ascii_case(fragment))?;
+        .find(|anchor| anchor.to_lowercase() == lowered)?;
     Some(format!(
         "`#{fragment}` differs only in case from `#{anchor}`, which the target defines"
     ))
@@ -191,7 +219,7 @@ mod tests {
         fs.add_edge(Edge::new("index.md", "gone.md"));
         let composed = compose(&GraphSet::new(vec![fs]));
 
-        let findings = evaluate(&composed);
+        let findings = evaluate(&composed, &[crate::model::namespace("markdown")]);
         assert!(names(&findings).contains(&("unresolved-edge", "index.md")));
     }
 
@@ -236,7 +264,7 @@ mod tests {
         }
         let composed = compose(&GraphSet::new(vec![fs, markdown]));
 
-        let findings = evaluate(&composed);
+        let findings = evaluate(&composed, &[crate::model::namespace("markdown")]);
         let f = findings
             .iter()
             .find(|f| f.name == "unresolved-edge")
@@ -260,7 +288,7 @@ mod tests {
             "docs/predicated/artifact/src/lib.rs",
             "predicated/artifact/src/lib.rs",
         );
-        let findings = evaluate(&composed);
+        let findings = evaluate(&composed, &[crate::model::namespace("markdown")]);
         let cause = findings
             .iter()
             .find(|f| f.name == "unresolved-edge")
@@ -286,7 +314,7 @@ mod tests {
             "docs/typo.rs",
             "typo.rs",
         );
-        let findings = evaluate(&composed);
+        let findings = evaluate(&composed, &[crate::model::namespace("markdown")]);
         let f = findings
             .iter()
             .find(|f| f.name == "unresolved-edge")
@@ -304,7 +332,7 @@ mod tests {
             "docs/x.md",
             "./x.md",
         );
-        let findings = evaluate(&composed);
+        let findings = evaluate(&composed, &[crate::model::namespace("markdown")]);
         let f = findings
             .iter()
             .find(|f| f.name == "unresolved-edge")
@@ -341,7 +369,7 @@ mod tests {
             json!([{ "line": 3, "link": "owners.md#security-console" }]),
         );
         assert!(
-            !names(&evaluate(&composed))
+            !names(&evaluate(&composed, &[crate::model::namespace("markdown")]))
                 .iter()
                 .any(|(name, _)| *name == "unresolved-fragment")
         );
@@ -359,7 +387,7 @@ mod tests {
                 { "line": 7, "link": "owners.md#no-such-team" },
             ]),
         );
-        let findings = evaluate(&composed);
+        let findings = evaluate(&composed, &[crate::model::namespace("markdown")]);
         let f = findings
             .iter()
             .find(|f| f.name == "unresolved-fragment")
@@ -378,7 +406,7 @@ mod tests {
                 { "line": 9, "link": "owners.md#typo" },
             ]),
         );
-        let findings: Vec<_> = evaluate(&composed)
+        let findings: Vec<_> = evaluate(&composed, &[crate::model::namespace("markdown")])
             .into_iter()
             .filter(|f| f.name == "unresolved-fragment")
             .collect();
@@ -392,7 +420,7 @@ mod tests {
             &["ngwaf-edge"],
             json!([{ "line": 5, "link": "owners.md#NGWAF-Edge" }]),
         );
-        let findings = evaluate(&composed);
+        let findings = evaluate(&composed, &[crate::model::namespace("markdown")]);
         let f = findings
             .iter()
             .find(|f| f.name == "unresolved-fragment")
@@ -402,10 +430,76 @@ mod tests {
     }
 
     #[test]
+    fn a_percent_encoded_fragment_resolves() {
+        // A browser percent-decodes before matching, and GitHub's own copied
+        // permalink is encoded for a non-ASCII anchor.
+        let composed = graph_with_fragments(
+            &["café"],
+            json!([{ "line": 3, "link": "owners.md#caf%C3%A9" }]),
+        );
+        assert!(
+            !names(&evaluate(&composed, &[crate::model::namespace("markdown")]))
+                .iter()
+                .any(|(name, _)| *name == "unresolved-fragment")
+        );
+    }
+
+    #[test]
+    fn decoding_does_not_accept_what_the_platform_rejects() {
+        // `#OBS%2092` decodes to `OBS 92`, which is still not `obs-92`. Decoding
+        // is not the loosening that slugging the citing side would be.
+        let composed = graph_with_fragments(
+            &["obs-92"],
+            json!([{ "line": 3, "link": "owners.md#OBS%2092" }]),
+        );
+        assert!(
+            names(&evaluate(&composed, &[crate::model::namespace("markdown")]))
+                .iter()
+                .any(|(name, _)| *name == "unresolved-fragment")
+        );
+    }
+
+    #[test]
+    fn frontmatter_cannot_claim_anchors_a_file_does_not_have() {
+        // Node metadata under `@frontmatter` is the author's own YAML. Only a
+        // graph whose parser publishes anchors is authoritative about them.
+        let mut fs = Graph::labeled("fs");
+        fs.set_node("work-items.md", fs_node());
+        fs.set_node("owners.md", fs_node());
+        let mut frontmatter = Graph::labeled("frontmatter");
+        frontmatter.set_node(
+            "owners.md",
+            Node::new(
+                json!({ "anchors": ["invented"] })
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            ),
+        );
+        let mut markdown = Graph::labeled("markdown");
+        let mut meta = Metadata::new();
+        meta.insert(
+            "occurrences".into(),
+            json!([{ "line": 3, "link": "owners.md#invented" }]),
+        );
+        markdown.add_edge(Edge::with_metadata("work-items.md", "owners.md", meta));
+        let composed = compose(&GraphSet::new(vec![fs, frontmatter, markdown]));
+
+        // `owners.md` was never read as markdown, so its fragments stay unknown
+        // however its frontmatter is written — no finding, and no false clearance.
+        let findings = evaluate(&composed, &[crate::model::namespace("markdown")]);
+        assert!(
+            !names(&findings)
+                .iter()
+                .any(|(n, _)| *n == "unresolved-fragment")
+        );
+    }
+
+    #[test]
     fn a_bare_hash_is_the_top_of_the_page() {
         let composed = graph_with_fragments(&["a"], json!([{ "line": 2, "link": "owners.md#" }]));
         assert!(
-            !names(&evaluate(&composed))
+            !names(&evaluate(&composed, &[crate::model::namespace("markdown")]))
                 .iter()
                 .any(|(name, _)| *name == "unresolved-fragment")
         );
@@ -427,7 +521,7 @@ mod tests {
         markdown.add_edge(Edge::with_metadata("guide.md", "src/lib.rs", meta));
         let composed = compose(&GraphSet::new(vec![fs, markdown]));
         assert!(
-            !names(&evaluate(&composed))
+            !names(&evaluate(&composed, &[crate::model::namespace("markdown")]))
                 .iter()
                 .any(|(name, _)| *name == "unresolved-fragment")
         );
@@ -439,7 +533,7 @@ mod tests {
         // defines no addresses, so the fragment is broken rather than unknown.
         let composed =
             graph_with_fragments(&[], json!([{ "line": 4, "link": "owners.md#anything" }]));
-        let findings = evaluate(&composed);
+        let findings = evaluate(&composed, &[crate::model::namespace("markdown")]);
         assert!(
             findings.iter().any(|f| f.name == "unresolved-fragment"),
             "got {:?}",
@@ -462,7 +556,7 @@ mod tests {
         markdown.add_edge(Edge::with_metadata("guide.md", "gone.md", meta));
         let composed = compose(&GraphSet::new(vec![fs, markdown]));
 
-        let findings = evaluate(&composed);
+        let findings = evaluate(&composed, &[crate::model::namespace("markdown")]);
         let found = names(&findings);
         assert!(
             found.contains(&("unresolved-edge", "guide.md")),
@@ -482,7 +576,7 @@ mod tests {
         fs.set_node("index.md", fs_node());
         let composed = compose(&GraphSet::new(vec![fs, markdown]));
 
-        let findings = evaluate(&composed);
+        let findings = evaluate(&composed, &[crate::model::namespace("markdown")]);
         let f = findings
             .iter()
             .find(|f| f.name == "unresolved-edge")
@@ -504,7 +598,7 @@ mod tests {
         let composed = compose(&GraphSet::new(vec![fs, markdown]));
 
         assert!(
-            !names(&evaluate(&composed))
+            !names(&evaluate(&composed, &[crate::model::namespace("markdown")]))
                 .iter()
                 .any(|(name, _)| *name == "unresolved-edge")
         );
@@ -519,7 +613,7 @@ mod tests {
         fs.add_edge(Edge::new("a.md", "b.md"));
         let composed = compose(&GraphSet::new(vec![fs]));
 
-        let findings = evaluate(&composed);
+        let findings = evaluate(&composed, &[crate::model::namespace("markdown")]);
         let n = names(&findings);
         assert!(n.contains(&("detached-node", "lonely.md")), "got {n:?}");
         assert!(!n.contains(&("detached-node", "a.md")));
@@ -537,7 +631,7 @@ mod tests {
         fs.set_node("lonely.md", fs_node());
         let composed = compose(&GraphSet::new(vec![fs]));
 
-        let findings = evaluate(&composed);
+        let findings = evaluate(&composed, &[crate::model::namespace("markdown")]);
         let n = names(&findings);
         assert!(
             !n.contains(&("detached-node", "guides")),

--- a/src/rules/structural.rs
+++ b/src/rules/structural.rs
@@ -99,7 +99,8 @@ pub fn evaluate(graph: &Graph, anchor_namespaces: &[String]) -> Vec<Finding> {
             )
             .with_target(format!("{}#{fragment}", edge.target))
             .with_lines(lines.into_iter().collect());
-            if let Some(cause) = case_mismatch_cause(&anchors, fragment) {
+            if let Some(cause) = case_mismatch_cause(&anchors, fragment, &percent_decode(fragment))
+            {
                 finding = finding.with_cause(cause);
             }
             findings.push(finding);
@@ -141,6 +142,8 @@ fn percent_decode(fragment: &str) -> String {
     while i < bytes.len() {
         if bytes[i] == b'%'
             && let Some(hex) = fragment.get(i + 1..i + 3)
+            // `from_str_radix` accepts a leading sign, so `%+A` would decode.
+            && hex.bytes().all(|b| b.is_ascii_hexdigit())
             && let Ok(byte) = u8::from_str_radix(hex, 16)
         {
             out.push(byte);
@@ -160,11 +163,15 @@ fn percent_decode(fragment: &str) -> String {
 /// untidy — the cause exists to make the fix obvious, not to excuse it.
 /// Resolution stays exact: matching case-insensitively here would accept an
 /// address the platform does not resolve.
-fn case_mismatch_cause(anchors: &[&str], fragment: &str) -> Option<String> {
-    let lowered = fragment.to_lowercase();
-    let anchor = anchors
-        .iter()
-        .find(|anchor| anchor.to_lowercase() == lowered)?;
+fn case_mismatch_cause(anchors: &[&str], fragment: &str, decoded: &str) -> Option<String> {
+    // Checked against the decoded spelling too, so a percent-encoded fragment
+    // gets the same help as a literal one.
+    let written = fragment.to_lowercase();
+    let decoded = decoded.to_lowercase();
+    let anchor = anchors.iter().find(|anchor| {
+        let anchor = anchor.to_lowercase();
+        anchor == written || anchor == decoded
+    })?;
     Some(format!(
         "`#{fragment}` differs only in case from `#{anchor}`, which the target defines"
     ))

--- a/src/rules/structural.rs
+++ b/src/rules/structural.rs
@@ -1,10 +1,13 @@
 //! Structural rules: findings derived from graph shape alone, no lockfile.
 //!
 //! Findings: `unresolved-edge` (an edge target with no `@fs` block — no defining
-//! node) and `detached-node` (a node with no inbound or outbound edges). URI
+//! node), `unresolved-fragment` (a link's `#fragment` names no anchor the target
+//! defines), and `detached-node` (a node with no inbound or outbound edges). URI
 //! targets are intentional external references, not unresolved.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+use serde_json::Value;
 
 use crate::diagnostic::Finding;
 use crate::model::{Graph, Node};
@@ -37,6 +40,64 @@ pub fn evaluate(graph: &Graph) -> Vec<Finding> {
         }
     }
 
+    // unresolved-fragment: a link carries a `#fragment` the target does not
+    // define. Reported per fragment rather than per edge, because a source citing
+    // two anchors of one target is one edge with two claims and only one of them
+    // may be wrong.
+    for edge in &graph.edges {
+        if is_uri(&edge.target) {
+            continue;
+        }
+        // An unresolvable target is already reported as `unresolved-edge`; the
+        // fragment is the lesser half of the same mistake.
+        let Some(target) = graph.nodes.get(&edge.target).filter(|n| n.is_resolved()) else {
+            continue;
+        };
+        // `None` means nothing read the target as a document with addressable
+        // positions, so its fragments are unknown, not broken.
+        let Some(anchors) = target.anchors() else {
+            continue;
+        };
+
+        let mut missing: BTreeMap<&str, BTreeSet<usize>> = BTreeMap::new();
+        for occurrence in edge.occurrences() {
+            let Some(link) = occurrence.get("link").and_then(Value::as_str) else {
+                continue;
+            };
+            // A bare `#` is a link to the top of the page, which every document
+            // answers to.
+            let Some(fragment) = link
+                .split_once('#')
+                .map(|(_, f)| f)
+                .filter(|f| !f.is_empty())
+            else {
+                continue;
+            };
+            if anchors.contains(&fragment) {
+                continue;
+            }
+            let lines = missing.entry(fragment).or_default();
+            if let Some(line) = occurrence.get("line").and_then(Value::as_u64) {
+                lines.insert(line as usize);
+            }
+        }
+
+        for (fragment, lines) in missing {
+            let mut finding = Finding::warn(
+                "unresolved-fragment",
+                &edge.source,
+                edge_provenance(edge),
+                "no matching anchor",
+            )
+            .with_target(format!("{}#{fragment}", edge.target))
+            .with_lines(lines.into_iter().collect());
+            if let Some(cause) = case_mismatch_cause(&anchors, fragment) {
+                finding = finding.with_cause(cause);
+            }
+            findings.push(finding);
+        }
+    }
+
     // detached-node: a file touched by no edge in either direction. Directories
     // are structural scaffolding — links point at the files inside them, not at
     // the directory — so a link-less directory is normal, not orphaned content.
@@ -60,6 +121,25 @@ pub fn evaluate(graph: &Graph) -> Vec<Finding> {
     }
 
     findings
+}
+
+/// A fragment that matches an anchor once case is ignored is almost certainly a
+/// typo, so name the anchor it meant.
+///
+/// Browsers fall back to an ASCII-case-insensitive match when no id matches
+/// exactly, so this link is not broken for a reader today — it is fragile across
+/// renderers and trivially fixable, which makes it worth surfacing rather than
+/// silently resolving. Resolution stays exact: matching case-insensitively here
+/// would normalize the citing side, and the whole point of running one slug
+/// function over the heading alone is to never accept more than the platform
+/// does.
+fn case_mismatch_cause(anchors: &[&str], fragment: &str) -> Option<String> {
+    let anchor = anchors
+        .iter()
+        .find(|anchor| anchor.eq_ignore_ascii_case(fragment))?;
+    Some(format!(
+        "`#{fragment}` differs only in case from `#{anchor}`, which the target defines"
+    ))
 }
 
 /// A path written against the graph root when links resolve against the
@@ -230,6 +310,165 @@ mod tests {
             .find(|f| f.name == "unresolved-edge")
             .unwrap();
         assert!(f.cause.is_none(), "got: {:?}", f.cause);
+    }
+
+    /// Compose a graph where `source` links `target` with the given fragments,
+    /// and `target` defines `anchors`.
+    fn graph_with_fragments(target_anchors: &[&str], occurrences: serde_json::Value) -> Graph {
+        let mut fs = Graph::labeled("fs");
+        fs.set_node("work-items.md", fs_node());
+        fs.set_node("owners.md", fs_node());
+        let mut markdown = Graph::labeled("markdown");
+        markdown.set_node(
+            "owners.md",
+            Node::new(
+                json!({ "anchors": target_anchors })
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            ),
+        );
+        let mut meta = Metadata::new();
+        meta.insert("occurrences".into(), occurrences);
+        markdown.add_edge(Edge::with_metadata("work-items.md", "owners.md", meta));
+        compose(&GraphSet::new(vec![fs, markdown]))
+    }
+
+    #[test]
+    fn a_fragment_the_target_defines_is_quiet() {
+        let composed = graph_with_fragments(
+            &["security-console"],
+            json!([{ "line": 3, "link": "owners.md#security-console" }]),
+        );
+        assert!(
+            !names(&evaluate(&composed))
+                .iter()
+                .any(|(name, _)| *name == "unresolved-fragment")
+        );
+    }
+
+    #[test]
+    fn a_fragment_the_target_does_not_define_fires_on_its_own_line() {
+        // The defect per-occurrence metadata was built for: one edge, two
+        // anchors, only one of them wrong. The finding names the wrong one's line
+        // and leaves the other alone.
+        let composed = graph_with_fragments(
+            &["security-console"],
+            json!([
+                { "line": 3, "link": "owners.md#security-console" },
+                { "line": 7, "link": "owners.md#no-such-team" },
+            ]),
+        );
+        let findings = evaluate(&composed);
+        let f = findings
+            .iter()
+            .find(|f| f.name == "unresolved-fragment")
+            .expect("expected a finding");
+        assert_eq!(f.target.as_deref(), Some("owners.md#no-such-team"));
+        assert_eq!(f.lines, vec![7], "line 3 is fine and is not implicated");
+        assert!(f.cause.is_none(), "nothing near it in case");
+    }
+
+    #[test]
+    fn one_fragment_cited_from_several_lines_is_one_finding() {
+        let composed = graph_with_fragments(
+            &["security-console"],
+            json!([
+                { "line": 3, "link": "owners.md#typo" },
+                { "line": 9, "link": "owners.md#typo" },
+            ]),
+        );
+        let findings: Vec<_> = evaluate(&composed)
+            .into_iter()
+            .filter(|f| f.name == "unresolved-fragment")
+            .collect();
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].lines, vec![3, 9]);
+    }
+
+    #[test]
+    fn a_case_mismatch_names_the_anchor_it_meant() {
+        let composed = graph_with_fragments(
+            &["ngwaf-edge"],
+            json!([{ "line": 5, "link": "owners.md#NGWAF-Edge" }]),
+        );
+        let findings = evaluate(&composed);
+        let f = findings
+            .iter()
+            .find(|f| f.name == "unresolved-fragment")
+            .expect("resolution is exact, so a case mismatch still fires");
+        let cause = f.cause.as_deref().expect("expected a cause");
+        assert!(cause.contains("`#ngwaf-edge`"), "got: {cause}");
+    }
+
+    #[test]
+    fn a_bare_hash_is_the_top_of_the_page() {
+        let composed = graph_with_fragments(&["a"], json!([{ "line": 2, "link": "owners.md#" }]));
+        assert!(
+            !names(&evaluate(&composed))
+                .iter()
+                .any(|(name, _)| *name == "unresolved-fragment")
+        );
+    }
+
+    #[test]
+    fn a_target_no_parser_read_has_unknown_fragments() {
+        // No graph published an `anchors` list for `src/lib.rs`, so a fragment
+        // into it is unknown rather than broken.
+        let mut fs = Graph::labeled("fs");
+        fs.set_node("guide.md", fs_node());
+        fs.set_node("src/lib.rs", fs_node());
+        let mut markdown = Graph::labeled("markdown");
+        let mut meta = Metadata::new();
+        meta.insert(
+            "occurrences".into(),
+            json!([{ "line": 4, "link": "src/lib.rs#L20" }]),
+        );
+        markdown.add_edge(Edge::with_metadata("guide.md", "src/lib.rs", meta));
+        let composed = compose(&GraphSet::new(vec![fs, markdown]));
+        assert!(
+            !names(&evaluate(&composed))
+                .iter()
+                .any(|(name, _)| *name == "unresolved-fragment")
+        );
+    }
+
+    #[test]
+    fn a_read_target_defining_nothing_makes_every_fragment_broken() {
+        // The other half of the `None`/empty distinction: a parser read it and it
+        // defines no addresses, so the fragment is broken rather than unknown.
+        let composed =
+            graph_with_fragments(&[], json!([{ "line": 4, "link": "owners.md#anything" }]));
+        let findings = evaluate(&composed);
+        assert!(
+            findings.iter().any(|f| f.name == "unresolved-fragment"),
+            "got {:?}",
+            names(&findings)
+        );
+    }
+
+    #[test]
+    fn an_unresolvable_target_reports_only_the_edge() {
+        // The fragment is the lesser half of the same mistake; reporting both
+        // would double-count one broken link.
+        let mut fs = Graph::labeled("fs");
+        fs.set_node("guide.md", fs_node());
+        let mut markdown = Graph::labeled("markdown");
+        let mut meta = Metadata::new();
+        meta.insert(
+            "occurrences".into(),
+            json!([{ "line": 4, "link": "gone.md#section" }]),
+        );
+        markdown.add_edge(Edge::with_metadata("guide.md", "gone.md", meta));
+        let composed = compose(&GraphSet::new(vec![fs, markdown]));
+
+        let findings = evaluate(&composed);
+        let found = names(&findings);
+        assert!(
+            found.contains(&("unresolved-edge", "guide.md")),
+            "got {found:?}"
+        );
+        assert!(!found.iter().any(|(name, _)| *name == "unresolved-fragment"));
     }
 
     #[test]

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -54,7 +54,9 @@ fn graph_emits_composed_jgf() {
         meta["@fs"]["hash"].as_str().unwrap().starts_with("b3:"),
         "fs node should be auto-hashed"
     );
-    assert_eq!(meta["_graphs"], serde_json::json!(["@fs"]));
+    // The markdown graph reads the file too, publishing the anchors it defines.
+    assert_eq!(meta["_graphs"], serde_json::json!(["@fs", "@markdown"]));
+    assert!(meta["@markdown"]["anchors"].is_array());
 
     // No markdown/frontmatter edges yet — fs is node-only (no symlinks here).
     assert!(graph["edges"].as_array().unwrap().is_empty());
@@ -167,7 +169,10 @@ fn graph_frontmatter_metadata_and_edge_dedup() {
     // @frontmatter metadata nests on the node, with merged _graphs provenance.
     let meta = &v["graph"]["nodes"]["doc.md"]["metadata"];
     assert_eq!(meta["@frontmatter"]["title"], "Doc");
-    assert_eq!(meta["_graphs"], serde_json::json!(["@frontmatter", "@fs"]));
+    assert_eq!(
+        meta["_graphs"],
+        serde_json::json!(["@frontmatter", "@fs", "@markdown"])
+    );
 
     // The shared edge is deduped: one edge, both graphs in _graphs.
     let edges = v["graph"]["edges"].as_array().unwrap();
@@ -213,11 +218,18 @@ fn graph_raw_emits_the_set() {
     assert!(fs_graph["nodes"]["doc.md"]["metadata"]["type"] == "file");
     assert!(fs_graph["nodes"]["doc.md"]["metadata"].get("@fs").is_none());
 
-    // frontmatter carries the bare metadata block; markdown is edge-only.
+    // Each text graph carries its own bare metadata block: frontmatter the
+    // parsed block, markdown the anchors the file defines.
     let frontmatter = graphs.iter().find(|g| g["label"] == "frontmatter").unwrap();
     let markdown = graphs.iter().find(|g| g["label"] == "markdown").unwrap();
     assert_eq!(frontmatter["nodes"]["doc.md"]["metadata"]["title"], "Doc");
-    assert!(markdown["nodes"].as_object().unwrap().is_empty());
+    assert!(markdown["nodes"]["doc.md"]["metadata"]["anchors"].is_array());
+    assert!(
+        markdown["nodes"]["doc.md"]["metadata"]
+            .get("@markdown")
+            .is_none(),
+        "raw fragments carry bare keys; the sigil arrives at compose"
+    );
 }
 
 /// `--raw` is JSON-only: it emits the fragment set even under the default text

--- a/tests/rules.rs
+++ b/tests/rules.rs
@@ -61,3 +61,71 @@ fn ignore_glob_suppresses_diagnostics() {
         "other.md should still be flagged, got: {stdout}"
     );
 }
+
+/// A link's `#fragment` is checked against the anchors its target defines: an
+/// anchor that exists is quiet, one that does not fires `unresolved-fragment` on
+/// the line that cites it, and a case-only mismatch names the anchor it meant.
+#[test]
+fn fragments_are_checked_against_the_targets_anchors() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), DEFAULT_CONFIG).unwrap();
+    fs::write(
+        dir.path().join("owners.md"),
+        "# Owners\n\n## security-console\n\nAna.\n\n## ngwaf-edge\n\nBo.\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("work-items.md"),
+        "# Work\n\n\
+         - [W-01](./owners.md#security-console)\n\
+         - [W-02](./owners.md#NGWAF-Edge)\n\
+         - [W-03](./owners.md#no-such-team)\n\
+         - [W-04](./owners.md)\n",
+    )
+    .unwrap();
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "check"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !stdout.contains("#security-console"),
+        "an anchor the target defines is quiet, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("work-items.md:5 → owners.md#no-such-team"),
+        "a missing anchor fires on its own line, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("work-items.md:4 → owners.md#NGWAF-Edge")
+            && stdout.contains("differs only in case from `#ngwaf-edge`"),
+        "a case-only mismatch names the anchor it meant, got: {stdout}"
+    );
+}
+
+/// A fragment into a target no parser read as a document is unknown, not broken:
+/// nothing published an anchor list for it, so drft cannot say the anchor is
+/// missing and does not guess.
+#[test]
+fn a_fragment_into_an_unread_target_is_not_flagged() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), DEFAULT_CONFIG).unwrap();
+    fs::write(dir.path().join("lib.rs"), "pub fn go() {}\n").unwrap();
+    fs::write(
+        dir.path().join("guide.md"),
+        "# Guide\n\nSee [go](lib.rs#L1).\n",
+    )
+    .unwrap();
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "check"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("unresolved-fragment"),
+        "a non-markdown target's fragments are unknown, got: {stdout}"
+    );
+}

--- a/tests/rules.rs
+++ b/tests/rules.rs
@@ -129,3 +129,47 @@ fn a_fragment_into_an_unread_target_is_not_flagged() {
         "a non-markdown target's fragments are unknown, got: {stdout}"
     );
 }
+
+/// The addresses a file answers to come from more than its headings, and a
+/// fragment is compared the way a browser compares it: a raw `<a id>`/`<a name>`
+/// is an address, and a percent-encoded fragment is decoded first.
+#[test]
+fn anchors_and_fragments_match_what_a_browser_resolves() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("drft.toml"), DEFAULT_CONFIG).unwrap();
+    fs::write(
+        dir.path().join("target.md"),
+        "---\npurpose: a single-key block\n---\n\n\
+         # Target\n\n\
+         <a id=\"faq\"></a>\n\n\
+         ## Café\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("cite.md"),
+        "# Cite\n\n\
+         - [html](./target.md#faq)\n\
+         - [encoded](./target.md#caf%C3%A9)\n\
+         - [frontmatter](./target.md#purpose-a-single-key-block)\n",
+    )
+    .unwrap();
+
+    let output = drft_bin()
+        .args(["-C", dir.path().to_str().unwrap(), "check"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !stdout.contains("#faq"),
+        "a raw <a id> is an address GitHub resolves, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("caf%C3%A9"),
+        "a percent-encoded fragment decodes before matching, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("cite.md:5 → target.md#purpose-a-single-key-block"),
+        "frontmatter is masked, so its closing --- is not a setext heading, got: {stdout}"
+    );
+}


### PR DESCRIPTION
## What it checks

A link carries two claims — that the file exists, and that the position inside it exists — and drft only ever checked the first. In a corpus where every cross-reference is an anchor and the file always exists, the citation graph is effectively unchecked: `#no-such-heading` reads exactly like a good link.

```
warn[unresolved-fragment]: work-items.md:5 → owners.md#no-such-team (no matching anchor)
warn[unresolved-fragment]: work-items.md:4 → owners.md#NGWAF-Edge (no matching anchor)
  cause: `#NGWAF-Edge` differs only in case from `#ngwaf-edge`, which the target defines
```

The markdown parser publishes the `#fragment` addresses each file it reads answers to, as `anchors` in its node metadata. `drft nodes <path> --field anchors` reads them.

## What defines an address

Two things, because a reader's platform resolves both:

- **A heading**, through the GitHub slug of its rendered text, with the `-1` suffix on a repeat. The suffix is re-checked rather than appended, so `a`, `a`, `a-1` yields `a`, `a-1`, `a-1-1` — a list that repeats an address cannot be checked against.
- **A raw `<a id>` / `<a name>`**, verbatim and case-sensitive. A hand-rolled table of contents and a back-compat anchor kept after a heading rename are both real addresses.

Rendered text excludes image alt text and inline HTML, which are not part of an element's text content. `{#custom}` is not honored, because GitHub ignores it and a tool-only anchor is exactly the 404 this rule exists to catch.

## Matching is exact, in one direction

drft slugs the **heading** and compares the fragment to the result. It never slugs the citing side — that would accept `#OBS 92` for an `obs-92` anchor, which a browser sends as `#OBS%2092` and does not find. Certifying a link that 404s for a reader is the one thing sub-file addressing must not do.

The one transformation applied is percent-decoding, because browsers apply it too and a permalink copied from the address bar is encoded for any non-ASCII anchor. It accepts exactly what the platform accepts and loosens nothing: `#OBS%2092` still decodes to `OBS 92` and still misses.

Id matching is case-sensitive, so a case-only mismatch is broken rather than untidy. It carries a `cause` naming the anchor it meant.

## Three cases stay quiet, and the distinctions are load-bearing

- A target **no parser read** has *unknown* fragments. A link into a `.rs` file, a symlink, or a doc outside the graph's `files` scope says nothing.
- A target that **was read and defines nothing** is the opposite: every fragment into it is broken. This is why a read file gets an `anchors` list even when empty — present-and-empty is a fact, absent is a silence.
- An **unresolvable target** reports `unresolved-edge` alone; the fragment is the lesser half of the same mistake.

Only a graph whose parser publishes anchors is authoritative about them, so a file writing `anchors:` in its own frontmatter claims nothing.

## One boundary for frontmatter

Getting the mask right meant retiring a systemic problem: **four call sites independently decided where frontmatter ends.** Every disagreement between them was a defect.

- The markdown parser has to mask frontmatter, or a single-key block's closing `---` reads as a setext heading and the file publishes an address it does not answer to. `docs/README.md` in this repo was doing exactly that.
- A block counts as frontmatter only when it parses as a YAML **mapping**. That is load-bearing, not cautious: `# First` is a YAML comment *and* a markdown ATX heading, so accepting a comment-only block would read `---\n\n# First\n\n---` as frontmatter and delete the most ordinary heading in markdown along with any link beneath it. A bare scalar is ambiguous the same way.
- All three consumers — metadata, the edge scan, and the mask — now take the boundary from one selector and differ only in whether spans are blanked *within* that block. Metadata prefers raw text so a service name in backticks survives as prose; the edge scan always masks so a `path.md` in prose is not a target.

That last one fixed a live bug: a backtick opened in frontmatter and closed in the body moved the boundary for the edge scan, in both directions. One direction lifted body prose into a declared source. The other **silently deleted every declared `sources:` edge** for that file — while the node's own metadata still reported those sources. It needed valid YAML and an ordinary code span, not pathological input.

## Behavior changes

- **Every markdown node gains an `@markdown` block** carrying `anchors`, so `_graphs` on those nodes now lists it.
- **Sequence-rooted frontmatter (`---\n- ./a.md\n---`) no longer contributes edges.** It already contributed no metadata, and no frontmatter convention defines a sequence root. Worth a CHANGELOG line at release; this repo's `keys = ["sources"]` config is unaffected.
- **`---key: v` is no longer frontmatter.** An opening fence must own its line; reading it otherwise invented metadata from a document's first paragraph.

## Known limitations, documented and queued

`[see](#section)` produces no edge, so anchor-only links are unobservable — the most common broken fragment in a long document. Documented in the rules reference with the workaround; segmentation resolves it by making an intra-file reference a real edge.

Also carried: BOM handling, a comment-only block's fabricated anchor, and `strip_code` shifting line numbers when a multi-line span is blanked.

## Verification

`cargo test` (253 unit + all integration suites), `cargo clippy --all-targets -- -D warnings`, `cargo fmt`, `dprint`, `drft check` clean with every touched file and its reviewed dependents locked by name. Six review rounds against fixtures and ~4,000 fuzz documents; the final round found no new defects in the code the fixes touched, and a differential over 400 generated files plus this repository moved nothing outside the intended cases.
